### PR TITLE
History View

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -183,6 +183,8 @@ FOAM_FILES([
   { name: "foam/u2/HTMLElement", flags: ['web'] },
   { name: "foam/u2/tag/Select", flags: ['web'] },
   { name: "foam/u2/Tabs", flags: ['web'] },
+  { name: "foam/u2/history/HistoryItemView", flags: ['web'] },
+  { name: "foam/u2/history/HistoryView", flags: ['web'] },
   { name: "foam/u2/view/ChoiceView", flags: ['web'] },
   { name: "foam/u2/view/RadioView", flags: ['web'] },
   { name: "foam/u2/view/TextField", flags: ['web'] },

--- a/src/foam/dao/history/HistoryRecord.js
+++ b/src/foam/dao/history/HistoryRecord.js
@@ -30,7 +30,7 @@ foam.CLASS({
     },
     {
       class: 'FObjectArray',
-      of: 'PropertyUpdate',
+      of: 'foam.dao.history.PropertyUpdate',
       name: 'updates'
     }
   ]

--- a/src/foam/u2/history/HistoryItemView.js
+++ b/src/foam/u2/history/HistoryItemView.js
@@ -1,0 +1,11 @@
+foam.INTERFACE({
+  package: 'foam.u2.history',
+  name: 'HistoryItemView',
+  extends: 'foam.u2.View',
+
+  documentation: 'View displaying history item',
+
+  methods: [
+    function outputItems(parentView, record) {}
+  ]
+});

--- a/src/foam/u2/history/HistoryView.js
+++ b/src/foam/u2/history/HistoryView.js
@@ -4,7 +4,7 @@ foam.CLASS({
   extends: 'foam.u2.View',
   requires: [ 'foam.u2.history.HistoryItemView' ],
 
-  documentation: 'View displaying invoice history',
+  documentation: 'View displaying history',
 
   axioms: [
     foam.u2.CSS.create({

--- a/src/foam/u2/history/HistoryView.js
+++ b/src/foam/u2/history/HistoryView.js
@@ -1,0 +1,73 @@
+foam.CLASS({
+  package: 'foam.u2.history',
+  name: 'HistoryView',
+  extends: 'foam.u2.View',
+  requires: [ 'foam.u2.history.HistoryItemView' ],
+
+  documentation: 'View displaying invoice history',
+
+  axioms: [
+    foam.u2.CSS.create({
+      code: `
+        ^{
+          width: 925px;
+          min-height: 200px;
+          background: white;
+          position: relative;
+          vertical-align: top;
+          margin-right: 6px;
+          border-radius: 3px;
+          overflow: hidden;
+          font-size: 12px;
+          padding-left: 20px;
+          margin-bottom: 20px;
+          z-index: 0;
+        }
+
+        /** 
+         * TODO: Dynamic height of vertical timeline bar 
+        */
+        ^verticalBar {
+          width: 2px;
+          height: 70%;
+          background-color: rgba(164, 179, 184, 0.3);
+          position: absolute;
+          left: 43px;
+          top: 90px;
+          z-index: -1;
+          margin-bottom: 20px;
+        }`
+    })
+  ],
+
+  properties: [
+    'data',
+    'historyItemView'
+  ],
+  
+  messages: [
+    { name: 'title', message: 'History' }
+  ],
+
+  methods: [
+    function initE() {
+      var view = this;
+
+      this
+        .addClass(this.myClass())
+        .start('h2').add(this.title).end()
+        .call(function outputItems() {
+          // Gets records from DAO
+          view.data.select().then(function(records) {
+            // Reverses records array for chronological output
+            view.forEach(records.array.reverse(), function(record) {
+              view.call(function() {
+                return this.historyItemView.outputItem(view, record)
+              })
+            })
+          })
+        })
+        .start('div').addClass(this.myClass('verticalBar')).end();
+    }
+  ]
+});


### PR DESCRIPTION
## Implementation Details
- `HistoryView` takes care of the general display of the timeline, title and bounding box.
- `HistoryItemView` provides an interface for the display of individual items (note this interface is not yet enforced by FOAM/TODO).
- `HistoryXYZItemView` implements HistoryItemView and takes care of outputting individual history XYZ records. 

## Demo
Add the following to an existing view. 
```js
.tag({ 
  class: 'foam.u2.history.HistoryView',
  data: INSERT_HISTORY_DAO_HERE,
  historyItemView: INSERT_HISTORY_ITEM_VIEW_IMPLEMENTATION_HERE.create()
})
```
