### PR TITLE
Refactor SQL, moving validation into SQLSupport

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -117,6 +117,7 @@ FOAM_FILES([
   { name: "foam/dao/TimingDAO" },
   { name: "foam/dao/LoggingDAO" },
   { name: "foam/dao/IDBDAO", flags: ['web'] },
+  { name: "foam/dao/SQL" },
   { name: "foam/parse/QueryParser" },
   { name: "foam/physics/Physical" },
   { name: "foam/physics/Collider" },

--- a/src/files.js
+++ b/src/files.js
@@ -117,7 +117,7 @@ FOAM_FILES([
   { name: "foam/dao/TimingDAO" },
   { name: "foam/dao/LoggingDAO" },
   { name: "foam/dao/IDBDAO", flags: ['web'] },
-  { name: "foam/dao/SQL" },
+  { name: "foam/dao/SQL", flags: ['sql'] },
   { name: "foam/parse/QueryParser" },
   { name: "foam/physics/Physical" },
   { name: "foam/physics/Collider" },

--- a/src/foam/dao/SQL.js
+++ b/src/foam/dao/SQL.js
@@ -124,11 +124,9 @@ foam.CLASS({
   refines: 'foam.mlang.predicate.Eq',
   methods: [
     function toSQL() {
-      var values = this.SQLSupport.create().values(this);
-
-      return values.v2 === null ?
-          values.v1 + ' IS NULL' :
-          values.v1 + " = " + values.v2 ;
+      return this.arg2 === null ?
+        this.sqlValue('arg1') + ' IS NULL' :
+        this.sqlValue('arg1') + " = " + this.sqlValue('arg2');
     }
   ]
 });

--- a/src/foam/dao/SQL.js
+++ b/src/foam/dao/SQL.js
@@ -25,6 +25,8 @@ foam.CLASS({
 foam.CLASS({
   refines: 'foam.mlang.predicate.AbstractPredicate',
 
+  requires: [ 'foam.dao.SQLException' ],
+
   methods: [
     function sqlValue(argName) {
       var arg = this[argName];
@@ -102,7 +104,6 @@ foam.CLASS({
 
 foam.CLASS({
   refines: 'foam.mlang.predicate.Has',
-  requires: [ 'foam.mlang.predicate.SQLSupport' ],
   methods: [
     function toSQL() {
       return this.sqlValue('arg1') + ' IS NOT NULL';
@@ -121,7 +122,6 @@ foam.CLASS({
 
 foam.CLASS({
   refines: 'foam.mlang.predicate.Eq',
-  requires: [ 'foam.mlang.predicate.SQLSupport' ],
   methods: [
     function toSQL() {
       var values = this.SQLSupport.create().values(this);
@@ -136,7 +136,6 @@ foam.CLASS({
 
 foam.CLASS({
   refines: 'foam.mlang.predicate.Neq',
-  requires: [ 'foam.mlang.predicate.SQLSupport' ],
   methods: [
     function toSQL() {
       return this.arg2 === null ?
@@ -149,10 +148,6 @@ foam.CLASS({
 
 foam.CLASS({
   refines: 'foam.mlang.predicate.Gt',
-  requires: [
-    'foam.mlang.predicate.SQLSupport',
-    'foam.dao.SQLException'
-  ],
   methods: [
     function toSQL() {
       return this.sqlValue('arg1') + ' > ' + this.sqlValue('arg2');
@@ -163,10 +158,6 @@ foam.CLASS({
 
 foam.CLASS({
   refines: 'foam.mlang.predicate.Gte',
-  requires: [
-    'foam.mlang.predicate.SQLSupport',
-    'foam.dao.SQLException'
-  ],
   methods: [
     function toSQL() {
       return this.sqlValue('arg1') + ' >= ' + this.sqlValue('arg2');
@@ -177,10 +168,6 @@ foam.CLASS({
 
 foam.CLASS({
   refines: 'foam.mlang.predicate.Lt',
-  requires: [
-    'foam.mlang.predicate.SQLSupport',
-    'foam.dao.SQLException'
-  ],
   methods: [
     function toSQL() {
       return this.sqlValue('arg1') + ' < ' + this.sqlValue('arg2');
@@ -191,10 +178,6 @@ foam.CLASS({
 
 foam.CLASS({
   refines: 'foam.mlang.predicate.Lte',
-  requires: [
-    'foam.mlang.predicate.SQLSupport',
-    'foam.dao.SQLException'
-  ],
   methods: [
     function toSQL() {
       return this.sqlValue('arg1') + ' <= ' + this.sqlValue('arg2');
@@ -241,7 +224,6 @@ foam.CLASS({
 
 foam.CLASS({
   refines: 'foam.mlang.predicate.In',
-  requires: [ 'foam.mlang.predicate.SQLSupport' ],
   methods: [
     function toSQL() {
       var s = this.sqlValue('arg1');

--- a/src/foam/dao/SQL.js
+++ b/src/foam/dao/SQL.js
@@ -28,8 +28,8 @@ foam.CLASS({
   methods: [
     function sqlValue(argName) {
       var arg = this[argName];
-      var v = arg.toSQL ? arg.toSQL() :
-        arg.toString ? arg.toString() :
+      var v = arg && arg.toSQL ? arg.toSQL() :
+        arg && arg.toString ? arg.toString() :
         arg;
 
       if ( v === undefined || v === null )


### PR DESCRIPTION
Move validation into SQLSupport which removes the use of SUPER for validation and results in arg1/arg2 toSQL/toString only being called once. 
Unary/Binary throw SQLExceptions reporting that toSQL has not be implemented for the particular mlang.  This could be removed if we decide to refine toSQL into all mlangs. 