### PR TITLE
Fix doc gen script

### DIFF
--- a/doc/plugins/jsdoc-foam-plugin.js
+++ b/doc/plugins/jsdoc-foam-plugin.js
@@ -41,7 +41,7 @@
 
 var fs = require('fs');
 var exports;
-require("../../src/foam.js");
+require('../../src/foam.js');
 
 var modelComments = {};
 
@@ -190,14 +190,18 @@ var getDefinitionType = function getDefinitionType(node) {
   given the node of the CLASS call */
 var getCLASSPackage = function getCLASSPackage(node) {
 
-  var pkg = getNodePropertyNamed(node, 'package').replace(/\./g, '/');
-  if ( ! pkg ) {
+  var pkg = getNodePropertyNamed(node, 'package');
+  if (typeof pkg == 'string') {
+    pkg = pkg.replace(/\./g, '/');
     if ( getDefinitionType(node) === 'LIB' ) {
       pkg = getNodePropertyNamed(node, 'name').replace(/\./g, '/');
       pkg = pkg.substring(0, pkg.lastIndexOf('/'));
     } else {
       pkg = 'foam/core';
     }
+  }
+  else {
+    pkg = 'foam/core';
   }
 
   return pkg;
@@ -227,6 +231,7 @@ var getCLASSName = function getCLASSName(node) {
   if ( j > 0 ) {
     name = name.substring(j + 1);
   }
+
   return ( pkg ? 'module:' + pkg + '.' : '' ) + name;
 };
 
@@ -409,6 +414,15 @@ exports.astNodeVisitor = {
     if ( getDefinitionType(node) ) {
       var defType = getDefinitionType(node);
       var className = getNodePropertyNamed(node, 'name');
+
+      if (typeof className === 'object') {
+        console.info('skipping dynamic generated foam.CLASS: ', {
+          file: currentSourceName,
+          node: e
+        });
+        return;
+      }
+
       var classPackage = getCLASSPackage(node);
       var classExt = getCLASSPath(node, 'extends');
 
@@ -512,8 +526,8 @@ exports.astNodeVisitor = {
         }
       };
 
-      //console.log('++++++++++++++++++', parser._resultBuffer);
-      //console.log('********',e.comment, className, classPackage);
+      // console.log('++++++++++++++++++', parser._resultBuffer);
+      // console.log('********',e.comment, className, classPackage);
 
     } // function in an array (methods, todo: listeners, etc)
     else if ( node.type === 'FunctionExpression' &&

--- a/doc/plugins/jsdoc-foam-plugin.js
+++ b/doc/plugins/jsdoc-foam-plugin.js
@@ -40,6 +40,7 @@
 */
 
 var fs = require('fs');
+var logger = require('jsdoc/util/logger');
 var exports;
 require('../../src/foam.js');
 
@@ -164,11 +165,11 @@ var getComment = function getComment(node, filename) {
 
   // only allow one type of commenting
   if ( commentsFound > 1 ) {
-    console.warn('!!! Only one type of comment allowed. Found:');
-    console.warn('  documentation property:', propComment);
-    console.warn('  function body comment:', bodyComment);
-    console.warn('  object literal (inside braces):', objComment);
-    console.warn('  leading comment:', leadingComment);
+    logger.warn('!!! Only one type of comment allowed. Found:');
+    logger.warn('  documentation property:', propComment);
+    logger.warn('  function body comment:', bodyComment);
+    logger.warn('  object literal (inside braces):', objComment);
+    logger.warn('  leading comment:', leadingComment);
   }
   return propComment || bodyComment || objComment || leadingComment;
 };
@@ -328,7 +329,7 @@ var processArgs = function processArgs(e, node) {
       }
     }
   } catch ( err ) {
-    console.log('!!! Args not processed for ', err);
+    logger.error('!!! Args not processed for ', err);
   }
 };
 
@@ -416,7 +417,7 @@ exports.astNodeVisitor = {
       var className = getNodePropertyNamed(node, 'name');
 
       if (typeof className === 'object') {
-        console.info('skipping dynamic generated foam.CLASS: ', {
+        logger.info('skipping dynamic generated foam.CLASS: ', {
           file: currentSourceName,
           node: e
         });
@@ -454,11 +455,11 @@ exports.astNodeVisitor = {
         if ( newComment &&
              modelComments[classPackage + '.' + className] &&
              modelComments[classPackage + '.' + className].mainCommentFound ) {
-          console.warn('!!! Found multiple comment types defined for',
+          logger.warn('!!! Found multiple comment types defined for',
             classPackage + '.' + className);
-          console.warn('  old:', modelComments[classPackage +
+          logger.warn('  old:', modelComments[classPackage +
             '.' + className]._queue);
-          console.warn('  new:', newComment);
+          logger.warn('  new:', newComment);
           return;
         }
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "coverage": "JASMINE_CONFIG_PATH=jasmine_coverage.json istanbul cover -- jasmine \n istanbul instrument ./src/ -o ./tmp_cov___/ \n rm -rf ./tmp_cov___",
     "benchmarks": "JASMINE_CONFIG_PATH=jasmine_benchmarks.json jasmine",
     "benchmarksDebug": "JASMINE_CONFIG_PATH=jasmine_benchmarks.json node-debug -c node_modules/jasmine/bin/jasmine.js",
-    "doc": "rm -rf doc/gen && jsdoc -c jsdoc.conf -r -t ./doc/template -d ./doc/gen ./src/",
+    "doc": "rm -rf doc/gen && ./node_modules/jsdoc/jsdoc.js --debug -c jsdoc.conf -r -t ./doc/template -d ./doc/gen ./src/",
     "lint": "jshint -c .jshintrc  ./src/ && jscs -c .jscsrc ./src/"
   }
 }


### PR DESCRIPTION
dynamic generated classes such as [this](https://github.com/foam-framework/foam2/blob/master/src/foam/dao/Relationship.js#L214) makes the jsdoc script to fail, making new users unable to run the docs script.

this PR: 

 - makes the script to skip documenting dynamically generated classes, for now, until the documentation is migrated into the new browser-based version.
- use jsdoc/util/logger instead of console logs.