### PR TITLE
MultiPartID index support

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -97,6 +97,7 @@ FOAM_FILES([
   { name: "foam/dao/index/AATree" },
   { name: "foam/dao/index/TreeIndex" },
   { name: "foam/dao/index/AutoIndex" },
+  { name: "foam/dao/index/MultiKeyIndex" },
   { name: "foam/dao/MDAO" },
   { name: "foam/dao/ArrayDAO" },
   { name: "foam/dao/TimestampDAO" },

--- a/src/foam/dao/index/MultiKeyIndex.js
+++ b/src/foam/dao/index/MultiKeyIndex.js
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+foam.CLASS({
+  package: 'foam.dao.index',
+  name: 'MultiKeyIndex',
+  extends: 'foam.dao.index.ProxyIndex',
+
+  methods: [
+    function toPrettyString(indent) {
+      var ret = '  '.repeat(indent) + 'MultiKey(' + this.$UID + ')\n';
+      ret += this.delegate.toPrettyString(indent + 1);
+      return ret;
+    }
+  ]
+
+});
+
+foam.CLASS({
+  package: 'foam.dao.index',
+  name: 'MultiKeyIndexNode',
+  extends: 'foam.dao.index.ProxyIndexNode',
+
+  methods: [
+    function get(key) {
+      // MultiKey indexes use an array of values as the key. To find the
+      // sub-index, we must dig into the delegate's tail indexes. Abort if
+      // any key part is not found, returning undefined.
+      // TODO(jacksonic): validate key array
+      var subIndex = this.delegate.get(key[0]);
+      for (var i = 1; (i < key.length && subIndex); ++i) {
+        subIndex = subIndex.get(key[i]);
+      }
+      return subIndex;
+    },
+  ]
+});
+
+foam.CLASS({
+  refines: 'foam.core.MultiPartID',
+
+  requires: [ 'foam.dao.index.MultiKeyIndex' ],
+
+  methods: [
+    function toIndex(tail) {
+      // build index, innermost to outermost
+      var index = tail;
+      var ps = this.props;
+      for (var i = ps.length - 1; i >= 0; --i) {
+        index = ps[i].toIndex(index);
+      }
+      return this.MultiKeyIndex.create({ delegate: index });
+    }
+  ]
+});

--- a/src/foam/dao/index/MultiKeyIndex.js
+++ b/src/foam/dao/index/MultiKeyIndex.js
@@ -27,7 +27,6 @@ foam.CLASS({
       return ret;
     }
   ]
-
 });
 
 foam.CLASS({
@@ -42,11 +41,11 @@ foam.CLASS({
       // any key part is not found, returning undefined.
       // TODO(jacksonic): validate key array
       var subIndex = this.delegate.get(key[0]);
-      for (var i = 1; (i < key.length && subIndex); ++i) {
+      for ( var i = 1; ( i < key.length && subIndex ); ++i ) {
         subIndex = subIndex.get(key[i]);
       }
       return subIndex;
-    },
+    }
   ]
 });
 
