### PR TITLE
Enum default values and ChoiceView fix

### DIFF
--- a/src/foam/core/Enum.js
+++ b/src/foam/core/Enum.js
@@ -292,7 +292,6 @@ foam.CLASS({
 });
 
 
-// TODO(adamvy): Support default values.
 foam.CLASS({
   package: 'foam.core',
   name: 'Enum',
@@ -305,6 +304,12 @@ foam.CLASS({
       class: 'Class',
       name: 'of',
       required: true
+    },
+    {
+      name: 'value',
+      expression: function(of) {
+        return of && of.VALUES[0];
+      },
     },
     [
       'adapt',

--- a/src/foam/core/Enum.js
+++ b/src/foam/core/Enum.js
@@ -307,6 +307,10 @@ foam.CLASS({
     },
     {
       name: 'value',
+      adapt: function(_, n) {
+        if ( foam.String.isInstance(n) ) n = this.of[n];
+        return n
+      },
       expression: function(of) {
         return of && of.VALUES[0];
       },

--- a/src/foam/u2/EnumView.js
+++ b/src/foam/u2/EnumView.js
@@ -17,8 +17,8 @@ foam.CLASS({
     },
     {
       name: 'choices',
-      factory: function() {
-        return this.of.VALUES.map(function(v) { return [ v, v.label ]; });
+      expression: function(of) {
+        return of ? of.VALUES.map(function(v) { return [ v, v.label ]; }) : [];
       }
     }
   ],

--- a/src/foam/u2/view/ChoiceView.js
+++ b/src/foam/u2/view/ChoiceView.js
@@ -90,12 +90,6 @@ foam.CLASS({
 
         return nu;
       },
-      postSet: function() {
-        var d = this.data;
-        if ( this.choices.length ) {
-          this.choice = ( d && this.findChoiceByData(d) ) || this.defaultValue;
-        }
-      }
     },
     {
       class: 'Int',
@@ -160,6 +154,9 @@ foam.CLASS({
   ],
 
   methods: [
+    function init() {
+      this.onDetach(this.choices$.sub(this.onChoicesUpdate));
+    },
     function initE() {
       // If no item is selected, and data has not been provided, select the 0th
       // entry.
@@ -219,6 +216,16 @@ foam.CLASS({
   ],
 
   listeners: [
+    {
+      name: 'onChoicesUpdate',
+      isFramed: true,
+      code: function() {
+        var d = this.data;
+        if ( this.choices.length ) {
+          this.choice = ( d && this.findChoiceByData(d) ) || this.defaultValue;
+        }
+      }
+    },
     {
       name: 'onDAOUpdate',
       isFramed: true,


### PR DESCRIPTION
Allow an enum property to have a default value that's a string of the value you want.
E.g.
{
  name: 'myProp',
  class: 'Enum',
  of: 'MyEnum',
  value: 'SOME_ENUM_VALUE',
}
will give myProp a default value of MyEnum.SOME_ENUM_VALUE

Also a fix for ChoiceView to handle choices changing via an expression properly.