### PR TITLE
Added java getter for required prop flag

### DIFF
--- a/java_src/foam/core/PropertyInfo.java
+++ b/java_src/foam/core/PropertyInfo.java
@@ -11,6 +11,7 @@ public interface PropertyInfo
   public ClassInfo getClassInfo();
 
   public boolean getTransient();
+  public boolean getRequired();
   public String getName();
   public Object get(Object obj);
   public void set(Object obj, Object value);

--- a/src/foam/java/PropertyInfo.js
+++ b/src/foam/java/PropertyInfo.js
@@ -42,6 +42,7 @@ foam.CLASS({
     },
     'sourceCls',
     'propType',
+    'propRequired',
     'jsonParser',
     {
       name: 'methods',
@@ -99,6 +100,12 @@ foam.CLASS({
             type: 'boolean',
             visibility: 'public',
             body: 'return ' + this.transient + ';'
+          },
+          {
+            name: 'getRequired',
+            visibility: 'public',
+            type: 'boolean',
+            body: 'return ' + Boolean(this.propRequired) + ';'
           }
         ]
       }

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -53,6 +53,7 @@ foam.CLASS({
         sourceCls: cls,
         propName: this.name,
         propType: this.javaType,
+        propRequired: this.required,
         jsonParser: this.javaJSONParser,
         extends: this.javaInfoType,
         transient: this.transient


### PR DESCRIPTION
- Provides a getter in the java generated code to see if a particular property has been set to required
- Note, defaults to false (not required)

Named `getRequired()` inline with rest of API, `isRequired()` could be more intuitive. 