### PR TITLE
foam.dao.Relationship: Name relationships between Foo and Bar types

### DIFF
--- a/src/foam/dao/Relationship.js
+++ b/src/foam/dao/Relationship.js
@@ -50,7 +50,7 @@ foam.CLASS({
       hidden: true,
       getter: function() {
         return this.lookup(this.sourceModel).name +
-          foam.String.capitalize(this.forwardName) + 'Relationship';
+          this.lookup(this.targetModel).name + 'Relationship';
       }
     },
     'forwardName',


### PR DESCRIPTION
"FooBarRelationship" rather than "FooBarsRelationship". This is more
consistent and a less confusing name in the M:N relationship case.