### PR TITLE
Java @Override Flag Support

### DIFF
--- a/src/foam/java/InterfaceMethod.js
+++ b/src/foam/java/InterfaceMethod.js
@@ -35,6 +35,11 @@ foam.CLASS({
       name: 'args'
     },
     {
+      class: 'Boolean',
+      name: 'override',
+      value: false
+    },
+    {
       name: 'body',
       documentation: 'Dummy property to silence warnings',
       setter: function() {},
@@ -45,6 +50,11 @@ foam.CLASS({
 
   methods: [
     function outputJava(o) {
+      if (this.override) {
+        o.indent();
+        o.out("@Override\n");
+      }
+
       o.indent();
       o.out(this.visibility, this.visibility ? ' ' : '',
         this.type, ' ', this.name, '(');

--- a/src/foam/java/InterfaceMethod.js
+++ b/src/foam/java/InterfaceMethod.js
@@ -53,6 +53,7 @@ foam.CLASS({
       if (this.override) {
         o.indent();
         o.out("@Override\n");
+        o.indent();
       }
 
       o.indent();

--- a/src/foam/java/Method.js
+++ b/src/foam/java/Method.js
@@ -30,12 +30,22 @@ foam.CLASS({
       of: 'foam.java.Argument',
       name: 'args'
     },
+    {
+      class: 'Boolean',
+      name: 'override',
+      value: false
+    },
     { class: 'StringArray', name: 'throws' },
     { class: 'foam.java.CodeProperty', name: 'body' }
   ],
 
   methods: [
     function outputJava(o) {
+      if (this.override) {
+        o.indent();
+        o.out("@Override\n");
+      }
+
       o.indent();
       o.out(this.visibility, this.visibility ? ' ' : '',
         this.static ? 'static ' : '',

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -227,6 +227,11 @@ foam.CLASS({
       class: 'Boolean',
       name: 'javaSupport',
       value: true
+    },
+    {
+      class: 'Boolean',
+      name: 'override',
+      value: false
     }
   ],
 
@@ -258,6 +263,7 @@ foam.CLASS({
         name: this.name,
         type: this.javaReturns || 'void',
         visibility: 'public',
+        override: this.override,
         synchronized: this.synchronized,
         throws: this.javaThrows,
         args: this.args && this.args.map(function(a) {

--- a/src/foam/nanos/auth/Group.js
+++ b/src/foam/nanos/auth/Group.js
@@ -18,12 +18,12 @@ foam.CLASS({
     {
       class: 'String',
       name: 'id',
-      documenation: 'Unique name of the Group.'
+      documentation: 'Unique name of the Group.'
     },
     {
       class: 'String',
       name: 'description',
-      documenation: 'Description of the Group.'
+      documentation: 'Description of the Group.'
     },
     {
       class: 'String',

--- a/src/foam/nanos/auth/Permission.js
+++ b/src/foam/nanos/auth/Permission.js
@@ -18,7 +18,7 @@
      {
        class: 'String',
        name: 'description',
-       documenation: 'Description of the Group.'
+       documentation: 'Description of the Group.'
      }
    ]
  });


### PR DESCRIPTION
- Added support for `@Override` flag. Flag permits for better error handling.
> When overriding a method, you might want to use the `@Override` annotation that instructs the compiler that you intend to override a method in the superclass. If, for some reason, the compiler detects that the method does not exist in one of the superclasses, then it will generate an error. For more information on `@Override`, see Annotations.
> https://docs.oracle.com/javase/tutorial/java/IandI/override.html

- Fixed `documentation` typo in nanos