### PR TITLE
MDAO code clean-up

### DIFF
--- a/src/foam/dao/MDAO.js
+++ b/src/foam/dao/MDAO.js
@@ -54,15 +54,16 @@ foam.CLASS({
     },
     {
       class: 'Boolean',
-      name: 'autoIndex',
-      value: false
+      name: 'autoIndex'
     },
     {
-      name: 'idIndex'
+      name: 'idIndex',
+      transient: true
     },
     {
       /** The root IndexNode of our index. */
-      name: 'index'
+      name: 'index',
+      transient: true
     }
   ],
 


### PR DESCRIPTION
- No need for value: false on Boolean property
- Making index properties transient allows for network portability
  + E.g. use case: Send spec of DAO to create over network to DAO host