### PR TITLE
Register named refinements in context

### DIFF
--- a/src/foam/core/Boot.js
+++ b/src/foam/core/Boot.js
@@ -214,12 +214,11 @@ foam.LIB({
           foam.package.registerClass(cls);
         } else if ( m.name ) {
           // Register refinement id in global context.
-          foam.register(cls, ( clsDef.package || 'foam.core' ) + '.' +
-              clsDef.name);
+          foam.register(cls, ( cls.package || 'foam.core' ) + '.' + m.name);
         }
         // TODO(markdittmer): Identify and name anonymous refinements with:
         // else {
-        //   console.warn('Refinement without unique id', clsDef);
+        //   console.warn('Refinement without unique id', cls);
         //   debugger;
         // }
 

--- a/src/foam/core/Boot.js
+++ b/src/foam/core/Boot.js
@@ -192,13 +192,15 @@ foam.LIB({
       /* Creates a Foam class from a plain-old-object definition.
           @method CLASS
           @memberof module:foam */
-      foam.CLASS = function(clsDef) {
+      foam.CLASS = function(clsDef, skipRegistration) {
         var classOfModel = clsDef.class ?
             foam.lookup(clsDef.class) : foam.core.Model;
         var modelOfClass = classOfModel.create(clsDef);
         modelOfClass.validate();
         var cls = modelOfClass.buildClass();
         cls.validate();
+
+        if ( skipRegistration ) return cls;
 
         if ( ! clsDef.refines ) {
           // Register class in global context.
@@ -228,13 +230,7 @@ foam.LIB({
         // existing class.
         clsDef.refines = clsDef.id;
 
-        // Same as phase2()'s foam.CLASS() above, except skip registration.
-        var classOfModel = clsDef.class ?
-            foam.lookup(clsDef.class) : foam.core.Model;
-        var modelOfClass = classOfModel.create(clsDef);
-        modelOfClass.validate();
-        var cls = modelOfClass.buildClass();
-        cls.validate();
+        foam.CLASS(clsDef, true);
       }
     },
 

--- a/src/foam/core/Boot.js
+++ b/src/foam/core/Boot.js
@@ -195,7 +195,7 @@ foam.LIB({
           (3) Construct and validate the new class.
           @method CLASS
           @memberof module:foam */
-      foam.CLASS = function(m) {
+      foam.CLASS = function(m, skipRegistration) {
         var cls   = m.class ? foam.lookup(m.class) : foam.core.Model;
         var model = cls.create(m);
         model.validate();

--- a/src/foam/core/EndBoot.js
+++ b/src/foam/core/EndBoot.js
@@ -185,7 +185,7 @@ foam.boot.end();
   foam.json.Storage does not encode storageTransient fields.
  */
 foam.CLASS({
-  refines: 'Property',
+  refines: 'foam.core.Property',
 
   properties: [
     {

--- a/src/foam/u2/view/TableView.js
+++ b/src/foam/u2/view/TableView.js
@@ -16,7 +16,7 @@
  */
 
 foam.CLASS({
-  package: 'foam.u2',
+  package: 'foam.u2.view',
   name: 'TableCellPropertyRefinement',
 
   refines: 'foam.core.Property',


### PR DESCRIPTION
Modify Boot.phase2 to register refinements under <package>.<name>, but only when name is provided in class/refinement definition.