### PR TITLE
NotFoundPlan should have cost 0, not the max

### DIFF
--- a/src/foam/dao/index/Plan.js
+++ b/src/foam/dao/index/Plan.js
@@ -42,7 +42,7 @@ foam.CLASS({
   axioms: [ foam.pattern.Singleton.create() ],
 
   properties: [
-    { name: 'cost', value: Number.MAX_VALUE }
+    { name: 'cost', value: 0 }
   ],
 
   methods: [


### PR DESCRIPTION
As I talked to @kgrgreer , the `cost` property of the NotFoundPlan is zero.