### PR TITLE
Slot: Drop detach-on-class-change logic. Affords cases such as:

### DIFF
--- a/src/foam/core/Slot.js
+++ b/src/foam/core/Slot.js
@@ -320,14 +320,7 @@ foam.CLASS({
 
       // If the parent object changes class, then don't update
       // because a new class will have different sub-slots.
-      if ( this.of ) {
-        if ( this.of !== ( o && o.cls_ ) ) {
-          s.detach();
-          return;
-        }
-      } else {
-        if ( o ) this.of = o.cls_;
-      }
+      if ( ( ! this.of  ) && o ) this.of = o.cls_;
 
       this.prevSub = o && o.slot(this.name).sub(this.valueChange);
       this.valueChange();


### PR DESCRIPTION
view.add(view.data$.('foo');
...
view.data = undefined;
...
view.data = somethingWithFoo;