### PR TITLE
Add MD browser components, backed by Polymer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ server.bat
 *~
 coverage
 doc/gen/*
+**/bower_components/*

--- a/src/com/chrome/apis/Controller.js
+++ b/src/com/chrome/apis/Controller.js
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+foam.CLASS({
+  package: 'foam.u2.md',
+  name: 'DAOController',
+  extends: 'foam.u2.DAOController',
+
+
+  methods: [
+    function initE() {
+      // TODO(braden): Once toPropertyE is generalized to actions etc., use that
+      // here if practical.
+      var list = this.listFactory$f({
+        rowFactory: this.rowFactory,
+        data: this.data
+      });
+    },
+  ]
+});
+
+foam.CLASS({
+  package: 'com.chrome.apis',
+  name: 'Controller',
+  extends: 'foam.u2.Element',
+  requires: [
+    //'com.chrome.apis.Experiment',
+    'com.chrome.apis.Origin',
+    //'com.chrome.apis.User',
+    'foam.dao.CachingDAO',
+    'foam.dao.GUIDDAO',
+    'foam.dao.IDBDAO',
+    'foam.dao.MDAO',
+    'foam.u2.Stack',
+    'foam.u2.md.DAOController',
+    'foam.u2.md.StackView',
+    'foam.u2.md.Toolbar',
+    'foam.u2.md.ToolbarContainer'
+  ],
+
+  exports: [
+    'originDAO',
+    'stack'
+  ],
+
+  properties: [
+    {
+      name: 'originDAO',
+      factory: function() {
+        return this.GUIDDAO.create({
+          of: this.Origin,
+          delegate: this.CachingDAO.create({
+            of: this.Origin,
+            src: this.IDBDAO.create({ of: this.Origin }),
+            cache: this.MDAO.create({ of: this.Origin })
+          })
+        });
+      }
+    },
+    {
+      name: 'stack',
+      factory: function() {
+        return this.Stack.create();
+      }
+    }
+  ],
+
+  methods: [
+    function initE() {
+      this.cssClass('flex').cssClass('layout').cssClass('vertical');
+      var sv = this.StackView.create();
+      this.add(sv);
+      var inner = this.ToolbarContainer.create({
+        toolbar: this.Toolbar.create({
+          title: 'Chrome Experiments'
+        }),
+        body: this.DAOController.create({ data: this.originDAO })
+      });
+
+      //inner.cssClass('layout').cssClass('vertical');
+
+      this.stack.pushOnly(inner);
+    }
+  ],
+
+  axioms: [
+    foam.u2.CSS.create({
+      code: function CSS() {/*
+        body {
+          height: 100vh;
+          margin: 0;
+          padding: 0;
+        }
+      */}
+    })
+  ]
+});

