### PR TITLE
Extends interfaces

### DIFF
--- a/src/foam/core/Context.js
+++ b/src/foam/core/Context.js
@@ -43,8 +43,22 @@
      * @param opt_suppress Suppress throwing an error.
      **/
     lookup: function(id, opt_suppress) {
-      var ret = typeof id === 'string' && this.__cache__[id];
-
+      // If it's an interface extending other interfaces, it won't
+      // be string, it'll an array of strings
+      var ret;
+      if ( typeof id === 'string' && this.__cache__[id] ) {
+        ret = this.__cache__[id];
+      }
+      else if ( id && id.length > 0 ) {
+        for ( i = 0 ; i < id.length ; i++ ) {
+          if( typeof id[i] === 'string' && this.__cache__[id[i]] ) {
+            ret = this.__cache__[id[i]];
+          } else {
+            ret = false;
+            break;
+          }
+        }
+      }
       if ( ! opt_suppress ) {
         foam.assert(
             ret,

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -347,9 +347,10 @@ foam.CLASS({
         cls.buildJavaClass =  function(cls) {
           cls = cls || foam.java.Interface.create();
 
-          cls.name = this.name;
-          cls.package = this.package;
-          cls.extends = this.extends;
+          cls.name = this.model_.name;
+          cls.package = this.model_.package;
+          cls.extends = this.model_.extends ===  'foam.core.AbstractInterface' ?
+                        this.extends : this.model_.extends;
 
           var axioms = this.getAxioms();
 
@@ -627,7 +628,7 @@ foam.CLASS({
       template: function() {/*
   <%= this.javaType %> values1 = get_(o1);
   <%= this.javaType %> values2 = get_(o2);
-  
+
   if ( values1.length > values2.length ) return 1;
   if ( values1.length < values2.length ) return -1;
 

--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -54,18 +54,27 @@ foam.CLASS({
   ]
 });
 
-
 foam.INTERFACE({
   package: 'foam.mlang',
-  name: 'Expr',
+  name: 'F',
 
-  documentation: 'Expression interface: f(obj) -> val.',
+  documentation: 'Function for Expression interface: f(obj) -> val.',
 
   methods: [
     {
       name: 'f',
       args: [ 'obj' ]
-    },
+    }
+  ]
+});
+
+foam.INTERFACE({
+  package: 'foam.mlang',
+  name: 'Expr',
+  extends: ['foam.mlang.F'],
+  documentation: 'Expression interface: extends Function and executes partialEval.',
+
+  methods: [
     {
       name: 'partialEval'
     }

--- a/src/foam/mlang/mlangJava.js
+++ b/src/foam/mlang/mlangJava.js
@@ -16,7 +16,7 @@
  */
 
 foam.INTERFACE({
-  refines: 'foam.mlang.Expr',
+  refines: 'foam.mlang.F',
 
   methods: [
     {
@@ -28,7 +28,14 @@ foam.INTERFACE({
         }
       ],
       javaReturns: 'Object'
-    },
+    }
+  ]
+});
+
+foam.INTERFACE({
+  refines: 'foam.mlang.Expr',
+
+  methods: [
     {
       name: 'partialEval',
       javaReturns: 'foam.mlang.Expr'
@@ -46,7 +53,6 @@ foam.CLASS({
   ]
 });
 
-debugger;
 foam.INTERFACE({
   refines: 'foam.mlang.predicate.Predicate',
 

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -16,6 +16,7 @@ var classes = [
   'foam.mlang.predicate.Gte',
   'foam.mlang.predicate.Lt',
   'foam.mlang.predicate.Lte',
+  'foam.mlang.F',
   'foam.mlang.Expr',
   'foam.mlang.AbstractExpr',
   'foam.mlang.predicate.Eq',


### PR DESCRIPTION
I was creating an interface to be extended by another interface and noticed it didn't really extended it, it was just getting its methods. 
So I first change the `refinements.js` to stop ignoring the `model_.extends` and some other properties. 
Also changed the `Context.js` because the `lookout` method was considering only `string` types, but, for example the `extends` property of an interface is an array of string, so now we are checking whether it's an array or a string.