### PR TITLE
Some method arg fixes

### DIFF
--- a/src/foam/core/Argument.js
+++ b/src/foam/core/Argument.js
@@ -302,7 +302,11 @@ foam.CLASS({
     {
       class: 'FObjectArray',
       of: 'foam.core.Argument',
-      name: 'args'
+      name: 'args',
+      adaptArrayElement: function(o, prop) {
+        return foam.String.isInstance(o) ?
+          foam.core.Argument.create({name: o}) : o;
+      }
     }
   ]
 });

--- a/src/foam/core/templates.js
+++ b/src/foam/core/templates.js
@@ -180,7 +180,7 @@ foam.CLASS({
           ( result[0] ? t : result[1] ) +
           this.FOOTER;
 
-      var newArgs = ['opt_outputter'].concat(args);
+      var newArgs = ['opt_outputter'].concat(args.map(function(a) { return a.name }));
       var f = eval(
         '(function() { ' +
           'var TOC = function(o) { return foam.templates.TemplateOutput.create(); };' +


### PR DESCRIPTION
Refining a method's args to an FObjectArray seems to have broken templates because templates assume args are just strings so this CL properly adapts strings to foam.core.Arguments and uses foam.core.Arguments in templates.