--- a/src/com/chrome/apis/Controller.js
+++ b/src/com/chrome/apis/Controller.js
@@ -19,6 +19,13 @@ foam.CLASS({
   name: 'DAOController',
   extends: 'foam.u2.DAOController',
 
+  requires: [
+    'foam.u2.md.Button',
+    'foam.u2.md.DAOCreateController',
+    'foam.u2.md.DAOUpdateController',
+    'foam.u2.md.Toolbar',
+    'foam.u2.md.ToolbarContainer'
+  ],
 
   methods: [
     function initE() {
@@ -28,7 +35,189 @@ foam.CLASS({
         rowFactory: this.rowFactory,
         data: this.data
       });
+
+      list.rowClick.sub(this.rowClick);
+      this.add(list);
+
+      var fab = this.Button.create({
+        action: this.NEW_ITEM,
+        data: this,
+        icon: 'add',
+        type: 'fab'
+      }).cssClass(this.myCls('fab'));
+      this.add(fab);
     },
+
+    // TODO(braden): Try to avoid the explicit context hackery here, using
+    // .startContext() and the like.
+    function buildCreateController(X) {
+      var toolbar = this.Toolbar.create();
+      var Y = X.createSubContext({ toolbar: toolbar });
+      return this.ToolbarContainer.create({
+        toolbar: toolbar,
+        body: this.SUPER(Y)
+      }, Y);
+    },
+    function buildUpdateController(X, obj) {
+      var toolbar = this.Toolbar.create();
+      var Y = X.createSubContext({ toolbar: toolbar });
+      return this.ToolbarContainer.create({
+        toolbar: toolbar,
+        body: this.SUPER(Y, obj)
+      }, Y);
+    }
+  ],
+
+  axioms: [
+    foam.u2.CSS.create({
+      code: function CSS() {/*
+        ^fab {
+          position: absolute;
+          right: 16px;
+          bottom: 16px;
+        }
+      */}
+    })
+  ]
+});
+
+foam.CLASS({
+  package: 'foam.u2.md',
+  name: 'DAOCreateController',
+  extends: 'foam.u2.DAOCreateController',
+
+  requires: [
+    'foam.u2.md.Button',
+    'foam.u2.md.DetailView'
+  ],
+
+  imports: [
+    'toolbar'
+  ],
+
+  // TODO(braden) : These actions are duplicated. When Actions inherit properly,
+  // these just need to set the icon, and not duplicate the code.
+  actions: [
+    {
+      name: 'cancel',
+      icon: 'clear',
+      code: function() {
+        this.stack.popMe(this);
+      }
+    },
+    {
+      name: 'save',
+      icon: 'check',
+      code: function() {
+        this.clearFocus_();
+        this.dao.put(this.data).then(function() {
+          this.stack.popMe(this);
+        }.bind(this));
+      }
+    }
+  ],
+
+  methods: [
+    function initE() {
+      this.add(this.buildDetailView());
+      //var dv = this.DetailView.create({ of: this.of });
+      //dv.data$ = this.data$;
+      //this.add(dv);
+
+      this.toolbar.title$ = this.title$;
+      this.toolbar.addLeftAction(this.createButton(this.CANCEL));
+      this.toolbar.addRightAction(this.createButton(this.SAVE));
+    },
+
+    function createButton(action) {
+      return this.Button.create({
+        action: action,
+        type: 'icon',
+        data: this
+      });
+    }
+  ]
+});
+
+
+foam.CLASS({
+  package: 'foam.u2.md',
+  name: 'DAOUpdateController',
+  extends: 'foam.u2.DAOUpdateController',
+
+  requires: [
+    'foam.u2.md.Button',
+    'foam.u2.md.DetailView'
+  ],
+
+  imports: [
+    'toolbar'
+  ],
+
+  // TODO(braden) : These actions are duplicated. When Actions inherit properly,
+  // these just need to set the icon, and not duplicate the code.
+  actions: [
+    {
+      name: 'back',
+      icon: 'arrow-back',
+      isAvailable: function(dirty_) { return ! dirty_; },
+      code: function(X) {
+        X.stack.popMe(this);
+      }
+    },
+    {
+      name: 'delete',
+      icon: 'delete',
+      isAvailable: function(dirty_) { return ! dirty_; },
+      code: function(X) {
+        this.dao.remove(this.data);
+        this.back();
+      }
+    },
+    {
+      name: 'cancel',
+      icon: 'clear',
+      isAvailable: function(dirty_) { return dirty_; },
+      code: function(X) {
+        this.clearFocus_();
+        this.innerData = this.data.clone();
+      }
+    },
+    {
+      name: 'submit',
+      icon: 'check',
+      isAvailable: function(dirty_) { return dirty_; },
+      code: function(X) {
+        // TODO(braden): Handle long-running submits here. Some UI affordance
+        // for the fact that work is being done here.
+        this.clearFocus_();
+        this.dao.put(this.innerData).then(function(nu) {
+          this.data = nu;
+          this.innerData = nu.clone();
+        }.bind(this));
+      }
+    }
+  ],
+
+
+  methods: [
+    function initE() {
+      this.add(this.DetailView.create({ data$: this.innerData$ }));
+
+      this.toolbar.title$ = this.title$;
+      this.toolbar.addLeftAction(this.createButton(this.BACK));
+      this.toolbar.addLeftAction(this.createButton(this.CANCEL));
+      this.toolbar.addRightAction(this.createButton(this.SUBMIT));
+      this.toolbar.addRightAction(this.createButton(this.DELETE));
+    },
+
+    function createButton(action) {
+      return this.Button.create({
+        action: action,
+        type: 'icon',
+        data: this
+      });
+    }
   ]
 });
 
