### PR TITLE
Fix ManyToManyRelationshipDAO

### DIFF
--- a/src/foam/dao/ManyToManyRelationshipDAO.js
+++ b/src/foam/dao/ManyToManyRelationshipDAO.js
@@ -25,17 +25,17 @@ foam.CLASS({
   documentation: 'Adapts a DAO based on a *:* Relationship.',
 
   properties: [
-    'junctionProperty', // TODO(markdittmer): Is this needed?
+    'junctionProperty',
     'joinDAOKey',
-    'targetProperty', // TODO(markdittmer): Is this needed?
+    'targetProperty',
     {
       name: 'predicate',
       documentation: `ManyToMany filtered querys are always "backward" to
-        match sourceId and source object's id.`,
+        match inverse-namd property and source object's id.`,
       getter: function() {
-        // TODO(markdittmer): Can the desired property ever be something other
-        // than SOURCE_ID?
-        return this.EQ(this.of.SOURCE_ID, this.obj.id);
+        return this.EQ(
+          this.of[foam.String.constantize(this.relationship.inverseName)],
+          this.obj.id);
       }
     }
   ],
@@ -48,7 +48,7 @@ foam.CLASS({
       return self.SUPER(self.MAP(self.junctionProperty)).then(function(map) {
         return joinDAO.select(sink, skip, limit, order, self.AND(
           predicate || self.TRUE,
-          self.IN(joinDAO.of.ID, map.delegate.a)));
+          self.IN(self.targetProperty, map.delegate.a)));
       });
     }
   ]

--- a/src/foam/dao/ManyToManyRelationshipDAO.js
+++ b/src/foam/dao/ManyToManyRelationshipDAO.js
@@ -43,7 +43,7 @@ foam.CLASS({
   methods: [
     function select(sink, skip, limit, order, predicate) {
       var self = this;
-      var joinDAO = self.__context__[self.joinDAOKey];
+      var joinDAO = this.__context__[this.joinDAOKey];
 
       return self.SUPER(self.MAP(self.junctionProperty)).then(function(map) {
         return joinDAO.select(sink, skip, limit, order, self.AND(

--- a/src/foam/dao/Relationship.js
+++ b/src/foam/dao/Relationship.js
@@ -290,6 +290,8 @@ foam.CLASS({
       */
     },
 
+    // TODO(markdittmer): Use of "forward" here doesn't seem right. No call
+    // sites pass a second parameter.
     function targetQueryFromSource(obj, forward) {
       var targetClass = this.lookup(forward ? this.targetModel : this.sourceModel);
       var name        = forward ? this.inverseName : this.forwardName;

--- a/src/foam/dao/Relationship.js
+++ b/src/foam/dao/Relationship.js
@@ -293,8 +293,6 @@ foam.CLASS({
       */
     },
 
-    // TODO(markdittmer): Use of "forward" here doesn't seem right. No call
-    // sites pass a second parameter.
     function targetQueryFromSource(obj, forward) {
       var targetClass = this.lookup(forward ? this.targetModel : this.sourceModel);
       var name        = forward ? this.inverseName : this.forwardName;

--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -1641,6 +1641,7 @@ foam.CLASS({
     'foam.mlang.predicate.Contains',
     'foam.mlang.predicate.ContainsIC',
     'foam.mlang.predicate.Eq',
+    'foam.mlang.predicate.False',
     'foam.mlang.predicate.Func',
     'foam.mlang.predicate.Gt',
     'foam.mlang.predicate.Gte',
@@ -1654,6 +1655,7 @@ foam.CLASS({
     'foam.mlang.predicate.Or',
     'foam.mlang.predicate.StartsWith',
     'foam.mlang.predicate.StartsWithIC',
+    'foam.mlang.predicate.True',
     'foam.mlang.sink.Count',
     'foam.mlang.sink.Explain',
     'foam.mlang.sink.GroupBy',
@@ -1675,6 +1677,9 @@ foam.CLASS({
     function _binary_(name, arg1, arg2) {
       return this[name].create({ arg1: arg1, arg2: arg2 });
     },
+
+    function TRUE() { return this.True.create(); },
+    function FALSE() { return this.False.create(); },
 
     function OR() { return this._nary_("Or", arguments); },
     function AND() { return this._nary_("And", arguments); },

--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -1674,6 +1674,11 @@ foam.CLASS({
     'foam.mlang.sink.Sum'
   ],
 
+  constants: {
+    FALSE: foam.mlang.predicate.False.create(),
+    TRUE: foam.mlang.predicate.True.create()
+  },
+
   methods: [
     function _nary_(name, args) {
       return this[name].create({ args: Array.from(args) });
@@ -1686,9 +1691,6 @@ foam.CLASS({
     function _binary_(name, arg1, arg2) {
       return this[name].create({ arg1: arg1, arg2: arg2 });
     },
-
-    function TRUE() { return this.True.create(); },
-    function FALSE() { return this.False.create(); },
 
     function OR() { return this._nary_("Or", arguments); },
     function AND() { return this._nary_("And", arguments); },


### PR DESCRIPTION
`ManyToManyRelationshipDAO` was not loading the appropriate filter predicate for `select()`ing over what it is `of`. This PR attempts to fix that logic error and add some other niceness such as `skip, ..., predicate` support and `TRUE`/`FALSE` exported by `Expressions`.