### PR TITLE
Adding node7 test to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "7"
   - "6"
   - "5"
 


### PR DESCRIPTION
Node 7 is the latest version of node, while 6 is under long term support.