### PR TITLE
Fix for TreeIndex IN optimization

### DIFF
--- a/src/foam/dao/MDAO.js
+++ b/src/foam/dao/MDAO.js
@@ -257,7 +257,7 @@ foam.CLASS({
         );
       }
 
-      return this.MergePlan.create({ of: this.of, subPlans: plans });
+      return this.MergePlan.create({ of: this.of, subPlans: plans, predicates: args });
     },
 
     function toString() {

--- a/src/foam/dao/index/Plan.js
+++ b/src/foam/dao/index/Plan.js
@@ -168,6 +168,8 @@ foam.CLASS({
   ]
 });
 
+
+
 /**
   Merges results from multiple sub-plans and deduplicates, sorts, and
   filters the results.
@@ -190,9 +192,9 @@ foam.CLASS({
   properties: [
     {
       class: 'Class',
-      name: 'of',
-      required: true
-    }
+      name: 'of'
+    },
+    'predicates',
   ],
 
   methods: [
@@ -201,8 +203,8 @@ foam.CLASS({
       removes duplicates, sorts, skips, and limits.
     */
     function execute(promise, sink, skip, limit, order, predicate) {
-      if ( order ) return this.executeOrdered.apply(this, arguments);
-      return this.executeFallback.apply(this, arguments);
+      if ( order ) return this.executeOrdered(promise, sink, skip, limit, order, predicate);
+      return this.executeFallback(promise, sink, skip, limit, order, predicate);
     },
 
     function executeOrdered(promise, sink, skip, limit, order, predicate) {
@@ -211,6 +213,8 @@ foam.CLASS({
        * results from the subPlans are also sorted, and can be merged
        * efficiently.
        */
+      foam.assert(order && order.compare, "Order.compare() must be supplied in MergePlan.executeOrdered()");
+      foam.assert(( ! this.predicates ) || ( this.predicates.size == this.subPlans.size ), "MergePlan.predicates, when specified, must match the number of subplans." );
 
       // quick linked list
       var NodeProto = { next: null, data: null };
@@ -219,13 +223,11 @@ foam.CLASS({
       // TODO: track list size, cut off if above skip+limit
 
       var sp = this.subPlans;
-      var predicates = predicate ? predicate.args : [];
+      var predicates = this.predicates;
       var subLimit = ( limit ? limit + ( skip ? skip : 0 ) : undefined );
       var promises = []; // track any async subplans
-      var dedupCompare = this.of.ID.compare.bind(this.of.ID);
-      // TODO: FIX In the case of no external ordering, a sort must be imposed
-      //   (fall back to old dedupe sink impl?)
-      var compare = order ? order.compare.bind(order) : foam.util.compare;
+      var dedupCompare = ( this.of ) ? this.of.ID.compare.bind(this.of.ID) : foam.util.compare;
+      var compare = order.compare.bind(order);
 
       // Each plan inserts into the list
       for ( var i = 0 ; i < sp.length ; ++i) {
@@ -239,7 +241,6 @@ foam.CLASS({
           //   and leave the insertion point where it is, so the next
           //   item can check if it is equal to the just-inserted item.
           var insertAfter = head;
-          // TODO: refactor with insertAfter as a property of a new class?
           insertPlanSink = foam.dao.QuickSink.create({
             putFn: function(o) {
               function insert() {
@@ -294,7 +295,7 @@ foam.CLASS({
           undefined,
           subLimit,
           order,
-          predicates[i]
+          predicates ? predicates[i] : predicate // array mode (one per subplan) or repeated use of single predicate
         );
         if ( nuPromiseRef[0] ) promises.push(nuPromiseRef[0]);
       }
@@ -341,8 +342,10 @@ foam.CLASS({
          delegate: this.decorateSink_(sink, skip, limit)
        });
 
+       foam.assert(( ! this.predicates ) || ( this.predicates.size == this.subPlans.size ), "MergePlan.predicates, when specified, must match the number of subplans." );
+
        var sp = this.subPlans;
-       var predicates = predicate ? predicate.args : [];
+       var predicates = this.predicates;
        var subLimit = ( limit ? limit + ( skip ? skip : 0 ) : undefined );
 
        for ( var i = 0 ; i < sp.length ; ++i) {
@@ -352,7 +355,7 @@ foam.CLASS({
            undefined,
            subLimit,
            order,
-           predicates[i]
+           predicates ? predicates[i] : predicate // array mode (one per subplan) or repeated use of single predicate
          );
        }
        // Since this execute doesn't collect results into a temporary

--- a/src/foam/dao/index/TreeIndex.js
+++ b/src/foam/dao/index/TreeIndex.js
@@ -87,7 +87,7 @@ foam.CLASS({
     'foam.core.Property',
     'foam.dao.ArraySink',
     'foam.mlang.sink.NullSink',
-    'foam.dao.index.AltPlan',
+    'foam.dao.index.MergePlan',
     'foam.dao.index.CountPlan',
     'foam.dao.index.CustomPlan',
     'foam.dao.index.NotFoundPlan',
@@ -421,8 +421,7 @@ foam.CLASS({
 
           if ( subPlans.length === 0 ) return m.NotFoundPlan.create();
 
-          // TODO: If ordering, AltPlan may need to sort like MergePlan.
-          return m.AltPlan.create({
+          return m.MergePlan.create({
             subPlans: subPlans,
             prop: prop
           });
@@ -439,11 +438,7 @@ foam.CLASS({
 
         subPlan = result.plan(sink, skip, limit, order, predicate, root);
 
-        // TODO: If ordering, AltPlan may need to sort like MergePlan.
-        return m.AltPlan.create({
-          subPlans: [subPlan],
-          prop: prop
-        });
+        return subPlan;
       }
 
       var ic = false;
@@ -480,8 +475,7 @@ foam.CLASS({
           subPlans.push(indexes[i].plan(sink, skip, limit, order, predicate, root));
         }
 
-        // TODO: If ordering, AltPlan may need to sort like MergePlan.
-        return m.AltPlan.create({
+        return m.MergePlan.create({
           subPlans: subPlans,
           prop: prop
         });

--- a/test/src/lib/Index.js
+++ b/test/src/lib/Index.js
@@ -324,7 +324,6 @@ describe('TreeIndex', function() {
 
     // Note: this is checking an implementation detail
     // Each item in the In array produces a plan
-    expect(foam.dao.index.AltPlan.isInstance(plan)).toEqual(true);
     expect(plan.subPlans.length).toEqual(3);
 
     plan.execute([], sink);
@@ -343,7 +342,6 @@ describe('TreeIndex', function() {
 
     // Note: this is checking an implementation detail
     // Each item in the In array produces a plan
-    expect(foam.dao.index.AltPlan.isInstance(plan)).toEqual(true);
     expect(plan.subPlans.length).toEqual(3);
 
     plan.execute([], sink);
@@ -368,10 +366,6 @@ describe('TreeIndex', function() {
   it('optimizes EQ', function() {
     plan = idx.plan(sink, undefined, undefined, undefined,
       m.EQ(test.Indexable.INT, 4));
-
-    // Note: this is checking an implementation detail
-    expect(foam.dao.index.AltPlan.isInstance(plan)).toEqual(true);
-    expect(plan.subPlans.length).toEqual(1);
 
     plan.execute([], sink);
 
@@ -735,6 +729,7 @@ describe('Plan', function() {
     foam.dao.index.CustomPlan.create().toString();
     foam.dao.index.CountPlan.create().toString();
     foam.dao.index.AltPlan.create().toString();
+    foam.dao.index.MergePlan.create().toString();
   });
 });
 
@@ -1048,7 +1043,7 @@ describe('MergePlan', function() {
       ids: ['a'],
       properties: [
         { name: 'a' },
-        { name: 'b' }
+        { name: 'b', class:'Date' }
       ]
     });
 
@@ -1102,8 +1097,8 @@ describe('MergePlan', function() {
 
     plan.execute([], sink, undefined, undefined, ordering);
     expect(sink.array.length).toBe(10);
-    expect(sink.array[0].b).toBe(1); // should be ordered by 'b'
-    expect(sink.array[9].b).toBe(10);
+    expect(sink.array[0].b).toEqual(new Date(1)); // should be ordered by 'b'
+    expect(sink.array[9].b).toEqual(new Date(10));
   });
 
   it('deduplicates with ordering', function() {
@@ -1239,21 +1234,21 @@ describe('MergePlan', function() {
 
     expect(sink.array.length).toBe(15);
 
-    expect(sink.array[0].a).toBe(14); expect(sink.array[0].b).toBe(-4);
-    expect(sink.array[1].a).toBe(13); expect(sink.array[1].b).toBe(-3);
-    expect(sink.array[2].a).toBe(12); expect(sink.array[2].b).toBe(-2);
-    expect(sink.array[3].a).toBe(11); expect(sink.array[3].b).toBe(-1);
-    expect(sink.array[4].a).toBe(10); expect(sink.array[4].b).toBe(0);
-    expect(sink.array[5].a).toBe(9); expect(sink.array[5].b).toBe(1);
-    expect(sink.array[6].a).toBe(8); expect(sink.array[6].b).toBe(2);
-    expect(sink.array[7].a).toBe(7); expect(sink.array[7].b).toBe(3);
-    expect(sink.array[8].a).toBe(6); expect(sink.array[8].b).toBe(4);
-    expect(sink.array[9].a).toBe(5); expect(sink.array[9].b).toBe(5);
-    expect(sink.array[10].a).toBe(4); expect(sink.array[10].b).toBe(6);
-    expect(sink.array[11].a).toBe(3); expect(sink.array[11].b).toBe(7);
-    expect(sink.array[12].a).toBe(2); expect(sink.array[12].b).toBe(8);
-    expect(sink.array[13].a).toBe(1); expect(sink.array[13].b).toBe(9);
-    expect(sink.array[14].a).toBe(0); expect(sink.array[14].b).toBe(10);
+      expect(sink.array[0].a).toBe(14); expect(sink.array[0].b).toEqual(new Date(-4));
+    expect(sink.array[1].a).toBe(13); expect(sink.array[1].b).toEqual(new Date(-3));
+    expect(sink.array[2].a).toBe(12); expect(sink.array[2].b).toEqual(new Date(-2));
+    expect(sink.array[3].a).toBe(11); expect(sink.array[3].b).toEqual(new Date(-1));
+    expect(sink.array[4].a).toBe(10); expect(sink.array[4].b).toEqual(new Date(0));
+    expect(sink.array[5].a).toBe(9); expect(sink.array[5].b).toEqual(new Date(1));
+    expect(sink.array[6].a).toBe(8); expect(sink.array[6].b).toEqual(new Date(2));
+    expect(sink.array[7].a).toBe(7); expect(sink.array[7].b).toEqual(new Date(3));
+    expect(sink.array[8].a).toBe(6); expect(sink.array[8].b).toEqual(new Date(4));
+    expect(sink.array[9].a).toBe(5); expect(sink.array[9].b).toEqual(new Date(5));
+    expect(sink.array[10].a).toBe(4); expect(sink.array[10].b).toEqual(new Date(6));
+    expect(sink.array[11].a).toBe(3); expect(sink.array[11].b).toEqual(new Date(7));
+    expect(sink.array[12].a).toBe(2); expect(sink.array[12].b).toEqual(new Date(8));
+    expect(sink.array[13].a).toBe(1); expect(sink.array[13].b).toEqual(new Date(9));
+    expect(sink.array[14].a).toBe(0); expect(sink.array[14].b).toEqual(new Date(10));
 
 
   });
@@ -1283,21 +1278,21 @@ describe('MergePlan', function() {
 
     expect(sink.array.length).toBe(15);
 
-    expect(sink.array[0].a).toBe(14); expect(sink.array[0].b).toBe(-4);
-    expect(sink.array[1].a).toBe(13); expect(sink.array[1].b).toBe(-3);
-    expect(sink.array[2].a).toBe(12); expect(sink.array[2].b).toBe(-2);
-    expect(sink.array[3].a).toBe(11); expect(sink.array[3].b).toBe(-1);
-    expect(sink.array[4].a).toBe(10); expect(sink.array[4].b).toBe(0);
-    expect(sink.array[5].a).toBe(9); expect(sink.array[5].b).toBe(1);
-    expect(sink.array[6].a).toBe(8); expect(sink.array[6].b).toBe(2);
-    expect(sink.array[7].a).toBe(7); expect(sink.array[7].b).toBe(3);
-    expect(sink.array[8].a).toBe(6); expect(sink.array[8].b).toBe(4);
-    expect(sink.array[9].a).toBe(5); expect(sink.array[9].b).toBe(5);
-    expect(sink.array[10].a).toBe(4); expect(sink.array[10].b).toBe(6);
-    expect(sink.array[11].a).toBe(3); expect(sink.array[11].b).toBe(7);
-    expect(sink.array[12].a).toBe(2); expect(sink.array[12].b).toBe(8);
-    expect(sink.array[13].a).toBe(1); expect(sink.array[13].b).toBe(9);
-    expect(sink.array[14].a).toBe(0); expect(sink.array[14].b).toBe(10);
+    expect(sink.array[0].a).toBe(14); expect(sink.array[0].b).toEqual(new Date(-4));
+    expect(sink.array[1].a).toBe(13); expect(sink.array[1].b).toEqual(new Date(-3));
+    expect(sink.array[2].a).toBe(12); expect(sink.array[2].b).toEqual(new Date(-2));
+    expect(sink.array[3].a).toBe(11); expect(sink.array[3].b).toEqual(new Date(-1));
+    expect(sink.array[4].a).toBe(10); expect(sink.array[4].b).toEqual(new Date(0));
+    expect(sink.array[5].a).toBe(9); expect(sink.array[5].b).toEqual(new Date(1));
+    expect(sink.array[6].a).toBe(8); expect(sink.array[6].b).toEqual(new Date(2));
+    expect(sink.array[7].a).toBe(7); expect(sink.array[7].b).toEqual(new Date(3));
+    expect(sink.array[8].a).toBe(6); expect(sink.array[8].b).toEqual(new Date(4));
+    expect(sink.array[9].a).toBe(5); expect(sink.array[9].b).toEqual(new Date(5));
+    expect(sink.array[10].a).toBe(4); expect(sink.array[10].b).toEqual(new Date(6));
+    expect(sink.array[11].a).toBe(3); expect(sink.array[11].b).toEqual(new Date(7));
+    expect(sink.array[12].a).toBe(2); expect(sink.array[12].b).toEqual(new Date(8));
+    expect(sink.array[13].a).toBe(1); expect(sink.array[13].b).toEqual(new Date(9));
+    expect(sink.array[14].a).toBe(0); expect(sink.array[14].b).toEqual(new Date(10));
 
   });
 
@@ -1326,11 +1321,11 @@ describe('MergePlan', function() {
 
     expect(sink.array.length).toBe(5);
 
-    expect(sink.array[0].a).toBe(11); expect(sink.array[0].b).toBe(-1);
-    expect(sink.array[1].a).toBe(10); expect(sink.array[1].b).toBe(0);
-    expect(sink.array[2].a).toBe(9); expect(sink.array[2].b).toBe(1);
-    expect(sink.array[3].a).toBe(8); expect(sink.array[3].b).toBe(2);
-    expect(sink.array[4].a).toBe(7); expect(sink.array[4].b).toBe(3);
+    expect(sink.array[0].a).toBe(11); expect(sink.array[0].b).toEqual(new Date(-1));
+    expect(sink.array[1].a).toBe(10); expect(sink.array[1].b).toEqual(new Date(0));
+    expect(sink.array[2].a).toBe(9); expect(sink.array[2].b).toEqual(new Date(1));
+    expect(sink.array[3].a).toBe(8); expect(sink.array[3].b).toEqual(new Date(2));
+    expect(sink.array[4].a).toBe(7); expect(sink.array[4].b).toEqual(new Date(3));
 
   });
 
@@ -1411,14 +1406,14 @@ describe('MergePlan', function() {
 
     expect(sink.array.length).toBe(8);
 
-    expect(sink.array[0].a).toBe(0); expect(sink.array[0].b).toBe(0);
-    expect(sink.array[1].a).toBe(1); expect(sink.array[1].b).toBe(0);
-    expect(sink.array[2].a).toBe(2); expect(sink.array[2].b).toBe(0);
-    expect(sink.array[3].a).toBe(3); expect(sink.array[3].b).toBe(0);
-    expect(sink.array[4].a).toBe(4); expect(sink.array[4].b).toBe(1);
-    expect(sink.array[5].a).toBe(5); expect(sink.array[5].b).toBe(1);
-    expect(sink.array[6].a).toBe(6); expect(sink.array[6].b).toBe(1);
-    expect(sink.array[7].a).toBe(7); expect(sink.array[7].b).toBe(1);
+    expect(sink.array[0].a).toBe(0); expect(sink.array[0].b).toEqual(new Date(0));
+    expect(sink.array[1].a).toBe(1); expect(sink.array[1].b).toEqual(new Date(0));
+    expect(sink.array[2].a).toBe(2); expect(sink.array[2].b).toEqual(new Date(0));
+    expect(sink.array[3].a).toBe(3); expect(sink.array[3].b).toEqual(new Date(0));
+    expect(sink.array[4].a).toBe(4); expect(sink.array[4].b).toEqual(new Date(1));
+    expect(sink.array[5].a).toBe(5); expect(sink.array[5].b).toEqual(new Date(1));
+    expect(sink.array[6].a).toBe(6); expect(sink.array[6].b).toEqual(new Date(1));
+    expect(sink.array[7].a).toBe(7); expect(sink.array[7].b).toEqual(new Date(1));
 
   });
 


### PR DESCRIPTION
TreeIndex now uses a MergePlan to dedup and sort subplans from IN optimization. This also introduced a new mode for MergePlan, where it takes a single predicate and repeats it for each subplan.execute(). Previous MDAO.planForOr() usage supplies separate predicates for each subplan.

Fixes #435 