### PR TITLE
Flags 'js' and 'java' are mutually exclusive.

### DIFF
--- a/src/foam.js
+++ b/src/foam.js
@@ -21,7 +21,7 @@
   var isWorker = typeof importScripts !== 'undefined';
 
   var flags    = this.FOAM_FLAGS || {};
-  flags.js     = true;
+  flags.js     = flags['java'] != true;
   flags.web    = ! isServer,
   flags.node   = isServer;
   flags.loader = ! isServer;


### PR DESCRIPTION
genjava.js will fail if foam.js flag 'js' is true. The 'js' and 'java' flags control which FooAware model is used: the class or interface.