### PR TITLE
ListSink update JSON class output to match ArraySink a -> array API c…

### DIFF
--- a/java_src/foam/dao/ListSink.java
+++ b/java_src/foam/dao/ListSink.java
@@ -18,7 +18,7 @@ public class ListSink
 
   public void outputJSON(StringBuilder out, foam.lib.json.Outputter outputter) {
     Object[] data = getData().toArray();
-    out.append("{\"class\":\"foam.dao.ArraySink\",\"a\":");
+    out.append("{\"class\":\"foam.dao.ArraySink\",\"array\":");
     outputter.output(out, data);
     out.append("}");
   }


### PR DESCRIPTION
…hange

Without this change, ClientDAO responses are never written to the calling DAO. 
This affects HTTPBox requests to GAE Datastore.