### PR TITLE
Fix documentation and code mismatch in mlang.CONTAINS

### DIFF
--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -642,7 +642,7 @@ foam.CLASS({
   extends: 'foam.mlang.predicate.Binary',
   implements: [ 'foam.core.Serializable' ],
 
-  documentation: 'Predicate returns true iff first arg found in second array argument.',
+  documentation: 'Predicate returns true iff second arg found in first array argument.',
 
   methods: [
     {
@@ -662,7 +662,7 @@ foam.CLASS({
   extends: 'foam.mlang.predicate.Binary',
   implements: [ 'foam.core.Serializable' ],
 
-  documentation: 'Predicate returns true iff first arg found in second array argument, ignoring case.',
+  documentation: 'Predicate returns true iff second arg found in first array argument, ignoring case.',
 
   methods: [
     function f(o) {


### PR DESCRIPTION
Documentations for Contains and ContainsIC in mlang are wrong.
The array.indexOf(element) method returns the first index at which a given element can be found in the array, or -1 if it is not present.

