### PR TITLE
Fix mlang STARTS_WITH() and add tests

### DIFF
--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -1714,7 +1714,7 @@ foam.CLASS({
     function HAS(a) { return this._unary_("Has", a); },
     function NOT(a) { return this._unary_("Not", a); },
     function KEYWORD(a) { return this._unary_("Keyword", a); },
-    function STARTS_WITH(a, b) { return this._binary_("StartsWith", a); },
+    function STARTS_WITH(a, b) { return this._binary_("StartsWith", a, b); },
     function STARTS_WITH_IC(a, b) { return this._binary_("StartsWithIC", a, b); },
     function FUNC(fn) { return this.Func.create({ fn: fn }); },
     function DOT(a, b) { return this._binary_("Dot", a, b); },

--- a/test/src/lib/mlang.js
+++ b/test/src/lib/mlang.js
@@ -710,4 +710,62 @@ describe('MLang', function() {
       });
     });
   });
+
+  describe('STARTS_WITH()', function() {
+    var STARTS_WITH;
+    beforeEach(function() {
+      var expr = foam.mlang.ExpressionsSingleton.create();
+      STARTS_WITH = expr.STARTS_WITH.bind(expr);
+    });
+
+    it('correctly implements STARTS_WITH', function() {
+      expect(STARTS_WITH('Murray', 'M').f()).toBe(true);
+      expect(STARTS_WITH('slash', 's').f()).toBe(true);
+      expect(STARTS_WITH('jimmy', 'j').f()).toBe(true);
+      expect(STARTS_WITH('jimmy', 'J').f()).toBe(false);
+    });
+
+    it('works on DAO', function(done) {
+      dao.where(STARTS_WITH(test.mlang.Person.NAME, 'J')).select()
+      .then(function(sink) {
+        expect(sink.a.length).toBe(2); // Jimi Hendrix and Jimmy Page
+        done();
+      });
+    });
+
+    it('toString()s nicely', function() {
+      expect(STARTS_WITH(test.mlang.Person.NAME, 'C').toString())
+          .toBe('STARTS_WITH(name, "C")');
+    });
+  });
+
+  describe('STARTS_WITH_IC()', function() {
+    var STARTS_WITH_IC;
+    beforeEach(function() {
+      var expr = foam.mlang.ExpressionsSingleton.create();
+      STARTS_WITH_IC = expr.STARTS_WITH_IC.bind(expr);
+    });
+
+    it('correctly implements STARTS_WITH_IC', function() {
+      expect(STARTS_WITH_IC('Murray', 'm').f()).toBe(true);
+      expect(STARTS_WITH_IC('Murray', 'M').f()).toBe(true);
+      expect(STARTS_WITH_IC('jimmy', 'J').f()).toBe(true);
+      expect(STARTS_WITH_IC('jimmy', 'j').f()).toBe(true);
+      expect(STARTS_WITH_IC('jimmy', 'a').f()).toBe(false);
+    });
+
+    it('works on DAO', function(done) {
+      dao.where(STARTS_WITH_IC(test.mlang.Person.NAME, 'j')).select()
+      .then(function(sink) {
+        expect(sink.a.length).toBe(2); // Jimi Hendrix and Jimmy Page
+        done();
+      });
+    });
+
+    it('toString()s nicely', function() {
+      expect(STARTS_WITH_IC(test.mlang.Person.NAME, 'C').toString())
+          .toBe('STARTS_WITH_IC(name, "C")');
+    });
+  });
+
 });


### PR DESCRIPTION
mlang STARTS_WITH function was failing because the second argument was not being registered and the `mlang` unit tests were not covering it. 

this PR:

- fixes mlang STARTS_WITH() function
- added tests for STARTS_WITH() and STARTS_WITH_IC()