### PR TITLE
Adding unescapeString function to HTML lib

### DIFF
--- a/src/foam/parsers/html/lib.js
+++ b/src/foam/parsers/html/lib.js
@@ -515,6 +515,19 @@
       },
       function isSelfClosing(nodeName) {
         return selfClosingNodeNames[nodeName];
+      },
+      function unescapeString(str) {
+        if ( ! foam.String.isInstance(str) ) return '';
+        var escapeKeys = Object.keys(escapes).map(function(key) {
+          return `&${key};`
+        });
+
+        var exp = RegExp(`(?=(${escapeKeys.join('|')}))\\1`, 'g');
+        return str.replace(exp, function(m) {
+          // m is in the form of &id; We drop first and last character.
+          var id = m.slice(1, -1);
+          return escapes[id];
+        });
       }
     ]
   });

--- a/src/foam/parsers/html/lib.js
+++ b/src/foam/parsers/html/lib.js
@@ -519,7 +519,7 @@
       function unescapeString(str) {
         if ( ! foam.String.isInstance(str) ) return '';
         var escapeKeys = Object.keys(escapes).map(function(key) {
-          return `&${key};`
+          return `&${key};`;
         });
 
         var exp = RegExp(`(?=(${escapeKeys.join('|')}))\\1`, 'g');

--- a/src/foam/parsers/html/lib.js
+++ b/src/foam/parsers/html/lib.js
@@ -506,6 +506,12 @@
     'yen': '¥',
   };
 
+  var escapeKeys = Object.keys(escapes).map(function(key) {
+    return `&${key};`;
+  });
+
+  var escapeSequenceRegExp = RegExp(`(?=(${escapeKeys.join('|')}))\\1`, 'g');
+
   foam.LIB({
     name: 'foam.parsers.html',
 
@@ -518,12 +524,8 @@
       },
       function unescapeString(str) {
         if ( ! foam.String.isInstance(str) ) return '';
-        var escapeKeys = Object.keys(escapes).map(function(key) {
-          return `&${key};`;
-        });
 
-        var exp = RegExp(`(?=(${escapeKeys.join('|')}))\\1`, 'g');
-        return str.replace(exp, function(m) {
+        return str.replace(escapeSequenceRegExp, function(m) {
           // m is in the form of &id; We drop first and last character.
           var id = m.slice(1, -1);
           return escapes[id];

--- a/src/foam/parsers/html/lib.js
+++ b/src/foam/parsers/html/lib.js
@@ -506,10 +506,10 @@
     'yen': '¥',
   };
 
+  // FUTURE: Lazily instantiate RegExp to save memory.
   var escapeKeys = Object.keys(escapes).map(function(key) {
     return `&${key};`;
   });
-
   var escapeSequenceRegExp = RegExp(`(?=(${escapeKeys.join('|')}))\\1`, 'g');
 
   foam.LIB({

--- a/test/src/parsers/HTMLlib.js
+++ b/test/src/parsers/HTMLlib.js
@@ -2,17 +2,7 @@ describe('HTML Lib', function() {
   var lib;
 
   beforeAll(function() {
-    foam.CLASS({
-      package: 'foam.parsers.html',
-      name: 'HTTPLibTest',
-      properties: [
-        {
-          name: 'lib',
-          factory: function() { return foam.parsers.html; }
-        }
-      ]
-    });
-    lib = foam.parsers.html.HTTPLibTest.create().lib;
+    lib = foam.parsers.html;
   });
 
   it('getHTMLEscapeChar should return unescaped character', function() {

--- a/test/src/parsers/HTMLlib.js
+++ b/test/src/parsers/HTMLlib.js
@@ -1,0 +1,35 @@
+describe('HTML Lib', function() {
+  var lib;
+
+  beforeAll(function() {
+    foam.CLASS({
+      package: 'foam.parsers.html',
+      name: 'HTTPLibTest',
+      properties: [
+        {
+          name: 'lib',
+          factory: function() { return foam.parsers.html; }
+        }
+      ]
+    });
+    lib = foam.parsers.html.HTTPLibTest.create().lib;
+  });
+
+  it('getHTMLEscapeChar should return unescaped character', function() {
+    expect(lib.getHtmlEscapeChar('lt')).toBe('<');
+    expect(lib.getHtmlEscapeChar('szlig')).toBe('ß');
+    expect(lib.getHtmlEscapeChar('micro')).toBe('µ');
+  });
+
+  it('unescapeString should return string with unescaped HTML entities', function() {
+    expect(lib.unescapeString('if (x &lt; 3) return true;')).toBe('if (x < 3) return true;');
+    expect(lib.unescapeString('std::vector<code> Foo;')).toBe('std::vector<code> Foo;');
+    expect(lib.unescapeString('std::vector&lt;code&gt; Foo;')).toBe('std::vector<code> Foo;');
+  });
+
+  it('unescapeString should not replace invalid HTML entities', function() {
+    expect(lib.unescapeString('&Potato; Foo;')).toBe('&Potato; Foo;');
+    expect(lib.unescapeString('&lt')).toBe('&lt');
+    expect(lib.unescapeString('lt;')).toBe('lt;');
+  });
+});


### PR DESCRIPTION
HTMLLexer no longer automatically escape text. This added function allows the user to unescape strings they wished to unescape.