### PR TITLE
Added SequenceNumberDAO implementation in Java

### DIFF
--- a/java_src/foam/dao/SequenceNumberDAO.java
+++ b/java_src/foam/dao/SequenceNumberDAO.java
@@ -1,0 +1,62 @@
+package foam.dao;
+
+import foam.core.ClassInfo;
+import foam.core.FObject;
+import foam.core.PropertyInfo;
+import foam.mlang.sink.Max;
+
+public class SequenceNumberDAO
+  extends ProxyDAO
+{
+  protected String property = "id";
+  protected int value = 1;
+  private PropertyInfo property_ = null;
+  
+  public AbstractDAO setOf(ClassInfo of) {
+    AbstractDAO ret = super.setOf(of);
+    this.property_ = null;
+    return ret;
+  }
+  
+  public SequenceNumberDAO setProperty(String property) {
+    this.property = property;
+    this.property_ = null;
+    return this;
+  }
+  
+  public SequenceNumberDAO setValue(int value) {
+    this.value = value;
+    return this;
+  }
+  
+  private PropertyInfo getProperty_() {
+    if (property_ != null) {
+      return property_;
+    }
+    
+    property_ = (PropertyInfo) this.of_.getAxiomByName(property);
+    return property_;
+  }
+  
+  /**
+   * Calculates the next largest value in the sequence
+   */
+  private void calcDelegateMax_() {
+    Max maxSink = (Max) new Max().setArg1(getProperty_());
+    ((AbstractDAO) getDelegate()).select(maxSink);
+    int maxValue = (int) maxSink.getValue();
+    if (maxValue < 1) return;
+    this.setValue(maxValue + 1);
+  }
+  
+  public FObject put(FObject obj) {
+    calcDelegateMax_();
+    int val = (int) getProperty_().f(obj);
+    if (val < 1) {
+      getProperty_().set(obj, this.value++);
+    } else if (val >= this.value ) {
+      this.value = (int) val + 1;
+    }
+    return getDelegate().put(obj);
+  }
+}

--- a/java_src/foam/dao/SequenceNumberDAO.java
+++ b/java_src/foam/dao/SequenceNumberDAO.java
@@ -30,11 +30,10 @@ public class SequenceNumberDAO
   }
   
   private PropertyInfo getProperty_() {
-    if (property_ != null) {
-      return property_;
+    if (property_ == null) {
+      property_ = (PropertyInfo) this.of_.getAxiomByName(property);
     }
     
-    property_ = (PropertyInfo) this.of_.getAxiomByName(property);
     return property_;
   }
   


### PR DESCRIPTION
Implementation assumes that the property being used as the sequence is an integer. (although may be better to use long instead).