### PR TITLE
Multi part id serialization

### DIFF
--- a/src/foam/core/IDSupport.js
+++ b/src/foam/core/IDSupport.js
@@ -74,6 +74,17 @@ foam.CLASS({
         }
         return 0;
       }
+    },
+    {
+      name: 'toJSON',
+      value: function toJSON(value, outputer) {
+        var ret = new Array(value.length);
+        var props = this.props;
+        for ( var i = 0; i < value.length; i++ ) {
+          ret[i] = props[i].toJSON(value[i], outputer);
+        }
+        return ret;
+      }
     }
   ],
 

--- a/src/foam/core/IDSupport.js
+++ b/src/foam/core/IDSupport.js
@@ -78,9 +78,12 @@ foam.CLASS({
     {
       name: 'toJSON',
       value: function toJSON(value, outputer) {
-        var ret = new Array(value.length);
         var props = this.props;
-        for ( var i = 0; i < value.length; i++ ) {
+
+        if ( props.length === 1 ) return value;
+
+        var ret = new Array(props.length);
+        for ( var i = 0; i < props.length; i++ ) {
           ret[i] = props[i].toJSON(value[i], outputer);
         }
         return ret;

--- a/src/foam/dao/IDBDAO.js
+++ b/src/foam/dao/IDBDAO.js
@@ -125,6 +125,9 @@ foam.CLASS({
     function serialize(obj) {
       return foam.json.Storage.objectify(obj);
     },
+    function serializeId(id) {
+      return this.of.ID.toJSON(id);
+    },
 
     function withStore(mode, fn) {
       return this.withStore_(mode, fn);
@@ -166,7 +169,8 @@ foam.CLASS({
       var self = this;
       return new Promise(function(resolve, reject) {
         self.withStore("readwrite", function(store) {
-          var request = store.put(self.serialize(value), value.id);
+          var request = store.put(self.serialize(value),
+                                  self.serializeId(value.id));
           request.transaction.addEventListener(
             'complete',
             function(e) {
@@ -182,8 +186,9 @@ foam.CLASS({
       });
     },
 
-    function find_(x, key) {
+    function find_(x, obj) {
       var self = this;
+      var key = this.serializeId(obj.id != undefined ? obj.id : obj);
 
       return new Promise(function(resolve, reject) {
         self.withStore("readwrite", function(store) {
@@ -207,7 +212,7 @@ foam.CLASS({
 
     function remove_(x, obj) {
       var self = this;
-      var key = obj.id != undefined ? obj.id : obj;
+      var key = this.serializeId(obj.id != undefined ? obj.id : obj);
       return new Promise(function(resolve, reject) {
         self.withStore("readwrite", function(store) {
           var getRequest = store.get(key);


### PR DESCRIPTION
IDBDAO fails to store objects with multi-part ids when those ids contain non-primitive (and/or nested array) values. This is a problem, in particular, for enum values that are modeled, but serialize to their ordinal value.

This patch implements `MultiPartID.toJSON` to delegate to "actual properties'" `toJSON` (which produces an ordinal in the case of enums). Then, `IDBDAO` is extended with `serializeId`, defaulting to invoke `this.of.ID.toJSON`.