### PR TITLE
DatastoreDAO breaking storage change: Store multi-part IDs and adapt binary predicates

### DIFF
--- a/src/com/google/cloud/datastore/DatastoreDAO.js
+++ b/src/com/google/cloud/datastore/DatastoreDAO.js
@@ -313,7 +313,7 @@ foam.CLASS({
         deletes[i] = { delete: arr[i].getDatastoreKey() };
       }
 
-      this.sendRequest('commit', {
+      return this.sendRequest('commit', {
         mode: 'TRANSACTIONAL',
         mutations: deletes,
         transaction: transaction

--- a/src/com/google/cloud/datastore/mlang.js
+++ b/src/com/google/cloud/datastore/mlang.js
@@ -33,7 +33,7 @@ foam.CLASS({
 
           [1] https://cloud.google.com/datastore/docs/reference/rest/v1/projects/runQuery#Projection`,
       code: function(query) {
-        query.projection = [ { property: { name: "__key__" } } ];
+        query.projection = [ { property: { name: '__key__' } } ];
       }
     },
     {
@@ -183,10 +183,17 @@ foam.CLASS({
       foam.assert(this.datastoreOpName,
           'Predicate has no datastore op name:', this.cls_.id);
 
+      var value = ( this.arg1.toDatastoreValue &&
+                    foam.mlang.Constant.isInstance(this.arg2) ) ?
+          // Allow property to override value constant serialization. This
+          // mirrors foam.mlang.predicate.Binary.adapt() delegating to
+          // arg1.adapt() in a similar fashion.
+          this.arg1.toDatastoreValue(this.arg2.value) :
+          com.google.cloud.datastore.toDatastoreValue(this.arg2);
       return {
         property: this.arg1.toDatastorePropertyReference(),
         op: this.datastoreOpName,
-        value: com.google.cloud.datastore.toDatastoreValue(this.arg2)
+        value:
       };
     },
 


### PR DESCRIPTION
MultiPartIDs are generally transient. However, storing these IDs as a property in Datastore allows IDs to be used as an order or predicate. In order to support MultiPartID in a predicate, additional changes to adapt predicate constants according to their corresponding property type (similar to Binary.adapt() implementation).

An alternative to this design would be to adapt incoming predicates to DatastoreDAO to convert `MLANG(Cls.ID, value)` to `AND(MLANG(Cls.FIRST_ID_PROP, valuePart1), ..., MLANG(Cls.LAST_ID_PROP, valuePartN))`. In fact, this might be the right thing to do universally, since `MultiPartID`'s storage transience should prevent it from being stored anywhere (hence mLangs that contain them need adaptation before being passed to a storage mechanism). If so, what's the best place to do this? Baking a special case into `predicate.Binary` for something so specific as `MultiPartID` feels wrong, but `partialEval() / f()` on `MultiPartID` is too low in the predicate tree to perform the transformation. @kgrgreer WDYT?