### PR TITLE
Restore foam.CLASS after the overridden foam.CLASS is called once.

### DIFF
--- a/src/foam/classloader/NodeModelFileDAO.js
+++ b/src/foam/classloader/NodeModelFileDAO.js
@@ -31,10 +31,15 @@ foam.CLASS({
     function find(id) {
       var foamCLASS = foam.CLASS;
       var self = this;
-      var model;
+      var modelToReturn;
       foam.CLASS = function(m) {
         var cls = m.class ? foam.lookup(m.class) : foam.core.Model;
-        model = cls.create(m, self);
+        var model = cls.create(m, self);
+        if ( model.id != id ) {
+          foamCLASS(m);
+        } else {
+          modelToReturn = model;
+        }
       }
       var sep = require('path').sep;
       var path = this.classpath + sep + id.replace(/\./g, sep) + '.js';
@@ -46,7 +51,8 @@ foam.CLASS({
       } finally {
         foam.CLASS = foamCLASS;
       }
-      return Promise.resolve(model);
+      if ( modelToReturn ) return Promise.resolve(modelToReturn);
+      return Promise.reject('Unable to find ' + id + ' in ' + path);
     }
   ]
 });

--- a/src/foam/classloader/NodeModelFileDAO.js
+++ b/src/foam/classloader/NodeModelFileDAO.js
@@ -31,15 +31,11 @@ foam.CLASS({
     function find(id) {
       var foamCLASS = foam.CLASS;
       var self = this;
-      var modelToReturn;
+      var model;
       foam.CLASS = function(m) {
         var cls = m.class ? foam.lookup(m.class) : foam.core.Model;
-        var model = cls.create(m, self);
-        if ( model.id != id ) {
-          foamCLASS(m);
-        } else {
-          modelToReturn = model;
-        }
+        model = cls.create(m, self);
+        foam.CLASS = foamCLASS;
       }
       var sep = require('path').sep;
       var path = this.classpath + sep + id.replace(/\./g, sep) + '.js';
@@ -51,8 +47,7 @@ foam.CLASS({
       } finally {
         foam.CLASS = foamCLASS;
       }
-      if ( modelToReturn ) return Promise.resolve(modelToReturn);
-      return Promise.reject('Unable to find ' + id + ' in ' + path);
+      return Promise.resolve(model);
     }
   ]
 });

--- a/src/foam/classloader/WebModelFileDAO.js
+++ b/src/foam/classloader/WebModelFileDAO.js
@@ -49,11 +49,16 @@ foam.CLASS({
       return req.send().then(function(payload) {
         return payload.resp.text();
       }).then(function(js) {
-        var model;
+        var modelToReturn;
         var foamCLASS = foam.CLASS;
         foam.CLASS = function(m) {
           var cls = m.class ? foam.lookup(m.class) : foam.core.Model;
-          model = cls.create(m, self);
+          var model = cls.create(m, self);
+          if ( model.id != id ) {
+            foamCLASS(m);
+          } else {
+            modelToReturn = model;
+          }
         }
         try {
           eval(js);
@@ -63,7 +68,8 @@ foam.CLASS({
         } finally {
           foam.CLASS = foamCLASS;
         }
-        return model;
+        if ( modelToReturn ) return Promise.resolve(modelToReturn);
+        return Promise.reject('Unable to find ' + id + ' at ' + url);
       });
     }
   ]

--- a/src/foam/classloader/WebModelFileDAO.js
+++ b/src/foam/classloader/WebModelFileDAO.js
@@ -49,16 +49,12 @@ foam.CLASS({
       return req.send().then(function(payload) {
         return payload.resp.text();
       }).then(function(js) {
-        var modelToReturn;
+        var model;
         var foamCLASS = foam.CLASS;
         foam.CLASS = function(m) {
           var cls = m.class ? foam.lookup(m.class) : foam.core.Model;
-          var model = cls.create(m, self);
-          if ( model.id != id ) {
-            foamCLASS(m);
-          } else {
-            modelToReturn = model;
-          }
+          model = cls.create(m, self);
+          foam.CLASS = foamCLASS;
         }
         try {
           eval(js);
@@ -68,8 +64,7 @@ foam.CLASS({
         } finally {
           foam.CLASS = foamCLASS;
         }
-        if ( modelToReturn ) return Promise.resolve(modelToReturn);
-        return Promise.reject('Unable to find ' + id + ' at ' + url);
+        return Promise.resolve(model);
       });
     }
   ]


### PR DESCRIPTION
This is to help handle files that contain more than one model being defined. With this change, the model that you're trying to load must occur first in the file that's being loaded. So the model will need to be first and refinements and other models have to be after it.