### PR TITLE
ENUM Property Getter Return Type Includes Class Name

### DIFF
--- a/src/foam/core/Enum.js
+++ b/src/foam/core/Enum.js
@@ -315,6 +315,12 @@ foam.CLASS({
         return of && of.VALUES[0];
       },
     },
+    {
+      name: 'javaValue',
+      expression: function(of) {
+        return this.of.package + '.' + this.of.name + '.' + (of && of.VALUES[0]);
+      },
+    },
     [
       'adapt',
       function(o, n, prop) {

--- a/src/foam/core/Enum.js
+++ b/src/foam/core/Enum.js
@@ -318,7 +318,9 @@ foam.CLASS({
     {
       name: 'javaValue',
       expression: function(of) {
-        return this.of.package + '.' + this.of.name + '.' + (of && of.VALUES[0]);
+        var val = (of && of.VALUES[0].name);
+        var prefix = this.of.package + '.' + this.of.name + '.';
+        return val.includes(prefix) ? val : prefix + val;
       },
     },
     [

--- a/src/foam/core/Enum.js
+++ b/src/foam/core/Enum.js
@@ -318,9 +318,9 @@ foam.CLASS({
     {
       name: 'javaValue',
       expression: function(of) {
-        var val = (of && of.VALUES[0].name);
+        var val = (of && of.VALUES[0]);
         var prefix = this.of.package + '.' + this.of.name + '.';
-        return val.includes(prefix) ? val : prefix + val;
+        return foam.String.isInstance(val) ? val : prefix + val;
       },
     },
     [

--- a/src/foam/core/Enum.js
+++ b/src/foam/core/Enum.js
@@ -319,8 +319,7 @@ foam.CLASS({
       name: 'javaValue',
       expression: function(of) {
         var val = (of && of.VALUES[0]);
-        var prefix = this.of.package + '.' + this.of.name + '.';
-        return foam.String.isInstance(val) ? val : prefix + val;
+        return foam.String.isInstance(val) ? val : this.of.id + '.' + val;
       },
     },
     [

--- a/src/foam/core/Enum.js
+++ b/src/foam/core/Enum.js
@@ -317,8 +317,8 @@ foam.CLASS({
     },
     {
       name: 'javaValue',
-      expression: function(of) {
-        return this.of.id + '.' + this.value;
+      expression: function(of, value) {
+        return of.id + '.' + value;
       },
     },
     [

--- a/src/foam/core/Enum.js
+++ b/src/foam/core/Enum.js
@@ -318,8 +318,7 @@ foam.CLASS({
     {
       name: 'javaValue',
       expression: function(of) {
-        var val = (of && of.VALUES[0]);
-        return foam.String.isInstance(val) ? val : this.of.id + '.' + val;
+        return this.of.id + '.' + this.value;
       },
     },
     [

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -88,8 +88,11 @@ foam.CLASS({
           type: this.javaType,
           visibility: 'public',
           body: 'if ( ! ' + isSet + ' ) {\n' +
-            ( this.hasOwnProperty('javaFactory') ? '  set' + capitalized + '(' + factoryName + '());\n' :
-                ' return ' + this.javaValue  + ';\n' ) +
+            ( this.hasOwnProperty('javaFactory') ? 
+                '  set' + capitalized + '(' + factoryName + '());\n' :
+                ' return ' + 
+                ( this.javaType == 'java.lang.Enum' ? this.of.name + '.' : '' )  +
+                this.javaValue  + ';\n' ) +
             '}\n' +
             'return ' + privateName + ';'
         }).

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -91,7 +91,9 @@ foam.CLASS({
             ( this.hasOwnProperty('javaFactory') ? 
                 '  set' + capitalized + '(' + factoryName + '());\n' :
                 ' return ' + 
-                ( this.javaType == 'java.lang.Enum' ? this.of.name + '.' : '' )  +
+                ( this.javaType == 'java.lang.Enum' ? 
+                    this.of.package + '.' + this.of.name + '.' : 
+                    '' )  +
                 this.javaValue  + ';\n' ) +
             '}\n' +
             'return ' + privateName + ';'

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -90,11 +90,7 @@ foam.CLASS({
           body: 'if ( ! ' + isSet + ' ) {\n' +
             ( this.hasOwnProperty('javaFactory') ? 
                 '  set' + capitalized + '(' + factoryName + '());\n' :
-                ' return ' + 
-                ( this.javaType == 'java.lang.Enum' ? 
-                    this.of.package + '.' + this.of.name + '.' : 
-                    '' )  +
-                this.javaValue  + ';\n' ) +
+                ' return ' + this.javaValue  + ';\n' ) +
             '}\n' +
             'return ' + privateName + ';'
         }).


### PR DESCRIPTION
Property getters for Enum types now include the class name when returning the default value. Resolves compilation errors. 

## Before
```java
public java.lang.Enum getAdrTp() {
  if ( ! AdrTpIsSet_ ) {
   return ADDR;
  }
  return AdrTp_;
}
```

## After
```java
public java.lang.Enum getAdrTp() {
  if ( ! AdrTpIsSet_ ) {
   return com.acme.AddressCode.ADDR;
  }
  return AdrTp_;
}
```
