### PR TITLE
Made changes to genjava file for external classes file and output path

### DIFF
--- a/tools/classes.js
+++ b/tools/classes.js
@@ -1,0 +1,71 @@
+var classes = [
+  'foam.core.Serializable',
+  'foam.mlang.predicate.Predicate',
+  'foam.mlang.predicate.True',
+  'foam.mlang.predicate.False',
+  'foam.mlang.predicate.And',
+  'foam.mlang.predicate.Gt',
+  'foam.mlang.predicate.Or',
+  'foam.mlang.predicate.AbstractPredicate',
+  'foam.mlang.predicate.Nary',
+  'foam.mlang.predicate.Unary',
+  'foam.mlang.predicate.Binary',
+  'foam.mlang.predicate.Contains',
+  'foam.mlang.predicate.StartsWithIC',
+  'foam.mlang.predicate.Gt',
+  'foam.mlang.predicate.Gte',
+  'foam.mlang.predicate.Lt',
+  'foam.mlang.predicate.Lte',
+  'foam.mlang.Expr',
+  'foam.mlang.AbstractExpr',
+  'foam.mlang.predicate.Eq',
+  'foam.mlang.Constant',
+  'foam.box.Box',
+  'foam.box.ProxyBox',
+  'foam.box.SubBox',
+  'foam.box.Message',
+  'foam.box.SubBoxMessage',
+  'foam.box.SubscribeMessage',
+  'com.google.foam.demos.appengine.TestModel',
+  'foam.box.HTTPReplyBox',
+  'com.google.foam.demos.appengine.TestService',
+  'com.google.foam.demos.heroes.Hero',
+  'com.google.auth.TokenVerifier',
+  'foam.box.RPCMessage',
+  'foam.box.RPCReturnMessage',
+  'foam.box.BoxRegistry',
+  'foam.box.BoxRegistryBox',
+  'foam.box.CheckAuthenticationBox',
+  'foam.dao.DAO',
+  'foam.dao.Sink',
+  'foam.dao.AbstractSink',
+  'foam.dao.PredicatedSink',
+  'foam.dao.OrderedSink',
+  'foam.dao.LimitedSink',
+  'foam.dao.SkipSink',
+  'foam.mlang.order.Comparator',
+  'foam.mlang.sink.Count',
+  'foam.nanos.boot.NSpec'
+];
+
+var abstractClasses = [
+//  'foam.json.Outputer'
+];
+
+var skeletons = [
+  'com.google.foam.demos.appengine.TestService',
+  'foam.dao.DAO'
+];
+
+var proxies = [
+  'foam.dao.DAO',
+  'foam.dao.Sink',
+  'com.google.foam.demos.appengine.TestService'
+];
+
+module.exports = {
+    classes: classes,
+    abstractClasses: abstractClasses,
+    skeletons: skeletons,
+    proxies: proxies
+}

--- a/tools/genjava.js
+++ b/tools/genjava.js
@@ -20,77 +20,21 @@ global.FOAM_FLAGS = { 'java': true, 'debug': true };
 
 require('../src/foam.js');
 
-var classes = [
-  'foam.core.Serializable',
-  'foam.mlang.predicate.Predicate',
-  'foam.mlang.predicate.True',
-  'foam.mlang.predicate.False',
-  'foam.mlang.predicate.And',
-  'foam.mlang.predicate.Gt',
-  'foam.mlang.predicate.Or',
-  'foam.mlang.predicate.AbstractPredicate',
-  'foam.mlang.predicate.Nary',
-  'foam.mlang.predicate.Unary',
-  'foam.mlang.predicate.Binary',
-  'foam.mlang.predicate.Contains',
-  'foam.mlang.predicate.StartsWithIC',
-  'foam.mlang.predicate.Gt',
-  'foam.mlang.predicate.Gte',
-  'foam.mlang.predicate.Lt',
-  'foam.mlang.predicate.Lte',
-  'foam.mlang.Expr',
-  'foam.mlang.AbstractExpr',
-  'foam.mlang.predicate.Eq',
-  'foam.mlang.Constant',
-  'foam.box.Box',
-  'foam.box.ProxyBox',
-  'foam.box.SubBox',
-  'foam.box.Message',
-  'foam.box.SubBoxMessage',
-  'foam.box.SubscribeMessage',
-  'com.google.foam.demos.appengine.TestModel',
-  'foam.box.HTTPReplyBox',
-  'com.google.foam.demos.appengine.TestService',
-  'com.google.foam.demos.heroes.Hero',
-  'com.google.auth.TokenVerifier',
-  'foam.box.RPCMessage',
-  'foam.box.RPCReturnMessage',
-  'foam.box.BoxRegistry',
-  'foam.box.BoxRegistryBox',
-  'foam.box.CheckAuthenticationBox',
-  'foam.dao.DAO',
-  'foam.dao.Sink',
-  'foam.dao.AbstractSink',
-  'foam.dao.PredicatedSink',
-  'foam.dao.OrderedSink',
-  'foam.dao.LimitedSink',
-  'foam.dao.SkipSink',
-  'foam.mlang.order.Comparator',
-  'foam.mlang.sink.Count',
-  'foam.nanos.boot.NSpec'
-];
-
-var abstractClasses = [
-//  'foam.json.Outputer'
-];
-
-var skeletons = [
-  'com.google.foam.demos.appengine.TestService',
-  'foam.dao.DAO'
-];
-
-var proxies = [
-  'foam.dao.DAO',
-  'foam.dao.Sink',
-  'com.google.foam.demos.appengine.TestService'
-];
-
-if ( process.argv.length != 3 ) {
-  console.log("USAGE: genjava.js output-path");
+if ( process.argv.length != 4 ) {
+  console.log("USAGE: genjava.js input-path output-path");
   process.exit(1);
 }
 
-var outdir = process.argv[2];
+var indir = process.argv[2];
+indir = require('path').resolve(require('path').normalize(indir));
+
+var externalFile = require(indir);
+var classes = externalFile.classes;
+var abstractClasses = externalFile.abstractClasses;
+var skeletons = externalFile.skeletons;
+var proxies = externalFile.proxies;
+
+var outdir = process.argv[3];
 outdir = require('path').resolve(require('path').normalize(outdir));
 
 function ensurePath(p) {


### PR DESCRIPTION
Allows for genjava.js to take a file list from external files. Command to run the generation of classes now includes `node ./tools/genjava.js  [input-file-path] [output-file-path]`