### PR TITLE
Forced refresh on HTTP 401

### DIFF
--- a/src/com/google/net/node/Google2LOAuthAgent.js
+++ b/src/com/google/net/node/Google2LOAuthAgent.js
@@ -112,6 +112,9 @@ foam.CLASS({
         this.onGetCredential,
         this.onNoCredential);
     },
+    function refreshCredential() {
+      return this.onNoCredential(new Error('Forced credential refresh'));
+    },
     {
       name: 'getIat',
       documentation: `Get "iat" for token request payload. This value should be

--- a/src/foam/net/auth/AuthAgent.js
+++ b/src/foam/net/auth/AuthAgent.js
@@ -26,7 +26,7 @@ foam.CLASS({
       (0) Export self as "authAgent" (already done in base class);
       (1) Register an auto-authenticating HTTPRequest as 'foam.net.HTTPRequest'
           in agents' sub-contexts;
-      (2) Implement getCredential().
+      (2) Implement getCredential() and refreshCredential().
 
       Clients instantiating agents must provide a requiresAuthorization(request)
       implementation; this allows authenticating HTTPRequests to determine
@@ -65,6 +65,13 @@ foam.CLASS({
       documentation: 'Aynchronously get an unexpired credential.',
       code: function() {
         return Promise.reject(new Error('Unable to get credential'));
+      }
+    },
+    {
+      name: 'refreshCredential',
+      documentation: 'Aynchronously get a new credential.',
+      code: function() {
+        return Promise.reject(new Error('Unable to refresh credential'));
       }
     }
   ]


### PR DESCRIPTION
AuthAgents implement refreshCredential(); AuthAwareHTTPRequests retry 401 with forced refresh.