### PR TITLE
Test and implement: Partitions/namespaces for DatastoreDAO/JS

### DIFF
--- a/src/com/google/cloud/datastore/BatchMutationDatastoreDAO.js
+++ b/src/com/google/cloud/datastore/BatchMutationDatastoreDAO.js
@@ -122,7 +122,7 @@ foam.CLASS({
       return new Promise(function(resolve, reject) {
         self.mutations_.push(self.DatastoreMutation.create({
           type: self.DatastoreMutationType.DELETE,
-          data: o.getDatastoreKey(),
+          data: o.getDatastoreKey(this.partitionId_),
           resolve: function(didRemove) {
             if ( didRemove ) self.pub('on', 'remove', o);
             resolve(o);

--- a/src/com/google/cloud/datastore/types.js
+++ b/src/com/google/cloud/datastore/types.js
@@ -388,8 +388,13 @@ foam.CLASS({
         name: com.google.cloud.datastore.toDatastoreKeyName(this)
       };
     },
-    function getDatastoreKey(opt_propertyPath) {
-      if ( ! opt_propertyPath ) return { path: [ this.getOwnDatastoreKey() ] };
+    function getDatastoreKey(partitionId, opt_propertyPath) {
+      if ( ! opt_propertyPath ) {
+        return {
+          partitionId: partitionId,
+          path: [ this.getOwnDatastoreKey() ]
+        };
+      }
 
       var o = this;
       var path = new Array(opt_propertyPath.length + 1);
@@ -408,9 +413,9 @@ foam.CLASS({
         path[i + 1] = o.getOwnDatastoreKey();
       }
 
-      return { path: path };
+      return { partitionId: partitionId, path: path };
     },
-    function toDatastoreEntity() {
+    function toDatastoreEntity(partitionId) {
       var properties = {};
       var ps = this.cls_.getAxiomsByClass(foam.core.Property);
 
@@ -426,7 +431,7 @@ foam.CLASS({
             value);
       }
 
-      return { key: this.getDatastoreKey(), properties: properties };
+      return { key: this.getDatastoreKey(partitionId), properties: properties };
     },
     function toDatastoreValue() {
       return { entityValue: this.toDatastoreEntity() };


### PR DESCRIPTION
All DatastoreDAOs now set "partitionId" [1]. Injecting `DatastoreDAO.__context__.datastoreNamespaceId` or `DatastoreDAO.namespaceId` causes DAO to use a custom datastore namespace in its "partitionId".

[1] https://cloud.google.com/datastore/docs/reference/rest/v1/PartitionId