### PR TITLE
Better environment detection (node js vs. web)

### DIFF
--- a/src/foam.js
+++ b/src/foam.js
@@ -17,7 +17,7 @@
 
 (function() {
 
-  var isServer = typeof process === 'object';
+  var isServer = typeof window === 'undefined';
   var isWorker = typeof importScripts !== 'undefined';
 
   var flags = this.FOAM_FLAGS || {};

--- a/src/foam/core/lib.js
+++ b/src/foam/core/lib.js
@@ -19,7 +19,7 @@
  * Top-Level of foam package
  */
 foam = {
-  isServer: typeof process === 'object',
+  isServer: typeof window === 'undefined',
   core:     {},
   next$UID: (function() {
     /* Return a unique id. */
@@ -30,7 +30,7 @@ foam = {
 
 
 /** Setup nodejs-like 'global' on web */
-if ( ! foam.isServer ) global = this;
+if ( ! foam.isServer ) global = window;
 
 
 Object.defineProperty(

--- a/src/lib/net.js
+++ b/src/lib/net.js
@@ -16,7 +16,7 @@
  */
 
 (function() {
-  var pkg = 'foam.net.' + (typeof process === 'undefined' ? 'web' : 'node');
+  var pkg = 'foam.net.' + (foam.isServer ? 'node' : 'web');
   var clss = [
     'HTTPRequest',
     'HTTPResponse',


### PR DESCRIPTION
Use` typeof window` instead of `typeof process`, and set `global` to `window` in web environments