### PR TITLE
Roll back the changes to the model daos

### DIFF
--- a/src/foam/classloader/NodeModelFileDAO.js
+++ b/src/foam/classloader/NodeModelFileDAO.js
@@ -23,14 +23,6 @@ foam.CLASS({
   properties: [
     {
       name: 'classpath'
-    },
-    {
-      name: 'loadedModels',
-      documentation: `Retain a copy of loaded models in case they are requested
-        later. This can happen, for example, if a modl is loaded twice in
-        different contexts. Subsequent require() calls will not re-invoke
-        foam.CLASS(), hence the model loaded the first time must be retained.`,
-      value: {}
     }
   ],
 
@@ -38,25 +30,13 @@ foam.CLASS({
     function find(id) {
       var foamCLASS = foam.CLASS;
       var self = this;
-      var model = this.loadedModels[id] || null;
+      var model;
 
-      if ( model ) return Promise.resolve(model);
-
-      foam.CLASS = function(clsDef) {
-        var classOfModel = clsDef.class ? foam.lookup(clsDef.class) :
-              foam.core.Model;
-        var modelOfClass = classOfModel.create(clsDef, self);
-        if ( modelOfClass.id === id ) {
-          model = modelOfClass;
-        } else {
-          // TODO(markdittmer): We should do something more reasonable here, but
-          // the DAO API only allows us to deliver one model in response to
-          // find().
-          console.warn(
-            'Class', id, 'created via arequire, but never built or registered');
-        }
-        self.loadedModels[modelOfClass.id] = modelOfClass;
-      };
+      foam.CLASS = function(m) {
+        var cls = m.class ? foam.lookup(m.class) : foam.core.Model;
+        model = cls.create(m, self);
+        foam.CLASS = foamCLASS;
+      }
 
       var sep = require('path').sep;
       var path = this.classpath + sep + id.replace(/\./g, sep) + '.js';

--- a/src/foam/classloader/WebModelFileDAO.js
+++ b/src/foam/classloader/WebModelFileDAO.js
@@ -49,23 +49,25 @@ foam.CLASS({
       return req.send().then(function(payload) {
         return payload.resp.text();
       }).then(function(js) {
-        var cls = null;
+        var model;
+        var foamCLASS = foam.CLASS;
+
+        foam.CLASS = function(m) {
+          var cls = m.class ? foam.lookup(m.class) : foam.core.Model;
+          model = cls.create(m, self);
+          foam.CLASS = foamCLASS;
+        };
 
         try {
           eval(js);
-
-          cls = foam.lookup(id, true);
-
-          if ( ! cls ) {
-            console.warn(
-                'Class', id, 'created via arequire, but never built or registered');
-          }
         } catch(e) {
           console.warn('Unable to load at ' + url + '. Error: ' + e.stack);
           return Promise.resolve(null);
+        } finally {
+          foam.CLASS = foamCLASS;
         }
 
-        return Promise.resolve(cls.model_);
+        return Promise.resolve(model);
       });
     }
   ]


### PR DESCRIPTION
This makes the classloader arequires mostly work. An arequire will arequire any dependencies needed. Custom properties aren't automatically pulled in but if you list the custom property in the model's requires then it might work but I haven't tested that workaround.