@@ -60,7 +59,7 @@ foam.CLASS({
       // build index, innermost to outermost
       var index = tail;
       var ps = this.props;
-      for (var i = ps.length - 1; i >= 0; --i) {
+      for ( var i = ps.length - 1; i >= 0; --i ) {
         index = ps[i].toIndex(index);
       }
       return this.MultiKeyIndex.create({ delegate: index });

--- a/test/src/lib/Index.js
+++ b/test/src/lib/Index.js
@@ -865,12 +865,15 @@ describe('AutoIndex', function() {
   var fakeRoot;
 
   beforeEach(function() {
+    // The base autoindex definition. ID is the INT property
     idx = foam.dao.index.AutoIndex.create({
       idIndex: test.Indexable.ID.toIndex(foam.dao.index.ValueIndex.create())
     });
 
+    // The instance to self-build by calling .plan(...) in each test
     idxInstance = idx.createNode();
 
+    // the ID index will start populated, and populate each newly added index
     idxInstance.bulkLoad(createData2(1000));
 
     fakeRoot = {

--- a/test/src/lib/Index.js
+++ b/test/src/lib/Index.js
@@ -947,16 +947,23 @@ describe('AutoIndex', function() {
       )
     );
 
+    // Note: changes to the order of predicates produced by this function may
+    // require the test to be revised.
     pred = pred.toDisjunctiveNormalForm();
 
+    // Expect that the index will:
+    // 0. start with an ID index covering property INT
+    // 1. add an index for FLOAT(ID:INT)
+    // 2. add an index for DATE(String(ID:INT))
+    // The standalone string predicate is satisifed by the 
+    //   DATE+STRING index, leaving three indexes at the root level
     for ( var i = 0; i < pred.args.length; i++ ) {
       var subpred = pred.args[i];
       var plan = idxInstance
         .plan(sink, undefined, undefined, undefined, subpred, fakeRoot)
-      console.log("plan for ", subpred.toString(), plan.cost);
-
       plan.execute([], sink, undefined, undefined, undefined, subpred);
     }
+
     expect(idxInstance.delegate.delegates.length).toEqual(3);
     expect(idxInstance.delegate.delegates[1].size()).toEqual(1000);
     expect(idxInstance.delegate.delegates[2].size()).toEqual(1000);
@@ -985,11 +992,11 @@ describe('AutoIndex', function() {
       m.LT(test.Indexable.DATE, 8)
     ];
 
+    // In this test every subpredicate should produce a new index
     for ( var i = 0; i < preds.length; i++ ) {
       var subpred = preds[i];
       var plan = idxInstance
         .plan(sink, undefined, undefined, undefined, subpred, fakeRoot)
-      console.log("plan for ", subpred.toString(), plan.cost);
       plan.execute([], sink, undefined, undefined, undefined, subpred);
 
       expect(idxInstance.delegate.delegates.length).toEqual(i+1);

--- a/test/src/lib/Index.js
+++ b/test/src/lib/Index.js
@@ -904,9 +904,8 @@ describe('AutoIndex', function() {
       .plan(sink, undefined, undefined, m.DESC(test.Indexable.INT), undefined, fakeRoot)
       .execute([], sink, undefined, undefined, m.DESC(test.Indexable.INT), undefined);
 
-    expect(idxInstance.delegate.delegates.length).toEqual(3);
+    expect(idxInstance.delegate.delegates.length).toEqual(2);
     expect(idxInstance.delegate.delegates[1].size()).toEqual(1000);
-    expect(idxInstance.delegate.delegates[2].size()).toEqual(1000);
 
   });
 
@@ -950,16 +949,17 @@ describe('AutoIndex', function() {
 
     pred = pred.toDisjunctiveNormalForm();
 
-    // the results end up small enough that the first index is good enough
-    // for all subpred cases
     for ( var i = 0; i < pred.args.length; i++ ) {
       var subpred = pred.args[i];
-      idxInstance
+      var plan = idxInstance
         .plan(sink, undefined, undefined, undefined, subpred, fakeRoot)
-        .execute([], sink, undefined, undefined, undefined, subpred);
+      console.log("plan for ", subpred.toString(), plan.cost);
+
+      plan.execute([], sink, undefined, undefined, undefined, subpred);
     }
-    expect(idxInstance.delegate.delegates.length).toEqual(2);
+    expect(idxInstance.delegate.delegates.length).toEqual(3);
     expect(idxInstance.delegate.delegates[1].size()).toEqual(1000);
+    expect(idxInstance.delegate.delegates[2].size()).toEqual(1000);
   });
 
   it('dnf works with NOT', function() {
@@ -985,16 +985,15 @@ describe('AutoIndex', function() {
       m.LT(test.Indexable.DATE, 8)
     ];
 
-    // the results end up small enough that the first index is good enough
-    // for all subpred cases
     for ( var i = 0; i < preds.length; i++ ) {
       var subpred = preds[i];
-      idxInstance
+      var plan = idxInstance
         .plan(sink, undefined, undefined, undefined, subpred, fakeRoot)
-        .execute([], sink, undefined, undefined, undefined, subpred);
+      console.log("plan for ", subpred.toString(), plan.cost);
+      plan.execute([], sink, undefined, undefined, undefined, subpred);
 
-      expect(idxInstance.delegate.delegates.length).toEqual(i+2);
-      expect(idxInstance.delegate.delegates[i+1].size()).toEqual(1000);
+      expect(idxInstance.delegate.delegates.length).toEqual(i+1);
+      expect(idxInstance.delegate.delegates[i].size()).toEqual(1000);
     }
   });
 


### PR DESCRIPTION
Fixes #135.

Some tests became more efficient as they gained a default index on the test model's Int property.