### PR TITLE
TypeChecking on LIBs active

### DIFF
--- a/src/foam/core/Argument.js
+++ b/src/foam/core/Argument.js
@@ -140,15 +140,15 @@ foam.CLASS({
   ],
 
   methods: [
-    /**
-      Validates the given argument against this type information.
-      If any type checks are failed, a TypeError is thrown.
-     */
-    function validate(/* any // the argument value to validate. */ arg) {
+    function validate(arg) {
+      /**
+        Validates the given argument against this type information.
+        If any type checks are failed, a TypeError is thrown.
+       */
       i = ( this.index >= 0 ) ? ' ' + this.index + ', ' : ', ';
 
       // optional check
-      if ( ( ! arg ) && typeof arg === 'undefined' ) {
+      if ( foam.Null.isInstance(arg) || foam.Undefined.isInstance(arg) ) {
         if ( ! this.optional ) {
           throw new TypeError(
               this.PREFIX + i + this.name +

--- a/src/foam/core/async.js
+++ b/src/foam/core/async.js
@@ -148,7 +148,7 @@ foam.LIB({
       };
     },
 
-    function sleep(/* number */ time) {
+    function sleep(/* foam.Number */ time) {
       /** Returns a function that returns a promise that delays by the given
         time before resolving. */
       return function() {

--- a/src/foam/core/async.js
+++ b/src/foam/core/async.js
@@ -45,22 +45,24 @@ foam.LIB({
   name: 'foam.async',
 
   methods: [
-    /** Takes an array of functions (that may return a promise) and runs
-      them one after anther. Functions that return a promise will have that
-      promise chained, such that the next function will not run until the
-      previous function's returned promise is resolved.
+    function sequence(s) {
+      /** Takes an array of functions (that may return a promise) and runs
+        them one after anther. Functions that return a promise will have that
+        promise chained, such that the next function will not run until the
+        previous function's returned promise is resolved.
 
-      <p>Errors are not handled, so chain any desired error handlers
-      onto the promise returned.
+        <p>Errors are not handled, so chain any desired error handlers
+        onto the promise returned.
 
-      <p>You can use sequence's returned function directly in a then call:
-      <pre>promise.then(foam.async.sequence(...));</pre>
-      <p>Or call it directly:
-      <pre>(foam.async.sequence(...))().then(...);</pre> */
-    function sequence(
-      /* array // An array of functions that return Promises */ s
-      /* function // A function that returns a promise that will
-                     resolve after the last function's return is resolved. */) {
+        <p>You can use sequence's returned function directly in a then call:
+        <pre>promise.then(foam.async.sequence(...));</pre>
+        <p>Or call it directly:
+        <pre>(foam.async.sequence(...))().then(...);</pre> 
+    
+        @param {array} s An array of functions that return Promises 
+        @returns {function}  A function that returns a promise that will
+                       resolve after the last function's return is resolved.
+      */
       return function() {
         if ( ! s.length ) return Promise.resolve();
 
@@ -72,25 +74,27 @@ foam.LIB({
       }
     },
 
-    /** Takes a function (that may return a promise) and runs it multiple
-      times. A function that returns a promise will have that
-      promise chained, such that the next call will not run until the
-      previous call's returned promise is resolved. The function passed in
-      will be called with one argument, the number of the iteration, from
-      0 to times - 1.
+    function repeat(times, fn) {
+      /** Takes a function (that may return a promise) and runs it multiple
+        times. A function that returns a promise will have that
+        promise chained, such that the next call will not run until the
+        previous call's returned promise is resolved. The function passed in
+        will be called with one argument, the number of the iteration, from
+        0 to times - 1.
 
-      <p>Errors are not handled, so chain any desired error handlers
-      onto the promise returned.
+        <p>Errors are not handled, so chain any desired error handlers
+        onto the promise returned.
 
-      <p>You can use repeat's returned function directly in a then call:
-      <pre>promise.then(foam.async.repeat(...));</pre>
-      <p>Or call it directly:
-      <pre>(foam.async.repeat(...))().then(...);</pre> */
-    function repeat(
-      /* number // number of times to repeat in sequence */ times,
-      /* function // that returns a Promise */ fn
-      /* function // A function that returns a Promise that will resolve
-                     after the last repetition's return resolves */) {
+        <p>You can use repeat's returned function directly in a then call:
+        <pre>promise.then(foam.async.repeat(...));</pre>
+        <p>Or call it directly:
+        <pre>(foam.async.repeat(...))().then(...);</pre> 
+    
+        @param {number} times number of times to repeat in sequence.
+        @param {function} fn Function that returns a Promise.
+        @returns {function}  A function that returns a Promise that will resolve
+                       after the last repetition's return resolves.
+      */
       return function() {
         var p = Promise.resolve();
         var n = 0;
@@ -117,12 +121,14 @@ foam.LIB({
       <pre>promise.then(foam.async.repeatParallel(...));</pre>
       <p>Or call it directly:
       <pre>(foam.async.repeatParallel(...))().then(...);</pre>
+    
+
+      @param {number} times number of times to repeat in sequence.
+      @param {function} fn Function that returns a Promise.
+      @returns {function}  A function that returns a Promise that will resolve
+                   after every repetition's return resolves    
     */
-    function repeatParallel(
-      /* number // number of times to repeat in parallel */ times,
-      /* function // that returns a Promise */ fn
-      /* function // A function that returns a Promise that will resolve
-                     after every repetition's return resolves */) {
+    function repeatParallel(times, fn) {
       return function() {
         var promises = [];
         for ( var i = 0; i < times; ++i ) {
@@ -132,9 +138,9 @@ foam.LIB({
       };
     },
 
-    /** Returns a function you can pass to a .then call, or other foam.async
-      functions. Takes variable arguments that are passed to console.log. */
     function log() {
+      /** Returns a function you can pass to a .then call, or other foam.async
+        functions. Takes variable arguments that are passed to console.log. */
       var args = arguments;
       return function() {
         console.log.apply(console, args);
@@ -142,9 +148,9 @@ foam.LIB({
       };
     },
 
-    /** Returns a function that returns a promise that delays by the given
-      time before resolving. */
-    function sleep(/* number // milliseconds to delay */ time) {
+    function sleep(/* number */ time) {
+      /** Returns a function that returns a promise that delays by the given
+        time before resolving. */
       return function() {
         return new Promise(function(resolve, reject) {
           setTimeout(function() { resolve(); }, time);

--- a/src/foam/core/debug.js
+++ b/src/foam/core/debug.js
@@ -331,8 +331,6 @@ foam.__context__ = foam.debug.Window.create(null, foam.__context__).__subContext
 
 
 
-/** The types library deals with type safety. */
-// ???: Should this go in foam.Function along with formalArgs() and be renamed just functionArgs?
 foam.LIB({
   name: 'foam.Function',
 
@@ -395,7 +393,7 @@ foam.LIB({
         // If nothing threw an exception, we are free to run the function
         var typeCheckerVal = fn.apply(this, arguments);
 
-        // check the typeCheckerurn value
+        // check the return value
         if ( args.returnType ) args.returnType.validate(typeCheckerVal);
 
         return typeCheckerVal;

--- a/src/foam/core/debug.js
+++ b/src/foam/core/debug.js
@@ -351,9 +351,34 @@ foam.LIB({
       *         then type check the returned value.
       */
     function typeCheck(fn) {
+      // Multiple definitions of LIBs may trigger this multiple times
+      // on the same function
+      if ( fn.isTypeChecker__ ) return fn;
+      
       // parse out the arguments and their types
       var args = foam.Function.args(fn);
-      var ret = function() {
+      
+      // check if no checkable arguments
+      var checkable = false;
+      function isArgUncheckable(a) {
+        return ( ( a.typeName === '' || a.typeName === 'any' || foam.Undefined.isInstance(a.typeName) ) && 
+          ( a.optional || a.repeated ) );
+      }
+      for ( var i = 0 ; i < args.length ; i++ ) {
+        if ( ! isArgUncheckable(args[i]) ) {
+          checkable = true;
+          break;
+        }
+      }
+      if ( ! checkable && args.returnType ) {
+        checkable = ! isArgUncheckable(args.returnType);
+      }
+      if ( ! checkable ) {
+        // nothing to check, don't decorate
+        return fn;
+      }
+      
+      var typeChecker = function() {
         // check each declared argument, arguments[i] can be undefined for
         // missing optional args, extra arguments are ok
         for ( var i = 0 ; i < args.length ; i++ )
@@ -368,44 +393,78 @@ foam.LIB({
         }
 
         // If nothing threw an exception, we are free to run the function
-        var retVal = fn.apply(this, arguments);
+        var typeCheckerVal = fn.apply(this, arguments);
 
-        // check the return value
-        if ( args.returnType ) args.returnType.validate(retVal);
+        // check the typeCheckerurn value
+        if ( args.returnType ) args.returnType.validate(typeCheckerVal);
 
-        return retVal;
+        return typeCheckerVal;
       }
 
       // keep the old value of toString (hide the decorator)
-      ret.toString = function() { return fn.toString(); }
+      typeChecker.toString = function() { return fn.toString(); }
+      typeChecker.isTypeChecker__ = true;
 
-      return ret;
+      return typeChecker;
     }
   ]
 });
 
-// // -- Uncomment to enable type checking on all methods --
-// // Access Argument now to avoid circular reference because of lazy model building.
-// foam.core.Argument;
-//
-// /* Methods gain type checking. */
-// foam.CLASS({
-//   refines: 'foam.core.Method',
-//
-//   properties: [
-//     {
-//       name: 'code',
-//       adapt: function(old, nu) {
-//         if ( nu )
-//           return foam.Function.typeCheck(nu);
-//
-//         return nu;
-//       }
-//     }
-//
-//   ]
-// });
+// -- Uncomment to enable type checking on all methods --
+// Access Argument now to avoid circular reference because of lazy model building.
+foam.core.Argument;
 
+/* Methods gain type checking. */
+foam.CLASS({
+  refines: 'foam.core.Method',
+
+  properties: [
+    {
+      name: 'code',
+      adapt: function(old, nu) {
+        if ( nu )
+          return foam.Function.typeCheck(nu);
+
+        return nu;
+      }
+    }
+
+  ]
+});
+// Upgrade a LIBs
+var upgradeLib = function upgradeLib(lib) {
+  for ( var key in lib ) {
+    var func = lib[key];
+    if ( foam.Function.isInstance(func) ) {
+      lib[key] = foam.Function.typeCheck(func);
+    }
+  }
+};
+
+// Upgrade each existing LIB
+for ( var name in foam.__LIBS__ ) {
+  upgradeLib(foam.__LIBS__[name]);
+}
+foam.__LIBS__ = null;
+
+// Decorate foam.LIB to typeCheck new libs
+var oldLIB = foam.LIB;
+foam.LIB = function typeCheckedLIB(model) {
+  // Create the lib normally
+  oldLIB(model);
+
+  // Find the created LIB
+  var root = global;
+  var path = model.name.split('.');
+  var i;
+  for ( i = 0 ; i < path.length ; i++ ) {
+    root = root[path[i]];
+  }
+  if ( ! root ) {
+    throw 'debug.js: type checking for LIB ' + model.name + ', LIB not created.';
+  }
+  upgradeLib(root);
+}
 
 
 

--- a/src/foam/core/lib.js
+++ b/src/foam/core/lib.js
@@ -99,6 +99,9 @@ foam.LIB = function LIB(model) {
     root = root[path[i]] || ( root[path[i]] = {} );
   }
 
+  // During boot, keep a list of created LIBs
+  if ( global.foam.__LIBS__ ) global.foam.__LIBS__[model.name] = root;
+
   if ( model.constants ) {
     foam.assert(
       typeof model.constants === 'object',
@@ -129,3 +132,4 @@ foam.LIB = function LIB(model) {
     }
   }
 };
+global.foam.__LIBS__ = Object.create(null);

--- a/src/foam/core/stdlib.js
+++ b/src/foam/core/stdlib.js
@@ -167,14 +167,9 @@ foam.LIB({
      * Decorates the function 'f' to cache the return value of 'f' when
      * called in the future. Also known as a 'thunk'.
      */
-    function memoize0(f) {
-      foam.assert(
-        typeof f === 'function',
-        'Cannot apply memoize to something that is not a function.');
-
+    function memoize0(/* function */ f) {
       var set = false, cache;
-
-      return foam.Function.setName(
+      var ret = foam.Function.setName(
           function() {
             if ( ! set ) {
               set = true;
@@ -183,19 +178,18 @@ foam.LIB({
             return cache;
           },
           'memoize0(' + f.name + ')');
+        ret.toString = function() { return f.toString(); };
+        return ret;
+        
     },
 
     /**
      * Decorates the function 'f' to cache the return value of 'f' when called
      * with a particular value for its first argument.
      */
-    function memoize1(f) {
-      foam.assert(
-        typeof f === 'function',
-        'Cannot apply memoize to something that is not a function.');
-
+    function memoize1(/* function */ f) {
       var cache = {}, nullCache, undefinedCache;
-      return foam.Function.setName(
+      var ret = foam.Function.setName(
           function(key) {
             foam.assert(
                 arguments.length === 1,
@@ -211,6 +205,8 @@ foam.LIB({
             return cache[mKey];
           },
           'memoize1(' + f.name + ')');
+        ret.toString = function() { return f.toString(); };
+        return ret;
     },
 
     /**
@@ -356,10 +352,7 @@ foam.LIB({
     },
     {
       name: 'constantize',
-      code: foam.Function.memoize1(function(str) {
-        foam.assert(typeof str === 'string',
-            'Cannot constantize non-string values.');
-
+      code: foam.Function.memoize1(function(/* string */ str) {
         // switches from from camelCase to CAMEL_CASE
         return str.replace(/([a-z])([^0-9a-z_])/g, '$1_$2').toUpperCase();
       })
@@ -367,11 +360,8 @@ foam.LIB({
 
     {
       name: 'labelize',
-      code: foam.Function.memoize1(function(str) {
-        if ( str === '' || str === null ) return '';
-
-        foam.assert(typeof str === 'string',
-            'Cannot labelize non-string values.');
+      code: foam.Function.memoize1(function(/* string? */ str) {
+        if ( str === '' || str === null || foam.Undefined.isInstance(str) ) return '';
 
         return this.capitalize(str.replace(/[a-z][A-Z]/g, function(a) {
           return a.charAt(0) + ' ' + a.charAt(1);
@@ -381,11 +371,8 @@ foam.LIB({
 
     {
       name: 'camelize',
-      code: foam.Function.memoize1(function(str) {
+      code: foam.Function.memoize1(function(/* string */ str) {
         if ( str === '' || str === null ) return '';
-
-        foam.assert(typeof str === 'string',
-            'Cannot camelize non-string values.');
 
         return str.replace(/([a-zA-Z0-9][^a-zA-Z0-9][a-zA-Z0-9])/g, function(a, c) {
           return a.charAt(0) + a.charAt(2).toUpperCase();

--- a/src/foam/core/stdlib.js
+++ b/src/foam/core/stdlib.js
@@ -167,7 +167,7 @@ foam.LIB({
      * Decorates the function 'f' to cache the return value of 'f' when
      * called in the future. Also known as a 'thunk'.
      */
-    function memoize0(/* function */ f) {
+    function memoize0(/* foam.Function */ f) {
       var set = false, cache;
       var ret = foam.Function.setName(
           function() {
@@ -187,7 +187,7 @@ foam.LIB({
      * Decorates the function 'f' to cache the return value of 'f' when called
      * with a particular value for its first argument.
      */
-    function memoize1(/* function */ f) {
+    function memoize1(/* foam.Function */ f) {
       var cache = {}, nullCache, undefinedCache;
       var ret = foam.Function.setName(
           function(key) {
@@ -352,7 +352,7 @@ foam.LIB({
     },
     {
       name: 'constantize',
-      code: foam.Function.memoize1(function(/* string */ str) {
+      code: foam.Function.memoize1(function(/* foam.String */ str) {
         // switches from from camelCase to CAMEL_CASE
         return str.replace(/([a-z])([^0-9a-z_])/g, '$1_$2').toUpperCase();
       })
@@ -360,7 +360,7 @@ foam.LIB({
 
     {
       name: 'labelize',
-      code: foam.Function.memoize1(function(/* string? */ str) {
+      code: foam.Function.memoize1(function(/* foam.String? */ str) {
         if ( str === '' || str === null || foam.Undefined.isInstance(str) ) return '';
 
         return this.capitalize(str.replace(/[a-z][A-Z]/g, function(a) {
@@ -371,7 +371,7 @@ foam.LIB({
 
     {
       name: 'camelize',
-      code: foam.Function.memoize1(function(/* string */ str) {
+      code: foam.Function.memoize1(function(/* foam.String */ str) {
         if ( str === '' || str === null ) return '';
 
         return str.replace(/([a-zA-Z0-9][^a-zA-Z0-9][a-zA-Z0-9])/g, function(a, c) {

--- a/src/foam/dao/AbstractDAO.js
+++ b/src/foam/dao/AbstractDAO.js
@@ -97,7 +97,7 @@ foam.CLASS({
         on a select()
       */
       name: 'skip',
-      code: function skip(/* number */ s) {
+      code: function skip(/* foam.Number */ s) {
         return this.SkipDAO.create({
           delegate: this,
           skip_: s
@@ -111,7 +111,7 @@ foam.CLASS({
         given count on a select().
       */
       name: 'limit',
-      code: function limit(/* number */ l) {
+      code: function limit(/* foam.Number */ l) {
         return this.LimitedDAO.create({
           delegate: this,
           limit_: l

--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -1179,14 +1179,14 @@ foam.LIB({
       return foam.mlang.order.Desc.create({ arg1: c });
     },
 
-    function toCompare(c /*foam.mlang.order.Comparator*/) {
+    function toCompare(c) {
       var ret = foam.Array.isInstance(c) ? foam.compare.compound(c) :
         foam.Function.isInstance(c) ? foam.mlang.order.CustomComparator.create({ compareFn: c }) :
         c ;
       return ret;
     },
 
-    function compound(/*array*/ args) {
+    function compound(args) {
       var cs = args.map(foam.compare.toCompare);
 
       if ( cs.length === 0 ) return;

--- a/src/foam/u2/Element.js
+++ b/src/foam/u2/Element.js
@@ -1252,7 +1252,7 @@ foam.CLASS({
       return this.parentNode;
     },
 
-    function add(/* vargs */) {
+    function add() {
       if ( this.content ) {
         this.content.add_(arguments, this);
       } else {

--- a/test/src/core/debug.js
+++ b/test/src/core/debug.js
@@ -35,8 +35,8 @@ function makeTestFn() {
   }
 }
 function makePrimitiveTestFn() { // multiline parsing, ha
-return function(/* string */ str, /*boolean*/ bool ,
-  /* function*/ func, /*object*/obj, /* number */num, /* array*/ arr ) {
+return function(/* foam.String */ str, /*foam.Boolean*/ bool ,
+  /* foam.Function */ func, /*foam.Object*/obj, /* foam.Number */num, /* []*/ arr ) {
     return (true);
   }
 }
@@ -148,7 +148,7 @@ describe('Argument.validate', function() {
   it('checks primitive types', function() {
     var params = foam.Function.args(makePrimitiveTestFn());
 
-    // /* string */ str, /*boolean*/ bool , /* function*/ func, /*object*/obj, /* number */num
+    // /* foam.String */ str, /*foam.Boolean*/ bool , /* foam.Function */ func, /*foam.Object*/obj, /* foam.Number */num
     expect(function() { params[0].validate('hello'); }).not.toThrow();
     expect(function() { params[1].validate(true); }).not.toThrow();
     expect(function() { params[2].validate(function() {}); }).not.toThrow();
@@ -159,7 +159,7 @@ describe('Argument.validate', function() {
   it('rejects wrong primitive types', function() {
     var params = foam.Function.args(makePrimitiveTestFn());
 
-    // /* string */ str, /*boolean*/ bool , /* function*/ func, /*object*/obj, /* number */num
+    // /* foam.String */ str, /*foam.Boolean*/ bool , /* foam.Function */ func, /*foam.Object*/obj, /* foam.Number */num
     expect(function() { params[0].validate(78); }).toThrow();
     expect(function() { params[1].validate('nice'); }).toThrow();
     expect(function() { params[2].validate({}); }).toThrow();
@@ -171,7 +171,7 @@ describe('Argument.validate', function() {
   it('parses empty args list with tricky function body', function() {
     var params = foam.Function.args(function() { (3+4); return (1); });
 
-    // /* string */ str, /*boolean*/ bool , /* function*/ func, /*object*/obj, /* number */num
+    // /* foam.String */ str, /*foam.Boolean*/ bool , /* foam.Function */ func, /*foam.Object*/obj, /* foam.Number */num
     expect(function() { params[0].validate(78); }).toThrow();
     expect(function() { params[1].validate('nice'); }).toThrow();
     expect(function() { params[2].validate({}); }).toThrow();
@@ -239,7 +239,7 @@ describe('foam.Function.typeCheck', function() {
   });
 
   it('fails bad return type', function() {
-   var rfn = foam.Function.typeCheck(function(arg /* object */) { return arg; });
+   var rfn = foam.Function.typeCheck(function(arg /* foam.Object */) { return arg; });
    expect(function() { rfn({}); }).not.toThrow();
    expect(function() { rfn(99); }).toThrow();
   });

--- a/test/src/core/stdlib.js
+++ b/test/src/core/stdlib.js
@@ -300,8 +300,8 @@ describe('foam.Function', function() {
     });
 
     it('grabs typed argument names', function() {
-      var fn = function(/* string */ str, /*boolean*/ bool ,
-        /* function*/ func, /*object*/obj, /* number */num, /* array*/ arr ) {
+      var fn = function(/* foam.String */ str, /*boolean*/ bool ,
+        /* foam.Function */ func, /*object*/obj, /* number */num, /* array*/ arr ) {
         return (true);
       }
       var args = foam.Function.argNames(fn);


### PR DESCRIPTION
Memoize0/1 retains the original function's toString() in order to support type checking on memo'd functions.