### PR TITLE
Fixed argument merging behaviour for abstract methods

### DIFF
--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -239,7 +239,7 @@ foam.CLASS({
       // Special merging behaviour for args.
       var argCount = Math.max(this.args.length, child.args.length)
       for ( var i = 0 ; i < argCount ; i++ ) {
-        result.args[i] = this.args[i].clone().copyFrom(child.args[i]);
+        result.args[i] = (this.args.length <= i) ? child.args[i] : this.args[i].clone().copyFrom(child.args[i]);
       }
 
       return result;

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -237,9 +237,8 @@ foam.CLASS({
       }
 
       // Special merging behaviour for args.
-      var argCount = Math.max(this.args.length, child.args.length)
-      for ( var i = 0 ; i < argCount ; i++ ) {
-        result.args[i] = (this.args.length <= i) ? child.args[i] : this.args[i].clone().copyFrom(child.args[i]);
+      for (var i = child.args.length ; i < this.args.length ; i++ ) {
+        result.args[i] = this.args[i].clone().copyFrom(child.args[i]);
       }
 
       return result;

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -237,9 +237,9 @@ foam.CLASS({
       }
 
       // Special merging behaviour for args.
-      for (var i = child.args.length ; i < this.args.length ; i++ ) {
-        result.args[i] = this.args[i].clone().copyFrom(child.args[i]);
-      }
+      var i = 0;
+      for ( ; i < this.args.length ; i++ ) result.args[i] = this.args[i].clone().copyFrom(child.args[i]);
+      for ( ; i < child.args.length ; i++ ) result.args[i] = child.args[i];
 
       return result;
     },


### PR DESCRIPTION
- Previously argCount logic could cause access to index out of range in `this.args`

## Previous Error
```
foam2/src/foam/java/refinements.js:242
        result.args[i] = this.args[i].clone().copyFrom(child.args[i]);
                                     ^

TypeError: Cannot read property 'clone' of undefined
    at Object.createChildMethod_ 
```

## Error Replication
Got the above error when I tried overriding the default object equality method (`equals`).