### PR TITLE
Modified AbstractPropertyInfo implementations for Byte, Double, Long, Short

### DIFF
--- a/java_src/foam/core/AbstractBytePropertyInfo.java
+++ b/java_src/foam/core/AbstractBytePropertyInfo.java
@@ -2,6 +2,6 @@ package foam.core;
 
 public abstract class AbstractBytePropertyInfo extends AbstractPropertyInfo {
   public int compareValues(byte b1, byte b2) {
-    return Byte.compare(b1, b2);
+    return java.lang.Byte.compare(b1, b2);
   }
 }

--- a/java_src/foam/core/AbstractDoublePropertyInfo.java
+++ b/java_src/foam/core/AbstractDoublePropertyInfo.java
@@ -2,6 +2,6 @@ package foam.core;
 
 public abstract class AbstractDoublePropertyInfo extends AbstractPropertyInfo {
   public int compareValues(double d1, double d2) {
-    return Double.compare(d1, d2);
+    return java.lang.Double.compare(d1, d2);
   }
 }

--- a/java_src/foam/core/AbstractLongPropertyInfo.java
+++ b/java_src/foam/core/AbstractLongPropertyInfo.java
@@ -2,6 +2,6 @@ package foam.core;
 
 public abstract class AbstractLongPropertyInfo extends AbstractPropertyInfo {
   public int compareValues(long o1, long o2) {
-    return Long.compare(o1, o2);
+    return java.lang.Long.compare(o1, o2);
   }
 }

--- a/java_src/foam/core/AbstractShortPropertyInfo.java
+++ b/java_src/foam/core/AbstractShortPropertyInfo.java
@@ -2,6 +2,6 @@ package foam.core;
 
 public abstract class AbstractShortPropertyInfo extends AbstractPropertyInfo {
   public int compareValues(short o1, short o2) {
-    return Short.compare(o1, o2);
+    return java.lang.Short.compare(o1, o2);
   }
 }


### PR DESCRIPTION
Modified the AbstactPropertyInfo implementations for Byte, Double, Long, and Short to add the `java.lang` package prefix to each of the compare function calls. This is to avoid a mix up with the equivalent `foam.core.*` classes of the same name when generating the Java versions of those classes.