### PR TITLE
FOAM FObject ⇔ CSV Parsing Updates

### DIFF
--- a/src/foam/lib/csv/CSV.js
+++ b/src/foam/lib/csv/CSV.js
@@ -177,7 +177,7 @@ foam.CLASS({
       if ( lines.length == 0 ) throw 'Insufficient CSV Input';
 
       // Trims quotes and splits CSV row into array
-      var props = this.splitIntoValues(lines[0]).map(this.splitProperty.bind(this));
+      var props = this.splitIntoValues(lines[0]).map(this.splitHeaderTitle.bind(this));
 
       for ( var i = 1 ; i < lines.length ; i++ ) {
         var values = this.splitIntoValues(lines[i]);
@@ -203,7 +203,7 @@ foam.CLASS({
       return parser.parseString(csvString, this.delimiter).map(field => field.value == undefined ? '' : field.value);
     },
 
-    function splitProperty(p) {
+    function splitHeaderTitle(p) {
       if ( ! this.validString(p) ) return [];
 
       var parser = foam.lib.csv.CSVParser.create();

--- a/src/foam/lib/csv/CSV.js
+++ b/src/foam/lib/csv/CSV.js
@@ -136,9 +136,9 @@ foam.CLASS({
       return this;
     },
 
-    function escapeString(source, escapeStr = ',') {
-      if ( source.includes(escapeStr) ) {
-        // Surrounds fields with escapeStr in quotes
+    function escapeString(source) {
+      if ( source.includes(',') ) {
+        // Surrounds fields with ',' in quotes
         // Escapes inner quotes by adding another quote char (Google Sheets strategy)
         source = '"' + this.replaceAll(source, '"', '""') + '"';
       }

--- a/src/foam/lib/csv/CSV.js
+++ b/src/foam/lib/csv/CSV.js
@@ -190,7 +190,7 @@ foam.CLASS({
       if ( ( csvString == undefined ) || ( csvString.length == 0) ) return [];
 
       var parser = foam.lib.csv.CSVParser.create();
-      return parser.parseString(csvString).map(field => field.value == undefined ? '' : field.value);
+      return parser.parseString(csvString, this.delimiter).map(field => field.value == undefined ? '' : field.value);
     },
 
     function createModel(props, values, cls) {

--- a/src/foam/lib/csv/CSVParser.js
+++ b/src/foam/lib/csv/CSVParser.js
@@ -14,36 +14,37 @@ foam.CLASS({
 
   properties: [
     {
-      name: 'grammar_',
-      value: function(alt, anyChar, literal, literalIC, not, notChars, optional,
-          plus, range, repeat, repeat0, seq, seq1, str, sym) {
-        return {
-          START: seq1(1, sym('ws'), repeat(sym('field'), ','), sym('ws')),
-
-          field: alt(sym('quotedText'), sym('unquotedText'), ''),
-
-          unquotedText: repeat(not(',', anyChar()), '', 1),
-
-          quotedText: seq1(1, '"', repeat(alt(sym('escapedQuote'), not('"', anyChar()))), '"'),
-
-          escapedQuote: '""',
-
-          white: alt(' ', '\t', '\r', '\n'),
-
-          // 0 or more whitespace characters.
-          ws: repeat0(sym('white')),
-        };
-      }
+      class: 'String',
+      name: 'delimiter'
     },
     {
       name: 'parser',
       factory: function() {
         var X = this.X;
-        var g = this.ImperativeGrammar.create({ symbols: this.grammar_ });
-
         var self = this;
+        
+        return this.ImperativeGrammar.create({ 
+          symbols: function(alt, anyChar, literal, literalIC, not, notChars, optional,
+          plus, range, repeat, repeat0, seq, seq1, str, sym) {
+            return {
 
-        g.addActions({
+              START: seq1(1, sym('ws'), repeat(sym('field'), literal(self.delimiter)), sym('ws')),
+
+              field: alt(sym('quotedText'), sym('unquotedText'), ''),
+
+              unquotedText: repeat(not(literal(self.delimiter), anyChar()), '', 1),
+
+              quotedText: seq1(1, '"', repeat(alt(sym('escapedQuote'), not('"', anyChar()))), '"'),
+
+              escapedQuote: '""',
+
+              white: alt(' ', '\t', '\r', '\n'),
+
+              // 0 or more whitespace characters.
+              ws: repeat0(sym('white'))
+            }
+          }
+        }).addActions({
           unquotedText: function(a) {
             return { node: 'unquotedText', value: a.join('') };
           },
@@ -54,15 +55,14 @@ foam.CLASS({
 
           escapedQuote: function() { return '"'; }
         });
-
-        return g;
       }
     }
   ],
 
   methods: [
-    function parseString(str, opt_start) {
-      return this.parser.parseString(str, opt_start);
+    function parseString(str, delimiter) {
+      this.delimiter = delimiter;
+      return this.parser.parseString(str);
     }
   ]
 });

--- a/src/foam/lib/csv/CSVParser.js
+++ b/src/foam/lib/csv/CSVParser.js
@@ -18,7 +18,11 @@ foam.CLASS({
       name: 'delimiter'
     },
     {
-      name: 'parser',
+      class: 'String',
+      name: 'nestedObjectSeperator'
+    },
+    {
+      name: 'stringParser',
       factory: function() {
         var X = this.X;
         var self = this;
@@ -56,13 +60,58 @@ foam.CLASS({
           escapedQuote: function() { return '"'; }
         });
       }
+    },
+    {
+      name: 'headerParser',
+      factory: function() {
+        var X = this.X;
+        var self = this;
+        
+        return this.ImperativeGrammar.create({ 
+          symbols: function(alt, anyChar, literal, literalIC, not, notChars, optional,
+          plus, range, repeat, repeat0, seq, seq1, str, sym) {
+            return {
+
+              START: seq1(1, sym('ws'), repeat(sym('field'), literal(self.nestedObjectSeperator)), sym('ws')),
+
+              field: alt(sym('text'), ''),
+
+              text: repeat(alt(sym('escapedSeperator'), not(self.nestedObjectSeperator, anyChar())), '', 1),
+
+              escapedSeperator: literal(self.nestedObjectSeperator + self.nestedObjectSeperator),
+
+              white: alt(' ', '\t', '\r', '\n'),
+
+              // 0 or more whitespace characters.
+              ws: repeat0(sym('white'))
+            }
+          }
+        }).addActions({
+          text: function(a) {
+            return { node: 'text', value: self.recoverHeaderTitle(a.join('')) };
+          },
+
+          escapedQuote: function() { return '"'; }
+        });
+      }
     }
   ],
 
   methods: [
     function parseString(str, delimiter) {
       this.delimiter = delimiter;
-      return this.parser.parseString(str);
+      return this.stringParser.parseString(str);
+    },
+    
+    function parseHeader(str, nestedObjectSeperator) {
+      this.nestedObjectSeperator = nestedObjectSeperator;
+      return this.headerParser.parseString(str);
+    },
+
+    function recoverHeaderTitle(t) {
+      // Recovers header title by replacing the nested object seperator x 2, by itself
+      return t.replace(new RegExp(this.nestedObjectSeperator + this.nestedObjectSeperator, 'g'), 
+                this.nestedObjectSeperator);
     }
   ]
 });


### PR DESCRIPTION
- Updated CFG for CSV value parser to take in delimiter as parameter
- Added CFG to recognize header `nestedObjectSeperator`

### Why the update?
- This takes care of the rare situation that the header title itself contains the `nestedObjectSeperator`. This escapes that situation and then parses accordingly.
- This also ensures arbitrary delimiters work with the custom CFG & parser. 