@@ -40,10 +229,7 @@ foam.CLASS({
     //'com.chrome.apis.Experiment',
     'com.chrome.apis.Origin',
     //'com.chrome.apis.User',
-    'foam.dao.CachingDAO',
-    'foam.dao.GUIDDAO',
-    'foam.dao.IDBDAO',
-    'foam.dao.MDAO',
+    'foam.dao.EasyDAO',
     'foam.u2.Stack',
     'foam.u2.md.DAOController',
     'foam.u2.md.StackView',
@@ -60,13 +246,11 @@ foam.CLASS({
     {
       name: 'originDAO',
       factory: function() {
-        return this.GUIDDAO.create({
+        return this.EasyDAO.create({
           of: this.Origin,
-          delegate: this.CachingDAO.create({
-            of: this.Origin,
-            src: this.IDBDAO.create({ of: this.Origin }),
-            cache: this.MDAO.create({ of: this.Origin })
-          })
+          guid: true,
+          cache: true,
+          daoType: this.EasyDAO.IDB
         });
       }
     },

--- a/src/com/chrome/apis/bower.json
+++ b/src/com/chrome/apis/bower.json
@@ -1,0 +1,37 @@
+{
+  "name": "chrome-origin-trials",
+  "authors": [
+    "Adam Van Ymeren <adamvy@google.com>",
+    "Braden Shepherdson <braden@google.com>"
+  ],
+  "description": "Dashboard for managing Chrome experiments.",
+  "main": "index.html",
+  "moduleType": [
+    "globals"
+  ],
+  "keywords": [
+    "foam",
+    "foam2",
+    "polymer"
+  ],
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "paper-toolbar": "PolymerElements/paper-toolbar#^1.1.4",
+    "paper-header-panel": "PolymerElements/paper-header-panel#^1.1.5",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.3.1",
+    "iron-icons": "PolymerElements/iron-icons#^1.1.3",
+    "paper-icon-button": "PolymerElements/paper-icon-button#^1.1.1",
+    "paper-drawer-panel": "PolymerElements/paper-drawer-panel#^1.0.9",
+    "paper-card": "PolymerElements/paper-card#^1.1.1",
+    "paper-fab": "PolymerElements/paper-fab#^1.2.0",
+    "paper-input": "PolymerElements/paper-input#^1.1.11",
+    "foam2-experimental": "foam-framework/foam2-experimental"
+  }
+}

--- a/src/com/chrome/apis/index.html
+++ b/src/com/chrome/apis/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Chrome Experiments</title>
+
+<!-- FOAM core -->
+<script src="../../../foam.js"></script>
+
+<!-- Polymer components -->
+<script src="./bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
+<link rel="import" href="./bower_components/paper-toolbar/paper-toolbar.html">
+<link rel="import"
+      href="./bower_components/paper-header-panel/paper-header-panel.html">
+<link rel="import"
+      href="./bower_components/iron-flex-layout/iron-flex-layout.html">
+<link rel="import"
+      href="./bower_components/iron-flex-layout/iron-flex-layout-classes.html">
+<link rel="import" href="./bower_components/iron-icons/iron-icons.html">
+<link rel="import"
+      href="./bower_components/iron-iconset-svg/iron-iconset-svg.html">
+<link rel="import"
+      href="./bower_components/paper-icon-button/paper-icon-button.html">
+<link rel="import"
+      href="./bower_components/paper-drawer-panel/paper-drawer-panel.html">
+<link rel="import" href="./bower_components/paper-card/paper-card.html">
+<link rel="import" href="./bower_components/paper-fab/paper-fab.html">
+<link rel="import" href="./bower_components/paper-input/paper-input.html">
+
+<style is="custom-style"
+    include="iron-flex iron-flex-alignment iron-flex-factors iron-flex-positioning"></style>
+
+<!--
+<paper-drawer-panel responsive-width="800px" fullbleed>
+  <paper-header-panel drawer>
+    <paper-toolbar><div title>Memegen</div></paper-toolbar>
+    <div>
+      Drawer contents go here
+      <p>
+    </div>
+  </paper-header-panel>
+
+  <paper-header-panel main>
+    <paper-header-panel class="flex">
+      <paper-toolbar>
+        <paper-icon-button icon="menu" paper-drawer-toggle></paper-icon-button>
+        <div title>Memegen</div>
+      </paper-toolbar>
+
+      <div id="content" class="flex">Main contents here</div>
+    </paper-header-panel>
+    <div class="fab-float">
+      <paper-fab id="new-meme-fab" icon="add"></paper-fab>
+    </div>
+  </paper-header-panel>
+</paper-drawer-panel>
+-->
+
+<!-- FOAM libraries -->
+<script src="../../../lib/u2/browser.js"></script>
+
+<!-- Application code -->
+<script src="./models.js"></script>
+<script src="./polymer.js"></script>
+<script src="./views.js"></script>
+<script src="./Controller.js"></script>
+
+<body class="fullbleed layout vertical">
+
+<script>
+var ctrl = foam.lookup('com.chrome.apis.Controller').create();
+window.document.body.insertAdjacentHTML('beforeend', ctrl.outerHTML);
+ctrl.load();
+</script>
+
+</body>
+

--- a/src/com/chrome/apis/index.html
+++ b/src/com/chrome/apis/index.html
@@ -26,7 +26,7 @@
 <link rel="import" href="./bower_components/paper-input/paper-input.html">
 
 <style is="custom-style"
-    include="iron-flex iron-flex-alignment iron-flex-factors iron-flex-positioning"></style>
+    include="iron-flex iron-flex-alignment iron-flex-factors"></style>
 
 <!--
 <paper-drawer-panel responsive-width="800px" fullbleed>
@@ -55,7 +55,9 @@
 -->
 
 <!-- FOAM libraries -->
-<script src="../../../lib/u2/browser.js"></script>
+<script src="../../../foam/u2/md/DetailView.js"></script>
+<script src="../../../foam/u2/browser.js"></script>
+<script src="../../../foam/u2/md/tag/PaperInput.js"></script>
 
 <!-- Application code -->
 <script src="./models.js"></script>

--- a/src/com/chrome/apis/models.js
+++ b/src/com/chrome/apis/models.js
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+foam.CLASS({
+  package: 'com.chrome.apis',
+  name: 'Origin',
+
+  properties: [
+    {
+      name: 'id',
+      hidden: true
+    },
+    {
+      class: 'String',
+      name: 'origin'
+      // TODO(braden): Validation rules for origins.
+    }
+    // TODO(braden): Add a reference to the owner here, for use with that
+    // Relationship.
+  ]
+  // TODO(braden): Add the relationship for activeExperiments on this origin.
+});

--- a/src/com/chrome/apis/polymer.js
+++ b/src/com/chrome/apis/polymer.js
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+foam.CLASS({
+  package: 'foam.u2.md',
+  name: 'StackView',
+  extends: 'foam.u2.BasicStackView',
+  methods: [
+    function initE() {
+      this.cssClass('flex').cssClass('layout').cssClass('vertical');
+      this.SUPER();
+    }
+  ]
+});
+
+foam.CLASS({
+  package: 'foam.u2.md',
+  name: 'Toolbar',
+  extends: 'foam.u2.Element',
+  properties: [
+    {
+      name: 'title'
+    },
+    [ 'nodeName', 'paper-toolbar' ]
+  ],
+
+  methods: [
+    function initE() {
+      this.start('span').cssClass('title').add(this.title$).end();
+    }
+  ]
+});
+
+foam.CLASS({
+  package: 'foam.u2.md',
+  name: 'ToolbarContainer',
+  extends: 'foam.u2.Element',
+
+  properties: [
+    {
+      name: 'toolbar',
+      required: true
+    },
+    {
+      name: 'body',
+      factory: function() {
+        return this.E('div');
+      }
+    },
+    [ 'nodeName', 'paper-header-panel' ]
+  ],
+
+  methods: [
+    function initE() {
+      this.attrs({ fullbleed: true });
+      this.add(this.toolbar.cssClass('paper-header'));
+      this.add(this.body.cssClass('content'));
+    }
+  ]
+});

--- a/src/com/chrome/apis/polymer.js
+++ b/src/com/chrome/apis/polymer.js
@@ -34,12 +34,33 @@ foam.CLASS({
     {
       name: 'title'
     },
+    {
+      name: 'leftActions_',
+      factory: function() {
+        return [];
+      }
+    },
+    {
+      name: 'rightActions_',
+      factory: function() {
+        return [];
+      }
+    },
     [ 'nodeName', 'paper-toolbar' ]
   ],
 
   methods: [
     function initE() {
+      this.add(this.leftActions_$);
       this.start('span').cssClass('title').add(this.title$).end();
+      this.add(this.rightActions_$);
+    },
+
+    function addLeftAction(button) {
+      this.leftActions_ = this.leftActions_.concat([ button ]);
+    },
+    function addRightAction(button) {
+      this.rightActions_ = this.rightActions_.concat([ button ]);
     }
   ]
 });
@@ -68,6 +89,95 @@ foam.CLASS({
       this.attrs({ fullbleed: true });
       this.add(this.toolbar.cssClass('paper-header'));
       this.add(this.body.cssClass('content'));
+    }
+  ]
+});
+
+foam.CLASS({
+  package: 'foam.u2',
+  name: 'PolymerWrapper',
+  extends: 'foam.u2.View'
+});
+
+foam.CLASS({
+  package: 'foam.u2.md',
+  name: 'StringRefinement',
+  refines: 'foam.core.String',
+  imports: [
+    'setTimeout'
+  ],
+  properties: [
+    {
+      class: 'Boolean',
+      name: 'onKey',
+      value: 'false'
+    },
+    {
+      name: 'toPropertyE',
+      value: function(X) {
+        return X.lookup('foam.u2.md.tag.PaperInput').create({
+          onKey: this.onKey,
+          label$: this.label$
+        }, X);
+      }
+    }
+  ]
+});
+
+foam.CLASS({
+  package: 'foam.u2.md',
+  name: 'Button',
+  extends: 'foam.u2.View',
+
+  properties: [
+    'action',
+    {
+      name: 'nodeName',
+      expression: function(type) {
+        return type === 'fab' ? 'paper-fab' :
+            type === 'icon' ? 'paper-icon-button' : 'paper-button';
+      }
+    },
+    {
+      name: 'type',
+      documentation: 'The flavour of button: either label, icon, label-icon, ' +
+          'or fab.',
+      value: 'label'
+    },
+    {
+      class: 'String',
+      name: 'icon',
+      documentation: 'The string name of the icon to use.',
+      expression: function(action) {
+        console.log('action ' + action.name + ' with icon ' + action.icon);
+        return action.icon;
+      }
+    }
+  ],
+
+  methods: [
+    function initE() {
+      // We need to configure the button differently depending on its type.
+      if ( this.type === 'fab' || this.type === 'icon' ) {
+        this.attrs({ icon: this.icon$ });
+      } else {
+        if ( this.type === 'label-icon' ) {
+          this.start('iron-icon').attrs({ icon: this.icon$ }).end();
+          this.add(this.action$.dot('label'));
+        }
+      }
+
+      this.attrs({
+        disabled: this.action.createIsEnabled$(this.data$)
+            .map(function(e) { return ! e ; })
+      });
+      this.enableCls('foam-u2-Element-hidden',
+          this.action.createIsAvailable$(this.data$), true);
+
+      var self = this;
+      this.on('click', function() {
+        self.action.maybeCall(self.__context__, self.data);
+      });
     }
   ]
 });

--- a/src/core/Action.js
+++ b/src/core/Action.js
@@ -49,6 +49,9 @@ foam.CLASS({
       expression: function(label) { return label; }
     },
     {
+      name: 'icon'
+    },
+    {
       class: 'String',
       name: 'help'
     },

--- a/src/foam/u2/Element.js
+++ b/src/foam/u2/Element.js
@@ -98,8 +98,19 @@ foam.CLASS({
       /* Performs expansion of the ^ shorthand on the CSS. */
       // TODO(braden): Parse and validate the CSS.
       // TODO(braden): Add the automatic prefixing once we have the parser.
-      return text.replace(/\^/g,
-          '.' + (cls.CSS_NAME || foam.String.cssClassize(cls.id)) + '-');
+      var base = '.' + (cls.CSS_NAME || foam.String.cssClassize(cls.id));
+      return text.replace(/\^(.)/g, function(match, next) {
+        var c = next.charCodeAt(0);
+        // Check if the next character is an uppercase or lowercase letter,
+        // number, - or _. If so, add a - because this is a modified string.
+        // If not, there's no extra -.
+        if ( (65 <= c && c <= 90) || (97 <= c && c <= 122) ||
+            (48 <= c && c <= 57) || c === 45 || c === 95 ) {
+          return base + '-' + next;
+        } else {
+          return base + next;
+        }
+      });
     }
   ]
 });

--- a/src/foam/u2/Element.js
+++ b/src/foam/u2/Element.js
@@ -52,7 +52,6 @@ foam.CLASS({
   ]
 });
 
