### PR TITLE
Add a hook to JSON stringify that makes it only output own properties.

### DIFF
--- a/src/foam/core/JSON.js
+++ b/src/foam/core/JSON.js
@@ -155,6 +155,11 @@ foam.CLASS({
     },
     {
       class: 'Boolean',
+      name: 'outputOwnPropertiesOnly',
+      value: true
+    },
+    {
+      class: 'Boolean',
       name: 'outputClassNames',
       value: true
     },
@@ -288,6 +293,7 @@ foam.CLASS({
     function outputProperty(o, p, includeComma) {
       if ( ! this.propertyPredicate(o, p ) ) return;
       if ( ! this.outputDefaultValues && p.isDefaultValue(o[p.name]) ) return;
+      if ( this.outputOwnPropertiesOnly && ! o.hasOwnProperty(p.name) ) return;
 
       var v = o[p.name];
 


### PR DESCRIPTION
I noticed stringify outputting values from expressions and that didn't seem right to me. How do you feel about this change? I could change the default value to preserve the current behaviour but the current behaviour feels wrong to me.