### PR TITLE
Added support for Java Array List

### DIFF
--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -627,15 +627,16 @@ foam.CLASS({
       template: function() {/*
   <%= this.javaType %> values1 = get_(o1);
   <%= this.javaType %> values2 = get_(o2);
-        if ( values1.length > values2.length ) return 1;
-        if ( values1.length < values2.length ) return -1;
+  
+  if ( values1.length > values2.length ) return 1;
+  if ( values1.length < values2.length ) return -1;
 
-        int result;
-        for ( int i = 0 ; i < values1.length ; i++ ) {
-          result = ((Comparable)values1[i]).compareTo(values2[i]);
-          if ( result != 0 ) return result;
-        }
-        return 0;*/}
+  int result;
+  for ( int i = 0 ; i < values1.length ; i++ ) {
+    result = ((Comparable)values1[i]).compareTo(values2[i]);
+    if ( result != 0 ) return result;
+  }
+  return 0;*/}
     }
   ]
 });
@@ -678,18 +679,18 @@ foam.CLASS({
     {
       name: 'compareTemplate',
       template: function() {/*
-<%= this.javaType %> values1 = get_(o1);
-<%= this.javaType %> values2 = get_(o2);
-if ( values1.length > values2.length ) return 1;
-if ( values1.length < values2.length ) return -1;
+  <%= this.javaType %> values1 = get_(o1);
+  <%= this.javaType %> values2 = get_(o2);
+  if ( values1.length > values2.length ) return 1;
+  if ( values1.length < values2.length ) return -1;
 
-int result;
-for ( int i = 0 ; i < values1.length ; i++ ) {
-result = ((Comparable)values1[i]).compareTo(values2[i]);
-if ( result != 0 ) return result;
-}
-return 0;
-*/}
+  int result;
+  for ( int i = 0 ; i < values1.length ; i++ ) {
+  result = ((Comparable)values1[i]).compareTo(values2[i]);
+  if ( result != 0 ) return result;
+  }
+  return 0;
+  */}
       }
   ]
 });
@@ -721,15 +722,16 @@ foam.CLASS({
       template: function() {/*
   <%= this.javaType %> values1 = get_(o1);
   <%= this.javaType %> values2 = get_(o2);
-        if ( values1.size() > values2.size() ) return 1;
-        if ( values1.size() < values2.size() ) return -1;
 
-        int result;
-        for ( int i = 0 ; i < values1.size() ; i++ ) {
-          result = ((Comparable)values1.get(i)).compareTo(values2.get(i));
-          if ( result != 0 ) return result;
-        }
-        return 0;*/}
+  if ( values1.size() > values2.size() ) return 1;
+  if ( values1.size() < values2.size() ) return -1;
+
+  int result;
+  for ( int i = 0 ; i < values1.size() ; i++ ) {
+    result = ((Comparable)values1.get(i)).compareTo(values2.get(i));
+    if ( result != 0 ) return result;
+  }
+  return 0;*/}
     }
   ]
 });

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -696,6 +696,46 @@ return 0;
 
 
 foam.CLASS({
+  package: 'foam.core',
+  name: 'ArrayList',
+  extends: 'foam.core.Array',
+
+  properties: [
+    ['javaType', 'ArrayList'],
+    ['javaInfoType', 'foam.core.AbstractPropertyInfo'],
+    ['javaJSONParser', 'foam.lib.json.ArrayParser']
+  ],
+
+  methods: [
+    function createJavaPropertyInfo_(cls) {
+      var info = this.SUPER(cls);
+      var compare = info.getMethod('compare');
+      compare.body = this.compareTemplate();
+      return info;
+    }
+  ],
+
+  templates: [
+    {
+      name: 'compareTemplate',
+      template: function() {/*
+  <%= this.javaType %> values1 = get_(o1);
+  <%= this.javaType %> values2 = get_(o2);
+        if ( values1.size() > values2.size() ) return 1;
+        if ( values1.size() < values2.size() ) return -1;
+
+        int result;
+        for ( int i = 0 ; i < values1.size() ; i++ ) {
+          result = ((Comparable)values1.get(i)).compareTo(values2.get(i));
+          if ( result != 0 ) return result;
+        }
+        return 0;*/}
+    }
+  ]
+});
+
+
+foam.CLASS({
   refines: 'foam.core.Boolean',
   properties: [
     ['javaType', 'boolean'],


### PR DESCRIPTION
## Java Array Lists
- Added custom comparison template for Java Array Lists to refinements.js


## Fixed spacing issues to improve consistency and readability for comparison templates

### Before:
```java
      public int compare(Object o1, Object o2) {
        
          java.util.ArrayList values1 = get_(o1);
          java.util.ArrayList values2 = get_(o2);
                if ( values1.size() > values2.size() ) return 1;
                if ( values1.size() < values2.size() ) return -1;
        
                int result;
                for ( int i = 0 ; i < values1.size() ; i++ ) {
                  result = ((Comparable)values1.get(i)).compareTo(values2.get(i));
                  if ( result != 0 ) return result;
                }
                return 0;
      }
```

### After:
```java
      public int compare(Object o1, Object o2) {
        
          java.util.ArrayList values1 = get_(o1);
          java.util.ArrayList values2 = get_(o2);
        
          if ( values1.size() > values2.size() ) return 1;
          if ( values1.size() < values2.size() ) return -1;
        
          int result;
          for ( int i = 0 ; i < values1.size() ; i++ ) {
            result = ((Comparable)values1.get(i)).compareTo(values2.get(i));
            if ( result != 0 ) return result;
          }
          return 0;
      }
```