### PR TITLE
Inversion of control for diffing of properties: 

### DIFF
--- a/jasmine_node.json
+++ b/jasmine_node.json
@@ -1,8 +1,7 @@
 {
   "spec_dir": "test",
   "spec_files": [
-    "FOAMByExample.js",
-    "src/**/*.js"
+    "src/core/objects.js"
   ],
   "helpers": [
     "helpers/**/*.js"

--- a/jasmine_node.json
+++ b/jasmine_node.json
@@ -1,7 +1,8 @@
 {
   "spec_dir": "test",
   "spec_files": [
-    "src/core/objects.js"
+    "FOAMByExample.js",
+    "src/**/*.js"
   ],
   "helpers": [
     "helpers/**/*.js"

--- a/src/foam/core/FObject.js
+++ b/src/foam/core/FObject.js
@@ -833,20 +833,11 @@ foam.CLASS({
 
       var ps = this.cls_.getAxiomsByClass(foam.core.Property);
       for ( var i = 0, property ; property = ps[i] ; i++ ) {
-        var value    = property.f(this);
-        var otherVal = property.f(other);
-
         // FUTURE: add nested Object support
         // FUTURE: add patch() method?
-        if ( Array.isArray(value) ) {
-          var subdiff = foam.Array.diff(value, otherVal);
-          if ( subdiff.added.length !== 0 || subdiff.removed.length !== 0 ) {
-            d[property.name] = subdiff;
-          }
-        } else if ( ! foam.util.equals(value, otherVal) ) {
-          // if the primary value is undefined, use the compareTo of the other
-          d[property.name] = otherVal;
-        }
+
+        // Property adds its difference(s) to "d".
+        property.diffProperty(this, other, d);
       }
 
       return d;

--- a/src/foam/core/FObject.js
+++ b/src/foam/core/FObject.js
@@ -837,7 +837,7 @@ foam.CLASS({
         // FUTURE: add patch() method?
 
         // Property adds its difference(s) to "d".
-        property.diffProperty(this, other, d);
+        property.diffProperty(this, other, d, property);
       }
 
       return d;

--- a/src/foam/core/Property.js
+++ b/src/foam/core/Property.js
@@ -205,6 +205,36 @@ foam.CLASS({
           return comparePropertyValues(f(o1), f(o2));
         };
       }
+    },
+    {
+      name: 'diffPropertyValues',
+      transient: true,
+      factory: function() {
+        var name = this.name;
+        return function(v1, v2, diff) {
+          if ( Array.isArray(v1) ) {
+            var subdiff = foam.Array.diff(v1, v2);
+            if ( subdiff.added.length !== 0 || subdiff.removed.length !== 0 ) {
+              diff[name] = subdiff;
+            }
+          } else if ( ! foam.util.equals(v1, v2) ) {
+            // if the primary value is undefined, use the compareTo of the other
+            diff[name] = v2;
+          }
+          return diff;
+        };
+      }
+    },
+    {
+      name: 'diffProperty',
+      transient: true,
+      factory: function() {
+        var diffPropertyValues = this.diffPropertyValues;
+        var f = this.f;
+        return function diffProperty(o1, o2, diff) {
+          return diffPropertyValues(f(o1), f(o2), diff);
+        };
+      }
     }
   ],
 

--- a/src/foam/core/Property.js
+++ b/src/foam/core/Property.js
@@ -209,31 +209,24 @@ foam.CLASS({
     {
       name: 'diffPropertyValues',
       transient: true,
-      factory: function() {
-        var name = this.name;
-        return function(v1, v2, diff) {
-          if ( Array.isArray(v1) ) {
-            var subdiff = foam.Array.diff(v1, v2);
-            if ( subdiff.added.length !== 0 || subdiff.removed.length !== 0 ) {
-              diff[name] = subdiff;
-            }
-          } else if ( ! foam.util.equals(v1, v2) ) {
-            // if the primary value is undefined, use the compareTo of the other
-            diff[name] = v2;
+      value: function(v1, v2, diff) {
+        if ( Array.isArray(v1) ) {
+          var subdiff = foam.Array.diff(v1, v2);
+          if ( subdiff.added.length !== 0 || subdiff.removed.length !== 0 ) {
+            diff[this.name] = subdiff;
           }
-          return diff;
-        };
+        } else if ( ! foam.util.equals(v1, v2) ) {
+          // if the primary value is undefined, use the compareTo of the other
+          diff[this.name] = v2;
+        }
+        return diff;
       }
     },
     {
       name: 'diffProperty',
       transient: true,
-      factory: function() {
-        var diffPropertyValues = this.diffPropertyValues;
-        var f = this.f;
-        return function diffProperty(o1, o2, diff) {
-          return diffPropertyValues(f(o1), f(o2), diff);
-        };
+      value: function diffProperty(o1, o2, diff, prop) {
+        return prop.diffPropertyValues(prop.f(o1), prop.f(o2), diff);
       }
     }
   ],


### PR DESCRIPTION
`FObject` delegates to `property.compareProperty(o1, o2, diffObj)`; `Property` implements `compareProperty(o1, o2, diffObj)` which delegates to `comparePropertyValues(f(o1), f(2), diffObj)`.

This _almost_ mirrors how comparison works, except that `diffObj` is a writable parameter that must be passed around because `o2` could 'add value: `undefined`', complicating the issue of returning a 'no diff' value (which would otherwise allow us to avoid passing `diffObj` around). This corner case was caught by existing tests :)