### PR TITLE
Sync DAO overhaul

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -140,6 +140,7 @@ FOAM_FILES([
   { name: "foam/dao/SequenceNumberDAO" },
   { name: "foam/dao/ContextualizingDAO" },
   { name: "foam/dao/VersionNoDAO" },
+  { name: "foam/dao/sync/SyncRecord" },
   { name: "foam/dao/SyncDAO" },
   { name: "foam/dao/EasyDAO" },
   { name: "foam/dao/NoSelectAllDAO" },

--- a/src/files.js
+++ b/src/files.js
@@ -139,6 +139,7 @@ FOAM_FILES([
   { name: "foam/dao/LRUDAOManager" },
   { name: "foam/dao/SequenceNumberDAO" },
   { name: "foam/dao/ContextualizingDAO" },
+  { name: "foam/dao/VersionNoDAO" },
   { name: "foam/dao/SyncDAO" },
   { name: "foam/dao/EasyDAO" },
   { name: "foam/dao/NoSelectAllDAO" },

--- a/src/foam/dao/SyncDAO.js
+++ b/src/foam/dao/SyncDAO.js
@@ -16,248 +16,353 @@
  */
 
 foam.CLASS({
-  package: 'foam.dao.sync',
-  name: 'SyncRecord',
-
-  documentation: 'Used by foam.dao.SyncDAO to track object updates and deletions.',
-
-  properties: [
-    'id',
-    {
-      class: 'Int',
-      name: 'syncNo',
-      value: -1
-    },
-    {
-      class: 'Boolean',
-      name: 'deleted',
-      value: false
-    }
-  ]
-});
-
-
-/**
-  SyncDAO synchronizes data between multiple client's offline caches and a server.
-  When syncronizing, each client tracks the last-seen version of each object,
-  or if the object was deleted. The most recent version is retained.
-  <p>
-  Make sure to set the syncProperty to use to track each object's version.
-  It will automatically be incremented as changes are put() into the SyncDAO.
-*/
-foam.CLASS({
   package: 'foam.dao',
   name: 'SyncDAO',
   extends: 'foam.dao.ProxyDAO',
 
-  requires: [
-    'foam.dao.sync.SyncRecord'
-  ],
+  documentation: `SyncDAO synchronizes data between multiple clients' offline
+      caches and a server. When syncronizing, each client tracks the last-seen
+      version of each object, or if the object was deleted. The most recent
+      version is retained.
 
-  implements: [
-    'foam.mlang.Expressions'
-  ],
+      Make sure to set the syncProperty to use to track each object's version.
+      It will automatically be incremented as changes are put() into the
+      SyncDAO.
 
-  imports: [
-    'setInterval'
-  ],
+      Remote DAOs that interact with SyncDAO clients should be decorated with
+      foam.dao.VersionNoDAO, or similar, to provision new version numbers for
+      records being written to the server.`,
+
+  requires: [ 'foam.dao.sync.SyncRecord' ],
+
+  implements: [ 'foam.mlang.Expressions' ],
+
+  imports: [ 'setInterval' ],
 
   properties: [
     {
-      /**
-        The shared server DAO to synchronize through.
-      */
       class: 'foam.dao.DAOProperty',
       name: 'remoteDAO',
+      documentation: 'The shared server DAO to synchronize to.',
       transient: true,
       required: true
     },
     {
-      /** The local cache to sync with the server DAO. */
       name: 'delegate',
+      documentation: 'The local cache to sync with the server DAO.'
     },
     {
-      /**
-        The DAO in which to store SyncRecords for each object. Each client
-        tracks their own sync state in a separate syncRecordDAO.
-      */
+      class: 'foam.dao.DAOProperty',
       name: 'syncRecordDAO',
+      documentation: `The DAO in which to store SyncRecords for each object.
+          Each client tracks their own sync state in a separate syncRecordDAO.`,
       transient: true,
       required: true
     },
     {
-      /**
-        The property to use to store the object version. This value on each
-        object will be incremented each time it is put() into the SyncDAO.
-      */
       name: 'syncProperty',
+      documentation: `The property to use to store the object version. This
+          value on each object will be incremented each time it is put() into
+          the SyncDAO.`,
       required: true,
       transient: true
     },
     {
-      /**
-        The class of object this DAO will store.
-      */
       name: 'of',
+      documentation: 'The class of object this DAO will store.',
       required: true,
       transient: true
     },
     {
-      /**
-        If using a remote DAO without push capabilities, such as an HTTP
-        server, polling will periodically attempt to synchronize.
-      */
       class: 'Boolean',
       name: 'polling',
-      value: false
+      documentation: `If using a remote DAO without push capabilities, such as
+          an HTTP server, polling will periodically attempt to synchronize.`
     },
     {
       /**
-        If using polling, pollingFrequency will determine the number of
-        milliseconds to wait between synchronization attempts.
+
       */
       class: 'Int',
       name: 'pollingFrequency',
+      documentation: `If using polling, pollingFrequency will determine the
+        number of milliseconds to wait between synchronization attempts.`,
       value: 1000
+    },
+    {
+      name: 'synced',
+      documentation: `A promise that resolves after any in-flight
+          synchronization pass completes.`,
+      factory: function() { return Promise.resolve(); }
+    },
+    {
+      name: 'syncRecordWriteSync_',
+      factory: function() { return Promise.resolve(); }
     }
   ],
 
   methods: [
-    /** @private */
     function init() {
       this.SUPER();
 
-      this.remoteDAO$proxy.sub('on', this.onRemoteUpdate);
+      // Only listen to DAOs that support push (i.e., do not require polling).
+      if ( ! this.polling )
+        this.remoteDAO$proxy.sub('on', this.onRemoteUpdate);
 
-      this.delegate.on.sub(this.onLocalUpdate);
-
-      if ( this.polling ) {
-        this.setInterval(function() {
-          this.sync();
-        }.bind(this), this.pollingFrequency);
-      }
-    },
-
-    /**
-      Updates the object's last seen info.
-    */
-    function put_(x, obj) {
-      return this.delegate.put_(x, obj).then(function(o) {
-        this.syncRecordDAO.put_(x,
-          this.SyncRecord.create({
-            id: o.id,
+      // Push initial data from delegate.
+      var self = this;
+      self.synced = self.delegate.select().then(function(sink) {
+        var array = sink.array;
+        for ( var i = 0; i < array.length; i++ ) {
+          self.syncRecordDAO.put(self.SyncRecord.create({
+            id: array[i].id,
             syncNo: -1
           }));
-        return o;
+        }
+      }).
+          // Like sync(), but on initial sync, syncFromRemote_() regardless of
+          // whether "polling" is set.
+          then(self.syncToRemote_.bind(self)).
+          then(self.syncFromRemote_.bind(self));
+
+      // Setup polling after initial sync.
+      if ( ! self.polling ) return;
+      self.synced.then(function() {
+        self.setInterval(function() {
+          self.sync();
+        }, self.pollingFrequency);
+      });
+    },
+    function sync() {
+      // Sync after any sync(s) in progress complete.
+      return this.synced = this.synced.then(function() {
+        console.log('sync');
+        var ret = this.syncToRemote_();
+
+        // Only syncFromRemote_ when polling (otherwise, updates will get pushed
+        // anyway).
+        if ( this.polling ) ret = ret.then(this.syncFromRemote_.bind(this));
+
+        return ret;
       }.bind(this));
     },
 
-    /**
-      Marks the object as deleted.
-    */
+    //
+    // DAO overrides.
+    //
+
+    function put_(x, obj) {
+      var self = this;
+      var ret;
+      return self.withSyncRecordTx_(function() {
+        return self.delegate.put_(x, obj).then(function(o) {
+          ret = o;
+          // Updates the object's last seen info.
+          return self.syncRecordDAO.put_(x, self.SyncRecord.create({
+            id: o.id,
+            syncNo: -1
+          }));
+        });
+      }).then(self.onLocalUpdate).then(function() { return ret; });
+    },
     function remove_(x, obj) {
-      return this.delegate.remove_(x, obj).then(function(o) {
-        this.syncRecordDAO.put_(x,
-          this.SyncRecord.create({
+      var self = this;
+      var ret;
+      return self.withSyncRecordTx_(function() {
+        return self.delegate.remove_(x, obj).then(function(o) {
+          ret = o;
+          // Marks the object as deleted.
+          self.syncRecordDAO.put_(x, self.SyncRecord.create({
             id: obj.id,
             deleted: true,
             syncNo: -1
           }));
-      }.bind(this));
-    },
-
-    /**
-      Marks all the removed objects' sync records as deleted.
-    */
-    function removeAll_(x, skip, limit, order, predicate) {
-      this.delegate.select_(x, null, skip, limit, order, predicate).then(function(a) {
-        a = a.array;
-        for ( var i = 0 ; i < a.length ; i++ ) {
-          this.remove_(x, a[i]);
-        }
-      }.bind(this));
-    },
-
-    /** @private */
-    function processFromServer(obj) {
-      this.delegate.put(obj).then(function(obj) {
-        this.syncRecordDAO.put(
-          this.SyncRecord.create({
-            id: obj.id,
-            syncNo: obj[this.syncProperty.name]
-          }));
-      }.bind(this));
-    },
-
-    /** @private */
-    function syncFromServer() {
-      var E = this;
-
-      this.syncRecordDAO.select(E.MAX(this.SyncRecord.SYNC_NO)).then(function(m) {
-        this.remoteDAO
-          .where(E.GT(this.syncProperty, m.value || 0))
-          .select().then(function(a) {
-            a = a.array;
-            for ( var i = 0 ; i < a.length ; i++ ) {
-              this.processFromServer(a[i]);
-            }
-          }.bind(this));
-      }.bind(this));
-    },
-
-    /** @private */
-    function syncToServer() {
-      var E = this;
-      var self = this;
-
-      this.syncRecordDAO
-        .where(E.EQ(this.SyncRecord.SYNC_NO, -1))
-        .select().then(function(records) {
-          records = records.array;
-
-          for ( var i = 0 ; i < records.length ; i++ ) {
-            var record = records[i]
-            var id = record.id;
-            var deleted = record.deleted;
-
-            if ( deleted ) {
-              var obj = self.of.create(undefined, self);
-              obj.id = id;
-              self.remoteDAO.remove(obj);
-            } else {
-              // TODO: Stop sending updates if the first one fails.
-              self.delegate.find(id).then(function(obj) {
-                if ( obj ) return self.remoteDAO.put(obj).then(function(obj) {
-                  self.processFromServer(obj);
-                });
-                return null;
-              });
-            }
-          }
         });
+      }).then(self.onLocalUpdate).then(function() { return ret; });
+    },
+    function removeAll_(x, skip, limit, order, predicate) {
+      // Marks all the removed objects' sync records as deleted via remove_().
+      return this.delegate.select_(x, null, skip, limit, order, predicate).
+          then(function(a) {
+            a = a.array;
+            var promises = [];
+
+            for ( var i = 0 ; i < a.length ; i++ ) {
+              promises.push(this.remove_(x, a[i]));
+            }
+
+            return Promise.all(promises);
+          }.bind(this));
     },
 
-    /** @private */
-    function sync() {
-      this.syncToServer();
-      this.syncFromServer();
+    //
+    // Private synchronization details.
+    //
+
+    {
+      name: 'putFromRemote_',
+      documentation: 'Process a put() to cache from remote.',
+      code: function(obj) {
+        // console.log('putFromRemote_', foam.json.stringify(obj));
+        var self = this;
+        var ret;
+        return self.withSyncRecordTx_(function() {
+          return self.delegate.put(obj).then(function(o) {
+            ret = o;
+            // console.log('putFromRemote_: store syncRecord for', foam.json.stringify(o));
+            return self.syncRecordDAO.put(self.SyncRecord.create({
+              id: o.id,
+              syncNo: o[self.syncProperty.name]
+            }));
+          });
+        }).then(function() { return ret; });
+      }
+    },
+    {
+      name: 'removeFromRemote_',
+      documentation: 'Process a remove() on cache from remote.',
+      code: function(obj) {
+        // console.log('removeFromRemote_', foam.json.stringify(obj));
+        var self = this;
+        var ret;
+        return self.withSyncRecordTx_(function() {
+          return self.delegate.remove(obj).then(function(o) {
+            ret = o;
+            // console.log('removeFromRemote_: store syncRecord for', foam.json.stringify(obj));
+            return self.syncRecordDAO.put(self.SyncRecord.create({
+              id: obj.id,
+              syncNo: obj[self.syncProperty.name],
+              deleted: true
+            }));
+          });
+        }).then(function() { return ret; });
+      }
+    },
+    {
+      name: 'resetFromRemote_',
+      documentation: 'Process a reset signal on cache from remote.',
+      code: function(obj) {
+        // console.log('resetFromRemote_', foam.json.stringify(obj));
+        // Clear sync records and data not associated with unsynced data, then
+        // sync.
+        var self = this;
+        var ret;
+        return self.withSyncRecordTx_(function() {
+          return self.syncRecordDAO(self.GT(self.SyncRecord.SYNC_NO, -1))
+              .removeAll().
+              then(self.syncRecordDAO.select.bind(self.syncRecordDAO)).
+              then(function(sink) {
+                var idsToKeep = sink.array.map(function(syncRecord) {
+                  return syncRecord.id;
+                });
+                // console.log('resetFromRemote_: Keeping', idsToKeep,
+                //             'not yet pushed');
+                return self.delegate.where(
+                    self.NOT(self.IN(self.of.ID, idsToKeep))).
+                    removeAll();
+              });
+        }).then(self.sync.bind(self));
+      }
+    },
+    {
+      name: 'syncFromRemote_',
+      documentation: 'Pull data from remote and sync it to cache.',
+      code: function() {
+        // console.log('syncFromRemote_');
+        var self = this;
+        var SYNC_NO = self.SyncRecord.SYNC_NO;
+
+        return self.syncRecordDAO.
+            // Like MAX(), but faster on DAOs that can optimize order+limit.
+            orderBy(self.DESC(SYNC_NO)).limit(1).
+            select().then(function(sink) {
+              var value = sink.array[0] && SYNC_NO.f(sink.array[0]);
+              // console.log('syncFromRemote_: version >', value || 0);
+              return self.remoteDAO.
+                  where(self.GT(self.syncProperty, value || 0)).
+                  select().then(function(sink) {
+                    var array = sink.array;
+                    var promises = [];
+
+                    for ( var i = 0 ; i < array.length ; i++ ) {
+                      promises.push(self.putFromRemote_(array[i]));
+                    }
+
+                    return Promise.all(promises);
+                  });
+            });
+      }
+    },
+    {
+      name: 'syncToRemote_',
+      documentation: 'Push data from cach to remote.',
+      code: function() {
+        // console.log('syncToRemote_');
+        var self = this;
+
+        return this.syncRecordDAO
+          .where(self.EQ(this.SyncRecord.SYNC_NO, -1))
+          .select().then(function(records) {
+            records = records.array;
+            var promises = [];
+
+            for ( var i = 0 ; i < records.length ; i++ ) {
+              var record = records[i];
+              var id = record.id;
+              var deleted = record.deleted;
+
+              if ( deleted ) {
+                var obj = self.of.create(undefined, self);
+                obj.id = id;
+                promises.push(self.remoteDAO.remove(obj));
+              } else {
+                // TODO: Stop sending updates if the first one fails.
+                promises.push(self.delegate.find(id).then(function(obj) {
+                  if ( ! obj ) return null;
+                  var ret = self.remoteDAO.put(obj);
+
+                  // When not polling, server result will processed when
+                  // onRemoteUpdate listener is fired.
+                  if ( self.polling ) {
+                    ret = ret.then(function(obj) {
+                      self.putFromRemote_(obj);
+                    });
+                  }
+
+                  return ret;
+                }));
+              }
+            }
+
+            return Promise.all(promises);
+          });
+      }
+    },
+    {
+      name: 'withSyncRecordTx_',
+      documentation: `Run a computation that writes to syncRecordDAO
+          transactionally with respect to other syncRecordDAO writes.`,
+      code: function(f) {
+        return this.syncRecordWriteSync_ = this.syncRecordWriteSync_.then(f);
+      }
     }
   ],
 
   listeners: [
-    /** @private */
-    function onRemoteUpdate(s, on, event, obj) {
-      if ( event == 'put' ) {
-        this.processFromServer(obj);
-      } else if ( event === 'remove' ) {
-        this.delegate.remove(obj);
-      } else if ( event === 'reset' ) {
-        this.delegate.removeAll();
+    {
+      name: 'onRemoteUpdate',
+      documentation: 'Respond to push event from remote.',
+      code: function(s, on, event, obj) {
+        if ( event == 'put' ) {
+          this.putFromRemote_(obj);
+        } else if ( event === 'remove' ) {
+          this.removeFromRemote_(obj);
+        } else if ( event === 'reset' ) {
+          this.resetFromRemote_();
+        }
       }
     },
-
     {
-      /** @private */
       name: 'onLocalUpdate',
       isMerged: true,
       mergeDelay: 100,

--- a/src/foam/dao/VersionNoDAO.js
+++ b/src/foam/dao/VersionNoDAO.js
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * Copyright 2017 The FOAM Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+foam.CLASS({
+  package: 'foam.dao',
+  name: 'VersionNoDAO',
+  extends: 'foam.dao.ProxyDAO',
+  implements: [ 'foam.mlang.Expressions' ],
+
+  classes: [
+    {
+      name: 'PutData',
+
+      properties: [
+        {
+          class: 'FObjectProperty',
+          of: 'FObject',
+          name: 'data'
+        },
+        {
+          class: 'Function',
+          name: 'resolve'
+        },
+        {
+          class: 'Function',
+          name: 'reject'
+        }
+      ]
+    }
+  ],
+
+  properties: [
+    {
+      class: 'FObjectProperty',
+      of: 'Property',
+      name: 'property',
+      required: true,
+      hidden: true,
+      transient: true
+    },
+    {
+      class: 'Int',
+      name: 'version',
+      value: 1
+    },
+    {
+      class: 'FObjectArray',
+      of: 'FObject',
+      // of: 'PutData',
+      name: 'putBacklog_'
+    },
+    {
+      class: 'Function',
+      name: 'putImpl_',
+      factory: function() { return this.putToBacklog_; }
+    }
+  ],
+
+  methods: [
+    function init() {
+      this.validate();
+      this.SUPER();
+
+      // Get largest version number in delegate's records.
+      this.delegate
+          // Like MAX(), but faster on DAOs that can optimize order+limit.
+          .orderBy(this.DESC(this.property)).limit(1)
+          .select().then(function(sink) {
+            var propName = this.property.name;
+            if ( sink.array[0] && sink.array[0][propName] )
+              this.version = sink.array[0][propName] + 1;
+
+            // Flush backlog, resolving put() promises.
+            var delegate = this.delegate;
+            var puts = this.putBacklog_;
+            for ( var i = 0; i < puts.length; i++ ) {
+              var obj = puts[i].data;
+              obj[propName] = this.version;
+              this.version++;
+              delegate.put(obj).then(puts[i].resolve, puts[i].reject);
+            }
+            this.putImpl_ = this.putToDelegate_;
+          }.bind(this));
+    },
+    function put_(x, obj) {
+      // Either putToBacklog_() or putToDelegate_(), depending on whether
+      // version number has been initialized.
+      return this.putImpl_(x, obj);
+    },
+    function putToBacklog_(x, obj) {
+      // Store put()s before version number is initialized.
+      return new Promise(function(resolve, reject) {
+        this.putBacklog_.push(this.PutData.create({
+          data: obj,
+          resolve: resolve,
+          reject: reject
+        }));
+      }.bind(this));
+    },
+    function putToDelegate_(x, obj) {
+      // Increment version number and put to delegate.
+      obj[this.property.name] = this.version;
+      this.version++;
+      return this.delegate.put_(x, obj);
+    }
+  ]
+});

--- a/src/foam/dao/sync/SyncRecord.js
+++ b/src/foam/dao/sync/SyncRecord.js
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2017 The FOAM Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+foam.CLASS({
+  package: 'foam.dao.sync',
+  name: 'SyncRecord',
+
+  documentation: `Used by foam.dao.SyncDAO to track object updates and
+      deletions.`,
+
+  properties: [
+    'id',
+    {
+      class: 'Int',
+      name: 'syncNo',
+      value: -1
+    },
+    {
+      class: 'Boolean',
+      name: 'deleted',
+      value: false
+    }
+  ]
+});

--- a/test/node/syncDAOStress.js
+++ b/test/node/syncDAOStress.js
@@ -1,0 +1,225 @@
+/**
+ * @license
+ * Copyright 2017 The FOAM Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Manual standalone test script for stress testing foam.dao.SyncDAO. To tweak
+ * test operation, jump to comment "Test configuration".
+ */
+
+require('../../src/foam.js');
+
+var Item;
+var BaseDAO;
+var ProxyDAO;
+var QuickSink;
+var SyncDAO;
+var SyncRecord;
+var VersionNoDAO;
+
+foam.CLASS({
+  package: 'foam.dao.test',
+  name: 'Item',
+
+  properties: [ 'id', [ 'version', -1 ], 'data' ]
+});
+
+foam.CLASS({
+  package: 'foam.dao.test',
+  name: 'BaseDAO',
+  extends: 'foam.dao.ProxyDAO',
+
+  documentation: `Clone before put()/remove() to delegate (default: MDAO). Also,
+      delay up to "maxDelay" milliseconds before passing put()/remove() to
+      delegate, and before returning delegate's response.`,
+
+  requires: [ 'foam.dao.MDAO' ],
+
+  properties: [
+    {
+      name: 'delegate',
+      factory: function() {
+        return this.MDAO.create({ of: this.of });
+      }
+    },
+    {
+      name: 'maxDelay',
+      documentation: `Maximum number of milliseconds to delay passing to
+          delegate and/or returning value from delegate.`,
+      value: 20
+    }
+  ],
+
+  methods: [
+    function put_(x, o) {
+      return this.delay_('put_', [ x, o.clone() ]);
+    },
+    function remove_(x, o) {
+      return this.delay_('remove_', [ x, o.clone() ]);
+    },
+    function delay_(op, args) {
+      var self = this;
+      return new Promise(function(resolve, reject) {
+        // Log to ensure ordering (i.e., no logs such as these should appear
+        // after verification step).
+        console.log('Base DAO', op);
+        setTimeout(function() {
+          console.log('Base DAO', op, 'send to delegate');
+          return self.delegate[op].apply(self.delegate, args).then(function(o) {
+            setTimeout(function() {
+              console.log('Base DAO', op, 'resolve');
+              resolve(o);
+            }, Math.floor(Math.random() * self.maxDelay));
+          }, function(e) {
+            setTimeout(function() {
+              console.log('Base DAO', op, 'reject');
+              reject(e);
+            }, Math.floor(Math.random() * self.maxDelay));
+          });
+        }, Math.floor(Math.random() * self.maxDelay));
+      });
+    }
+  ]
+});
+
+Item = foam.lookup('foam.dao.test.Item');
+BaseDAO = foam.lookup('foam.dao.test.BaseDAO');
+ProxyDAO = foam.lookup('foam.dao.ProxyDAO');
+QuickSink = foam.lookup('foam.dao.QuickSink');
+SyncDAO = foam.lookup('foam.dao.SyncDAO');
+SyncRecord = foam.lookup('foam.dao.sync.SyncRecord');
+VersionNoDAO = foam.lookup('foam.dao.VersionNoDAO');
+
+function getData(name) {
+  return name + ':' + Math.ceil(Math.random() * 1000);
+}
+
+/**
+ * Test configuration
+ */
+
+// Data in remote before VersionNoDAO is added.
+var initialData = [
+  Item.create({ id: 0, data: getData('initial') }),
+  Item.create({ id: 10, data: getData('initial') }),
+  Item.create({ id: 20, data: getData('initial') }),
+  Item.create({ id: 30, data: getData('initial') }),
+  Item.create({ id: 40, data: getData('initial') })
+];
+
+// Number of independent SyncDAOs communicating with remote.
+var numActiveAgents = 10;
+// Number of non-sync agents just put()/remove()ing to remote.
+var numPassiveAgents = 10;
+
+// Record ids span integers: [0, numRecords - 1].
+var numRecords = 50;
+// Number of times ("rounds") to synchronously put()/remove() records.
+var numRounds = 50;
+// Number of put()/remove()s per synchronous "round".
+var opsPerRound = 20;
+// Wait time between rounds.
+var waitBetweenRounds = 1000;
+// Wait time for sync DAOs to finish synchronizing before verifying results.
+// NOTE: If this value is too low, then spurious errors will be reported.
+var waitToSettle = 10000;
+
+/**
+ * DAO setup
+ */
+
+// Underlying DAO on remote.
+var remoteDelegate = BaseDAO.create({ of: Item });
+initialData.forEach(function(data) { remoteDelegate.put(data); });
+// DAO that agents hit when talking to remote.
+var remoteDAO = VersionNoDAO.create({
+  property: Item.VERSION,
+  delegate: remoteDelegate
+});
+
+// Agents using SyncDAOs.
+var activeAgents = new Array(numActiveAgents);
+for ( var i = 0; i < numActiveAgents; i++ ) {
+  // TODO(markdittmer): Add initial unsynced data to agents.
+  activeAgents[i] = SyncDAO.create({
+    of: Item,
+    remoteDAO: remoteDAO,
+    delegate: BaseDAO.create({ of: Item }),
+    syncProperty: Item.VERSION,
+    syncRecordDAO: BaseDAO.create({ of: SyncRecord })
+  });
+}
+
+// Agents talking directly to remote.
+var passiveAgents = new Array(numPassiveAgents);
+for ( var i = 0; i < numPassiveAgents; i++ ) {
+  passiveAgents[i] = ProxyDAO.create({ delegate: remoteDAO });
+}
+
+// All the agents.
+var agents = activeAgents.concat(passiveAgents);
+
+/**
+ * Test run(s)
+ */
+
+// Setup timers for each round.
+for ( var i = 0; i < numRounds; i++ ) {
+  setTimeout(function() {
+    for ( var j = 0; j < opsPerRound; j++ ) {
+      var agentNo = Math.floor(Math.random() * agents.length);
+      var agent = agents[agentNo];
+      var op = Math.floor(Math.random() * 2) === 0 ? 'put' : 'remove';
+      agent[op](Item.create({
+        id: Math.floor(Math.random() * numRecords),
+        data: getData('agent' + agentNo)
+      }));
+    }
+  }, i * waitBetweenRounds);
+}
+
+/**
+ * Test result verification.
+ */
+
+// Setup timer for verification.
+setTimeout(function() {
+  var reference;
+
+  // Add log marker after which no DAO activity should be logged.
+  // If DAO activity is logged after this line, results should not be trusted;
+  // increase timeouts to let SyncDAOs settle.
+  console.log('DONE! (There should be no BaseDAO logs below this line)');
+
+  var p = remoteDAO.select().then(function(sink) {
+    reference = sink.array;
+  });
+  for ( var i = 0; i < activeAgents.length; i++ ) {
+    // Wait for previous round (or "reference" accumulation) before reporting on
+    // next active agent.
+    p = p.then(function(i) {
+      return activeAgents[i].select().then(function(sink) {
+        var array = sink.array;
+        if ( array.length !== reference.length )
+          console.error('Agent', i, 'has too many/few records');
+        for ( var j = 0; j < array.length; j++ ) {
+          if ( ! foam.util.equals(array[j], reference[j]) )
+            console.error('Agent', i, 'does not match reference at', j);
+        }
+      });
+    }.bind(this, i));
+  }
+}, numRounds * waitBetweenRounds + waitToSettle);


### PR DESCRIPTION
Many of these changes are aesthetic (updating documentation strings; following latest conventions for public/private method names, etc.). Largest functional changes are synchronization:

- `sync()` passes do not overlap; they wait for the previous pass to complete
- `delegate.put()/remove()` + `syncRecordDAO.put()` are transactional

These changes appear to fix issues identified in standalone SyncDAO stress test: `test/node/syncDAOStress.js`