### PR TITLE
Add Aware Interface files and build flags for Java compilation

### DIFF
--- a/src/foam/dao/SinkJava.js
+++ b/src/foam/dao/SinkJava.js
@@ -38,13 +38,13 @@ foam.INTERFACE({
       javaReturns: 'void',
       args: [
         {
+          name: 'obj',
+          javaType: 'foam.core.FObject'
+        },
+        {
           name: 'sub',
           javaType: 'foam.core.Detachable'
         },
-        {
-          name: 'obj',
-          javaType: 'foam.core.FObject'
-        }
       ]
     },
     {
@@ -146,7 +146,7 @@ foam.CLASS({
               + '  setCount(getCount() + 1);\n'
               + '  return;'
               + '}\n'
-              + 'getDelegate().remove(sub, obj);'
+              + 'getDelegate().remove(obj, sub);'
     }
   ]
 });

--- a/src/foam/nanos/auth/EnabledAwareInterface.js
+++ b/src/foam/nanos/auth/EnabledAwareInterface.js
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright 2017 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.INTERFACE({
+  package: 'foam.nanos.auth',
+  name: 'EnabledAware'
+});

--- a/src/foam/nanos/auth/LastModifiedAwareInterface.js
+++ b/src/foam/nanos/auth/LastModifiedAwareInterface.js
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright 2017 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.INTERFACE({
+  package: 'foam.nanos.auth',
+  name: 'LastModifiedAware'
+});

--- a/src/foam/nanos/auth/LastModifiedByAwareInterface.js
+++ b/src/foam/nanos/auth/LastModifiedByAwareInterface.js
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright 2017 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.INTERFACE({
+  package: 'foam.nanos.auth',
+  name: 'LastModifiedByAware'
+});

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -6,11 +6,14 @@
 
 FOAM_FILES([
   { name: "foam/nanos/auth/ChangePassword" },
-  { name: "foam/nanos/auth/EnabledAware" },
+  { name: "foam/nanos/auth/EnabledAware", flags: ['js'] },
+  { name: "foam/nanos/auth/EnabledAwareInterface", flags: ['java'] },
   { name: "foam/nanos/auth/Group" },
   { name: "foam/nanos/auth/Language" },
-  { name: "foam/nanos/auth/LastModifiedAware" },
-  { name: "foam/nanos/auth/LastModifiedByAware" },
+  { name: "foam/nanos/auth/LastModifiedAware", flags: ['js'] },
+  { name: "foam/nanos/auth/LastModifiedAwareInterface", flags:['java']  },
+  { name: "foam/nanos/auth/LastModifiedByAware", flags: ['js'] },
+  { name: "foam/nanos/auth/LastModifiedByAwareInterface", flags: ['java'] },
   { name: "foam/nanos/auth/Login" },
   { name: "foam/nanos/auth/Permission" },
   { name: "foam/nanos/auth/User" },

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -43,6 +43,7 @@ var classes = [
   'foam.dao.OrderedSink',
   'foam.dao.LimitedSink',
   'foam.dao.SkipSink',
+  'foam.dao.RelationshipPropertyValue',
   'foam.mlang.order.Comparator',
   'foam.mlang.sink.Count',
   'foam.nanos.boot.NSpec',


### PR DESCRIPTION
Each of EnabledAware, LastModifiedAware, LastModifiedByAware must generate a corresponding Java interface file, via foam.INTERFACE, as these models are being 'implemented' in Java.
nanos.js specifies build flags 'js' and 'java'. Two flags are required as build.js creates a working set from non-flagged files and those matching the passed flags. This requires non-java foam builds to pass flag 'js' to build a foam-bin.js