### PR TITLE
Implement Datastore DAO handling of multi-part IDs…

### DIFF
--- a/src/com/google/cloud/datastore/DatastoreDAO.js
+++ b/src/com/google/cloud/datastore/DatastoreDAO.js
@@ -115,9 +115,9 @@ foam.CLASS({
       });
     },
 
-    function find(id) {
-      var key = foam.core.FObject.isInstance(id) ?
-          id.getDatastoreKey() : this.getDatastoreKeyFromId_(id);
+    function find(idOrObj) {
+      var key = foam.core.FObject.isInstance(idOrObj) ?
+          idOrObj.getDatastoreKey() : this.getDatastoreKeyFromId_(idOrObj);
       return this.getRequest('lookup', JSON.stringify({ keys: [ key ] })).send()
           .then(this.onResponse.bind(this, 'find')).then(this.onFindResponse);
     },
@@ -166,7 +166,7 @@ foam.CLASS({
       code: function(id) {
         return { path: [ {
           kind: this.of.getOwnClassDatastoreKind(),
-          name: id
+          name: com.google.cloud.datastore.toDatastoreKeyName(id)
         } ] };
       }
     },

--- a/src/com/google/cloud/datastore/types.js
+++ b/src/com/google/cloud/datastore/types.js
@@ -233,7 +233,7 @@ foam.LIB({
     {
       name: 'toDatastoreKeyName',
       code: foam.mmethod({
-        Number: function(n) { return n.toString(); },
+        Number: function(n) { return n + ''; },
         String: function(str) { return str; },
         FObject: function(o) {
           var idProp = o.cls_.ID;
@@ -265,11 +265,27 @@ foam.CLASS({
   refines: 'foam.core.Property',
 
   methods: [
-    function toDatastoreKeyName(o) {
-      return this.toDatastoreKeyNamePart(o);
+    {
+      name: 'toDatastoreKeyName',
+      documentation: `Construct a Datastore Key PathElement "name" from this
+        property. I.e.,
+        https://cloud.google.com/datastore/docs/reference/rest/v1/Key#PathElement
+        "name" property.`,
+      code: function(o) {
+        return this.toDatastoreKeyNamePart(o);
+      }
     },
-    function toDatastoreKeyNamePart(o) {
-      return this.f(o).toString();
+    {
+      name: 'toDatastoreKeyNamePart',
+      documentation: `Provide this property's contribution to a composite
+        Datastore Key PathElement "name" from this property. This is used by
+        MultiPartIDs to gather string fragments from multiple properies. See
+        https://cloud.google.com/datastore/docs/reference/rest/v1/Key#PathElement
+        "name" property for Datastore API usage details.`,
+      code: function(o) {
+        return this.f(o).toString();
+        return this.toDatastoreKeyNamePart(o);
+      }
     }
   ]
 });

--- a/src/com/google/cloud/datastore/types.js
+++ b/src/com/google/cloud/datastore/types.js
@@ -229,6 +229,82 @@ foam.LIB({
               JSON.stringify(v));
         };
       })()
+    },
+    {
+      name: 'toDatastoreKeyName',
+      code: foam.mmethod({
+        Number: function(n) { return n.toString(); },
+        String: function(str) { return str; },
+        FObject: function(o) {
+          var idProp = o.cls_.ID;
+          if ( ! idProp ) {
+            throw new Error('Attempt to construct datastore key from ' +
+                'unidentified object');
+          }
+          return idProp.toDatastoreKeyName(o);
+        },
+        Array: function(a) {
+          throw new Error('Multi-part keys must be derived from objects, not values');
+        },
+        Object: function(o) {
+          throw new Error('Cannot convert plain object to datastore key name');
+        }
+      }, function(o) {
+        throw new Error('Cannot convert ' + o + ' to datastore key name');
+      })
+    }
+  ]
+});
+
+//
+// Refine properties and multi-part ids to support conversion:
+// property-on-object => datastore-key-name
+//
+
+foam.CLASS({
+  refines: 'foam.core.Property',
+
+  methods: [
+    function toDatastoreKeyName(o) {
+      return this.toDatastoreKeyNamePart(o);
+    },
+    function toDatastoreKeyNamePart(o) {
+      return this.f(o).toString();
+    }
+  ]
+});
+
+foam.CLASS({
+  refines: 'foam.core.Date',
+
+  methods: [
+    function toDatastoreKeyNamePart(o) {
+      return this.f(o).toISOString();
+    }
+  ]
+});
+
+foam.CLASS({
+  refines: 'foam.core.MultiPartID',
+
+  properties: [
+    {
+      class: 'String',
+      name: 'stringSeparator',
+      value: ':'
+    }
+  ],
+
+  methods: [
+    function toDatastoreKeyName(o) {
+      var sep = this.stringSeparator;
+      var props = this.props;
+      var str = '';
+      for ( var i = 0; i < props.length; i++ ) {
+        str += props[i].toDatastoreKeyNamePart(o);
+        if ( i !== props.length - 1 ) str += sep;
+      }
+      return str;
     }
   ]
 });
@@ -252,19 +328,10 @@ foam.CLASS({
       return this.cls_.getClassDatastoreKind();
     },
     function getOwnDatastoreKey() {
-      if ( ! ( this.model_.ids || this.id ) ) {
-        throw new Error('Attempt to construct datastore key from ' +
-            'unidentified object');
-      }
-      var ids = this.model_.ids;
-      if ( ! ids )
-        return { kind: this.getOwnDatastoreKind(), name: this.id.toString() };
-
-      var name = new Array(ids.length);
-      for ( var i = 0; i < ids.length; i++ ) {
-        name = ids[i] + ( i < ids.length - 1 ? ':' : '' );
-      }
-      return { kind: this.getOwnDatastoreKind(), name: name };
+      return {
+        kind: this.getOwnDatastoreKind(),
+        name: com.google.cloud.datastore.toDatastoreKeyName(this)
+      };
     },
     function getDatastoreKey(opt_propertyPath) {
       if ( ! opt_propertyPath ) return { path: [ this.getOwnDatastoreKey() ] };


### PR DESCRIPTION
… via Property inversion-of-control.

Thanks to @jingt06 for clearly identifying the issues here (in #269). This is an alternative fix that gives `Property` objects control over how they contribute to mutli-part IDs.

There's one thing that I'm not thrilled with here, but I think the implementation is reasonably good: We're stuck having to support `find(objWithId)` as well as `find(id)`. The former case gives properties control over conversion-to-datastore. In the latter case, we cannot be sure of the right class + property to delegate to for inversion of control. In the interest of...

    It’s often better to make things distinctly different than to make them almost the same.
      ~Henry Spencer, in The Art of Unix Programming

I ground the key name multi-method in an implementation that throws for `Array`. The intended effect is that `find(id)` is supported for simple types, but *not* for multi-part id *values*. Lookup on multi-part ids require an object with property values to ensure that we don't lookup/generate/coerce two *different* ids for `find(objWithMultiPartId)` and `find(objWithMultiPartId.id)`.

@kgrgreer and @jingt06 PTAL.