### PR TITLE
Added Java import support for generated interfaces

### DIFF
--- a/src/foam/java/Interface.js
+++ b/src/foam/java/Interface.js
@@ -42,6 +42,10 @@ foam.CLASS({
       of: 'foam.java.InterfaceMethod',
       name: 'methods',
       factory: function() { return []; }
+    },
+    {
+      name: 'imports',
+      factory: function() { return []; }
     }
   ],
 
@@ -68,6 +72,12 @@ foam.CLASS({
       o.out('// WARNING: GENERATED CODE, DO NOT MODIFY BY HAND!\n');
 
       if ( this.package ) { o.out('package ', this.package, ';\n\n'); }
+
+      this.imports.forEach(function(i) {
+        o.out('import ' + i, ';\n');
+      });
+      
+      o.out('\n');
 
       o.out(this.visibility, this.visibility ? ' ' : '',
         'interface ', this.name);


### PR DESCRIPTION
- Support for `javaImports` in Interface. (Already available with classes). 

Implementation based on [Class.js](https://github.com/foam-framework/foam2/blob/master/src/foam/java/Class.js).
