### PR TITLE
Updated calls to new Buffer with either Buffer.alloc or Buffer.from

### DIFF
--- a/src/com/google/net/node/Google2LOAuthAgent.js
+++ b/src/com/google/net/node/Google2LOAuthAgent.js
@@ -130,7 +130,7 @@ foam.CLASS({
           "opt_enc" encoding. Default encoding is UTF-8.`,
       code: function(str, opt_enc) {
         return this.stripBase64ForURL(
-            new Buffer(str, opt_enc || 'utf8').toString('base64'));
+            Buffer.from(str, opt_enc || 'utf8').toString('base64'));
       }
     },
     {

--- a/src/foam/blob/Blob.js
+++ b/src/foam/blob/Blob.js
@@ -53,7 +53,7 @@ foam.CLASS({
       var self = this;
 
       var offset = 0;
-      var buf = new Buffer(8192 * 4);
+      var buf = Buffer.alloc(8192 * 4);
       var limit = self.size;
 
       function a() {
@@ -65,7 +65,7 @@ foam.CLASS({
 
         return self.read(buf, offset).then(function(buf2) {
           offset += buf2.length;
-          return writeFn(new Buffer(buf2));
+          return writeFn(Buffer.from(buf2));
         }).then(a);
       };
 
@@ -357,7 +357,7 @@ foam.CLASS({
       var hash = require('crypto').createHash('sha256');
 
       var bufsize = 8192;
-      var buffer = new Buffer(bufsize);
+      var buffer = Buffer.alloc(bufsize);
 
       var size = obj.size
       var remaining = size;

--- a/src/foam/blob/Blob_node.js
+++ b/src/foam/blob/Blob_node.js
@@ -22,7 +22,7 @@ foam.CLASS({
     {
       name: 'buffer',
       factory: function() {
-        return new Buffer(this.length);
+        return Buffer.alloc(this.length);
       }
     }
   ],

--- a/src/foam/dao/JournaledDAO.js
+++ b/src/foam/dao/JournaledDAO.js
@@ -49,12 +49,12 @@ if ( foam.isServer ) {
     methods: [
       function put(obj) {
         this.write_(
-          new Buffer("put(foam.json.parse(" +
+          Buffer.from("put(foam.json.parse(" +
                      foam.json.Storage.stringify(obj) + "));\n"));
       },
       function remove(obj) {
         this.write_(
-          new Buffer("remove(foam.json.parse(" +
+          Buffer.from("remove(foam.json.parse(" +
                      foam.json.Storage.stringify(obj) + "));\n"));
       },
       function write_(data) {

--- a/src/lib/node/net.js
+++ b/src/lib/node/net.js
@@ -58,7 +58,7 @@ foam.CLASS({
           (this.buffer.length > 125 ? 4 : 2);
 
       var i = 0;
-      var buffer = new Buffer(this.buffer.length + headerSize);
+      var buffer = Buffer.alloc(this.buffer.length + headerSize);
       // FIN = 1, RSV1-3 = 0
       buffer.writeUInt8(
         0x80 +
@@ -167,7 +167,7 @@ foam.CLASS({
 
     function maskingKey0(byte) {
       this.length = this.length_
-      this.buffer = new Buffer(this.length);
+      this.buffer = Buffer.alloc(this.length);
       this.bufferPos = 0;
       this.needed = this.length;
 
@@ -300,7 +300,7 @@ foam.CLASS({
     function write(msg) {
       var serialized = foam.json.Network.stringify(msg);
       var size = Buffer.byteLength(serialized);
-      var packet = new Buffer(size + 4);
+      var packet = Buffer.alloc(size + 4);
       packet.writeInt32LE(size);
       packet.write(serialized, 4);
       this.socket_.write(packet);
@@ -350,7 +350,7 @@ foam.CLASS({
         while ( start != data.length ) {
           if ( this.nextSize == 0 ) {
             this.nextSize = data.readInt32LE(start);
-            this.buffer = new Buffer(this.nextSize);
+            this.buffer = Buffer.alloc(this.nextSize);
             this.offset = 0;
             remaining = this.nextSize - this.offset;
             start += 4;
@@ -510,7 +510,7 @@ foam.CLASS({
 
       if ( typeof data == "string" ) {
         var opcode = 1;
-        data = new Buffer(data);
+        data = Buffer.from(data);
       } else {
         opcode = 2;
       }
@@ -721,7 +721,7 @@ foam.CLASS({
       if ( this.payload && this.Blob.isInstance(this.payload) ) {
         this.headers['Content-Length'] = this.payload.size;
       } else if ( this.payload ) {
-        buf = new Buffer(this.payload, 'utf8');
+        buf = Buffer.from(this.payload, 'utf8');
         if ( ! this.headers['Content-Length'] ) {
           this.headers['Content-Length'] = buf.length;
         }

--- a/test/node/lib/utf8.js
+++ b/test/node/lib/utf8.js
@@ -20,7 +20,7 @@ describe('UTF-8 decoder', function() {
     var decoder = foam.encodings.UTF8.create();
     var string = "Hello world! 23048alsdf alskl234";
 
-    var buffer = new Buffer(string, 'utf8');
+    var buffer = Buffer.from(string, 'utf8');
     decoder.put(new Uint8Array(buffer));
 
     expect(decoder.string).toBe(string);


### PR DESCRIPTION
`new Buffer` has been deprecated since Node 6 so I have replaced all the calls with either `Buffer.alloc` or `Buffer.from` where appropriate.