### PR TITLE
Comparator changes

### DIFF
--- a/src/foam/core/PropertyInfo.java
+++ b/src/foam/core/PropertyInfo.java
@@ -7,12 +7,13 @@
 package foam.core;
 
 import foam.lib.parse.Parser;
-import java.util.Comparator;
+import foam.mlang.order.Comparator;
+
 import java.util.Map;
 
 // ???: Why is this interface mutable?
 public interface PropertyInfo
-  extends foam.mlang.Expr, Comparator
+    extends foam.mlang.Expr, Comparator
 {
   public PropertyInfo setClassInfo(ClassInfo p);
   public ClassInfo getClassInfo();

--- a/src/foam/core/PropertyInfo.java
+++ b/src/foam/core/PropertyInfo.java
@@ -13,7 +13,7 @@ import java.util.Map;
 
 // ???: Why is this interface mutable?
 public interface PropertyInfo
-    extends foam.mlang.Expr, Comparator
+  extends foam.mlang.Expr, Comparator
 {
   public PropertyInfo setClassInfo(ClassInfo p);
   public ClassInfo getClassInfo();

--- a/src/foam/dao/index/AltIndex.java
+++ b/src/foam/dao/index/AltIndex.java
@@ -9,7 +9,7 @@ import foam.core.FObject;
 import foam.dao.Sink;
 import foam.mlang.predicate.Predicate;
 import java.util.ArrayList;
-import java.util.Comparator;
+import foam.mlang.order.Comparator;
 
 /** Note this class is not thread safe because ArrayList isn't thread-safe. Needs to be made safe by containment. **/
 public class AltIndex implements Index {

--- a/src/foam/dao/index/CountPlan.java
+++ b/src/foam/dao/index/CountPlan.java
@@ -8,7 +8,7 @@ package foam.dao.index;
 import foam.dao.Sink;
 import foam.mlang.predicate.Predicate;
 import foam.mlang.sink.Count;
-import java.util.Comparator;
+import foam.mlang.order.Comparator;
 
 public class CountPlan implements SelectPlan
 {

--- a/src/foam/dao/index/Index.java
+++ b/src/foam/dao/index/Index.java
@@ -9,10 +9,10 @@ package foam.dao.index;
 import foam.core.FObject;
 import foam.dao.Sink;
 import foam.mlang.predicate.Predicate;
-import java.util.Comparator;
+import foam.mlang.order.Comparator;
 
 public interface Index {
-  // Called when an Index is added 
+  // Called when an Index is added
   public void onAdd(Sink sink);
 
   public Object put(Object state, FObject value);

--- a/src/foam/dao/index/NoPlan.java
+++ b/src/foam/dao/index/NoPlan.java
@@ -8,7 +8,7 @@ package foam.dao.index;
 import foam.core.FObject;
 import foam.dao.Sink;
 import foam.mlang.predicate.Predicate;
-import java.util.Comparator;
+import foam.mlang.order.Comparator;
 
 /** Have-no-plan Plan. **/
 public class NoPlan implements FindPlan, SelectPlan

--- a/src/foam/dao/index/NotFoundPlan.java
+++ b/src/foam/dao/index/NotFoundPlan.java
@@ -8,7 +8,7 @@ package foam.dao.index;
 import foam.core.FObject;
 import foam.dao.Sink;
 import foam.mlang.predicate.Predicate;
-import java.util.Comparator;
+import foam.mlang.order.Comparator;
 
 /** Found that no data exists for the query. **/
 public class NotFoundPlan implements FindPlan, SelectPlan

--- a/src/foam/dao/index/SelectPlan.java
+++ b/src/foam/dao/index/SelectPlan.java
@@ -7,7 +7,7 @@ package foam.dao.index;
 
 import foam.dao.Sink;
 import foam.mlang.predicate.Predicate;
-import java.util.Comparator;
+import foam.mlang.order.Comparator;
 
 public interface SelectPlan extends Plan {
   public void select(Object state, Sink sink, int skip, int limit, Comparator order, Predicate predicate);

--- a/src/foam/mlang/order/ComparatorJava.js
+++ b/src/foam/mlang/order/ComparatorJava.js
@@ -8,7 +8,7 @@
    package: 'foam.mlang.order',
    name: 'Comparator',
 
-   javaExtends: [ 'java.lang.Comparable' ],
+   javaExtends: [ 'java.util.Comparator' ],
 
    methods: [
      {


### PR DESCRIPTION
1. Made ComparatorJava extend `java.util.Comparator` instead of `java.lang.Comparable`
2. Replaced import statements of `java.util.Comparator` to `foam.mlang.order.Comparator`