-
 foam.CLASS({
   package: 'foam.u2',
   name: 'CSS',
@@ -673,10 +672,8 @@ foam.CLASS({
       */
       var base = this.cls_.CSS_NAME || foam.String.cssClassize(this.cls_.id);
 
-      if ( ! opt_extra ) opt_extra = '';
-
       return base.split(/ +/).
-          map(function(c) { return c + '-' + opt_extra; }).
+          map(function(c) { return c + (opt_extra ? '-' + opt_extra : ''); }).
           join(' ');
     },
 

--- a/src/foam/u2/md/DetailView.js
+++ b/src/foam/u2/md/DetailView.js
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+foam.CLASS({
+  package: 'foam.u2.md',
+  name: 'DetailView',
+  extends: 'foam.u2.DetailView',
+  requires: [
+    'foam.core.Property'
+  ],
+
+  exports: [
+    'data'
+  ],
+
+  properties: [
+    {
+      name: 'data',
+      postSet: function(old, nu) {
+        if ( nu && nu.cls_ !== this.of ) this.of = nu.cls_;
+      }
+    },
+    {
+      name: 'of'
+    },
+    {
+      name: 'properties',
+      expression: function(of) {
+        return of.getAxiomsByClass(foam.core.Property).filter(function(p) {
+          return ! p.hidden;
+        });
+      }
+    },
+    {
+      name: 'title',
+      expression: function(of) {
+        return of.model_.label;
+      }
+    },
+    [ 'showTitle', true ],
+    [ 'nodeName', 'div' ]
+  ],
+
+  methods: [
+    function initE() {
+      this.add(this.properties$);
+    }
+  ]
+});

--- a/src/foam/u2/md/tag/PaperInput.js
+++ b/src/foam/u2/md/tag/PaperInput.js
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+foam.CLASS({
+  package: 'foam.u2.md.tag',
+  name: 'PaperInput',
+  extends: 'foam.u2.tag.Input',
+  properties: [
+    [ 'nodeName', 'paper-input' ],
+    {
+      class: 'Boolean',
+      name: 'onKey'
+    },
+    {
+      class: 'String',
+      name: 'label'
+    }
+  ],
+
+  methods: [
+    function initE() {
+      this.SUPER();
+      this.attrs({ label: this.label$ });
+    },
+    function link() {
+      this.attrSlot(null, this.onKey ? 'input' : 'change').linkFrom(this.data$);
+    }
+  ]
+});

--- a/test/src/lib/u2.js
+++ b/test/src/lib/u2.js
@@ -182,10 +182,10 @@ describe('U2', function() {
 
         expect(css.length).toBe(0);
         var e = test.css.Shorthand.create(null, X);
-        expect(css.indexOf('.test-css-Shorthand- {')).toBeGreaterThan(0);
+        expect(css.indexOf('.test-css-Shorthand {')).toBeGreaterThan(0);
         expect(css.indexOf('.test-css-Shorthand-bar {')).toBeGreaterThan(0);
         expect(css.indexOf(
-            '.test-css-Shorthand- .test-css-Shorthand-foo.test-css-Shorthand-bar {'
+            '.test-css-Shorthand .test-css-Shorthand-foo.test-css-Shorthand-bar {'
             )).toBeGreaterThan(0);
         expect(css.indexOf('.' + e.myCls())).toBeGreaterThan(0);
         expect(css.indexOf('.' + e.myCls('foo'))).toBeGreaterThan(0);
@@ -202,10 +202,10 @@ describe('U2', function() {
 
         expect(css.length).toBe(0);
         var e = test.css.ShorthandOverride.create(null, X);
-        expect(css.indexOf('.some-other-name- {')).toBeGreaterThan(0);
+        expect(css.indexOf('.some-other-name {')).toBeGreaterThan(0);
         expect(css.indexOf('.some-other-name-bar {')).toBeGreaterThan(0);
         expect(css.indexOf(
-            '.some-other-name- .some-other-name-foo.some-other-name-bar {'))
+            '.some-other-name .some-other-name-foo.some-other-name-bar {'))
           .toBeGreaterThan(0);
         expect(css.indexOf('.' + e.myCls())).toBeGreaterThan(0);
         expect(css.indexOf('.' + e.myCls('foo'))).toBeGreaterThan(0);


### PR DESCRIPTION
This is still pretty rough, but it was a working (not very well whitespaced) `DetailView`, with MD toolbars with all the various actions.

It comes with a basic demo port of the Chrome APIs app from FOAM 1, which is very, very incomplete.
