### PR TITLE
Unterminated literal (nanos/test) fix

### DIFF
--- a/src/foam/nanos/test/Test.js
+++ b/src/foam/nanos/test/Test.js
@@ -70,7 +70,7 @@ foam.CLASS({
 
         setLastRun(new Date());
         ps.flush();
-        setOutput(baos.toString());
+        setOutput(baos.toString());`
     }
   ]
 });


### PR DESCRIPTION
Minor patch to fix build


[3:45] 
Currently errors out


[3:45] 
 ```Property foam.core.FObjectProperty.of "value" hidden by "getter"
/Users/tanay/git/foam2/src/foam/nanos/test/Test.js:48
      javaCode: `
                ^
SyntaxError: Unterminated template literal
    at Object.exports.runInThisContext (vm.js:76:16)
    at Module._compile (module.js:542:28)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at loadServer (/Users/tanay/git/foam2/src/foam.js:54:5)
    at Array.forEach (native)
```

**CLOSED:** https://github.com/foam-framework/foam2/commit/8e3f119b71aa5093b6b043db1fcc8693753b9aed