### PR TITLE
License Header Tool, Removal of Property Refinement

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -87,7 +87,6 @@ FOAM_FILES([
   { name: "foam/java/MultiPartSetter", flags: ['java'] },
   { name: "foam/java/Outputter", flags: ['java'] },
   { name: "foam/java/PropertyInfo", flags: ['java'] },
-  { name: "foam/java/PropertyRefinement", flags: ['java'] },
   { name: "foam/java/Skeleton", flags: ['java'] },
   { name: "foam/java/JavaImport", flags: ['java'] },
   { name: "foam/java/refinements", flags: ['java'] },

--- a/src/foam/java/InterfaceMethod.js
+++ b/src/foam/java/InterfaceMethod.js
@@ -40,6 +40,12 @@ foam.CLASS({
       setter: function() {},
       getter: function() {}
     },
+    {
+      name: 'synchronized',
+      documentation: 'Dummy property to silence warnings',
+      setter: function() {},
+      getter: function() {}
+    },
     { class: 'StringArray', name: 'throws' }
   ],
 

--- a/src/foam/lib/parse/Chars.java
+++ b/src/foam/lib/parse/Chars.java
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2017 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 package foam.lib.parse;
 
 public class Chars implements Parser {

--- a/src/foam/lib/parse/Substring.java
+++ b/src/foam/lib/parse/Substring.java
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2017 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 package foam.lib.parse;
 
 public class Substring extends ProxyParser {

--- a/src/foam/tools/schemaimport/SchemaImport.js
+++ b/src/foam/tools/schemaimport/SchemaImport.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2017 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 foam.CLASS({
   package: 'foam.tools.schemaimport',
   name: 'SchemaImport',

--- a/src/foam/u2/history/HistoryItemView.js
+++ b/src/foam/u2/history/HistoryItemView.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2017 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 foam.INTERFACE({
   package: 'foam.u2.history',
   name: 'HistoryItemView',

--- a/src/foam/u2/history/HistoryView.js
+++ b/src/foam/u2/history/HistoryView.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2017 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 foam.CLASS({
   package: 'foam.u2.history',
   name: 'HistoryView',

--- a/tools/licenseFinder.sh
+++ b/tools/licenseFinder.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Finds files not starting with /** & don't have the extensions
+# of .DS_Store, .md, .txt, .html. Searches in src/foam/*
+
+for i in `grep -rL "/\*\*" ../src/foam/*`; do
+   # Skips DS_Store files
+   if [[ ${i} != *".DS_Store"* && ${i} != *".md" && ${i} != *".txt" && ${i} != *".html" ]];then
+    echo "$i"
+   fi
+done
+

--- a/tools/licenseFinder.sh
+++ b/tools/licenseFinder.sh
@@ -4,7 +4,6 @@
 # of .DS_Store, .md, .txt, .html. Searches in src/foam/*
 
 for i in `grep -rL "/\*\*" ../src/foam/*`; do
-   # Skips DS_Store files
    if [[ ${i} != *".DS_Store"* && ${i} != *".md" && ${i} != *".txt" && ${i} != *".html" ]];then
     echo "$i"
    fi


### PR DESCRIPTION
- Removed `PropertyRefinement.js` (empty file)
- Added licenses to files missing them
- Added synchronized dummy property to silence warnings
- Added a shell script which detects files within the `src/foam` directory which don't have `/**` at the start (indicating a missing license). 