### PR TITLE
Renaming "registry" property in BoxRegistry

### DIFF
--- a/src/foam/box/BoxRegistry.js
+++ b/src/foam/box/BoxRegistry.js
@@ -30,7 +30,7 @@ foam.CLASS({
 
   properties: [
     {
-      name: 'registry',
+      name: 'registry_',
       hidden: true,
       factory: function() { return {}; }
     }
@@ -59,9 +59,9 @@ foam.CLASS({
       name: 'doLookup',
       returns: 'foam.box.Box',
       code: function doLookup(name) {
-        if ( this.registry[name] &&
-             this.registry[name].exportBox )
-          return this.registry[name].exportBox;
+        if ( this.registry_[name] &&
+             this.registry_[name].exportBox )
+          return this.registry_[name].exportBox;
 
         throw this.NoSuchNameException.create({ name: name });
       },
@@ -78,12 +78,12 @@ foam.CLASS({
         var exportBox = this.SubBox.create({ name: name, delegate: this.me });
         exportBox = service ? service.clientBox(exportBox) : exportBox;
 
-        this.registry[name] = {
+        this.registry_[name] = {
           exportBox: exportBox,
           localBox: service ? service.serverBox(localBox) : localBox
         };
 
-        return this.registry[name].exportBox;
+        return this.registry_[name].exportBox;
       },
       args: [ 'name', 'service', 'box' ]
     },
@@ -92,19 +92,19 @@ foam.CLASS({
       returns: '',
       code: function(name) {
         if ( foam.box.Box.isInstance(name) ) {
-          for ( var key in this.registry ) {
+          for ( var key in this.registry_ ) {
             // TODO(markdittmer): Should there be a specialized compare() should
             // be implemented by NamedBox (to cut out delegate) and
             // foam.util.compare()?
-            if ( this.registry[key].exportBox === name ) {
-              delete this.registry[key];
+            if ( this.registry_[key].exportBox === name ) {
+              delete this.registry_[key];
               return;
             }
           }
           return;
         }
 
-        delete this.registry[name];
+        delete this.registry_[name];
       },
       args: [
         'name'

--- a/src/foam/box/BoxRegistryBox.js
+++ b/src/foam/box/BoxRegistryBox.js
@@ -45,10 +45,10 @@ foam.CLASS({
         if ( this.SubBoxMessage.isInstance(msg.object) ) {
           var name = msg.object.name;
 
-          if ( this.registry[name].localBox ) {
+          if ( this.registry_[name].localBox ) {
             // Unpack sub box object... is this right?
             msg.object = msg.object.object;
-            this.registry[name].localBox.send(msg);
+            this.registry_[name].localBox.send(msg);
           } else {
             if ( msg.attributes.errorBox ) {
               msg.attributes.errorBox.send(


### PR DESCRIPTION
This change attempts to reduce confusing and complications in other scenarios. For example, when import registry, overwriting the property.