### PR TITLE
Fix some bug in cloud datastore DAO and allow multi-part ids.

### DIFF
--- a/src/com/google/cloud/datastore/types.js
+++ b/src/com/google/cloud/datastore/types.js
@@ -146,17 +146,15 @@ foam.LIB({
       var id = key.name;
 
       var o = cls.create();
-
-      if ( cls.model_.ids && cls.model_.ids.length > 1 ) {
-        throw new Error('Not implemented: Deserialization of Cloud Datastore ' +
-            'multi-part ids');
+      if ( cls.model_.ids && cls.model_.ids.length === 1 ) {
+        o[cls.model_.ids[i]] = id;
+      } else {
+        for ( var i = 0; i < cls.model_.ids.length; i++ ) {
+          idName = cls.model_.ids[i];
+          o[idName] = com.google.cloud.datastore
+            .fromDatastoreValue(entity.properties[idName]);
+        }
       }
-
-      var idProp = cls.model_.ids && cls.model_.ids.length === 1 ?
-          cls.getAxiomByName(cls.model_.ids[0]) :
-          cls.getAxiomByName('id');
-
-      if ( idProp ) o[idProp.name] = id;
 
       var props = entity.properties;
       for ( var name in props ) {

--- a/src/com/google/cloud/datastore/types.js
+++ b/src/com/google/cloud/datastore/types.js
@@ -146,8 +146,8 @@ foam.LIB({
       var id = key.name;
 
       var o = cls.create();
-      if ( cls.model_.ids && cls.model_.ids.length === 1 ) {
-        o[cls.model_.ids[i]] = id;
+      if ( ! cls.model_.ids || cls.model_.ids.length === 1 ) {
+        o.id = id;
       } else {
         for ( var i = 0; i < cls.model_.ids.length; i++ ) {
           idName = cls.model_.ids[i];
@@ -258,11 +258,7 @@ foam.CLASS({
       if ( ! ids )
         return { kind: this.getOwnDatastoreKind(), name: this.id.toString() };
 
-      var name = new Array(ids.length);
-      for ( var i = 0; i < ids.length; i++ ) {
-        name[i] = this[ids[i]];
-      }
-      return { kind: this.getOwnDatastoreKind(), name: name.join('_') };
+      return { kind: this.getOwnDatastoreKind(), name: foam.json.stringify(this.id)};
     },
     function getDatastoreKey(opt_propertyPath) {
       if ( ! opt_propertyPath ) return { path: [ this.getOwnDatastoreKey() ] };

--- a/src/com/google/cloud/datastore/types.js
+++ b/src/com/google/cloud/datastore/types.js
@@ -262,9 +262,9 @@ foam.CLASS({
 
       var name = new Array(ids.length);
       for ( var i = 0; i < ids.length; i++ ) {
-        name = ids[i] + ( i < ids.length - 1 ? ':' : '' );
+        name[i] = this[ids[i]];
       }
-      return { kind: this.getOwnDatastoreKind(), name: name };
+      return { kind: this.getOwnDatastoreKind(), name: name.join('_') };
     },
     function getDatastoreKey(opt_propertyPath) {
       if ( ! opt_propertyPath ) return { path: [ this.getOwnDatastoreKey() ] };

--- a/src/com/google/cloud/datastore/types.js
+++ b/src/com/google/cloud/datastore/types.js
@@ -147,13 +147,13 @@ foam.LIB({
 
       var o = cls.create();
 
-      if ( cls.ids && cls.ids.length > 1 ) {
+      if ( cls.model_.ids && cls.model_.ids.length > 1 ) {
         throw new Error('Not implemented: Deserialization of Cloud Datastore ' +
             'multi-part ids');
       }
 
-      var idProp = cls.ids && cls.ids.length === 1 ?
-          cls.getAxiomByName(cls.ids[0]) :
+      var idProp = cls.model_.ids && cls.model_.ids.length === 1 ?
+          cls.getAxiomByName(cls.model_.ids[0]) :
           cls.getAxiomByName('id');
 
       if ( idProp ) o[idProp.name] = id;


### PR DESCRIPTION
@mdittmer take a look if you have time. Not urgent, we can discuss when you back.

1.
```javascript
var name = new Array(ids.length);
for ( var i = 0; i < ids.length; i++ ) {
     name = ids[i] + ( i < ids.length - 1 ? ':' : '' );
}
```
name was created as an Array, but was overwritten in the loop every time. Did you mean `name[i] = ...`?

2.
```javascript 
return { kind: this.getOwnDatastoreKind(), name: name };
```
As stated in the [API](https://cloud.google.com/datastore/docs/reference/rest/v1/Key#PathElement), name is a string, and is unique for each elements in dataStore. So I used ids.join('_') to create the unique id.

3.
```javascript
if ( cls.ids && cls.ids.length > 1 ) {
    ...
}
```
I didn't find ids exists in cls. DId you mean `cls.model_.ids`?

4.
```javascript
throw new Error('Not implemented: Deserialization of Cloud Datastore multi-part ids');
```
This will break in the browserAPI case. browserAPI uses ids = [brwserName, browserVersion, osName, osVersion, interfaceName, apiName]. I think the cloud datastore DAO should support multi-part ids.
Thus, for multi-part ids, I just update property values which belongs to the ids array. (An alternative way is do nothing if cls.ids.length is not 1, since the properties will be updated in the second for loop.)