### PR TITLE
Fix XSS vulnerability of foam.net.node.Handler

### DIFF
--- a/src/foam/net/node/Handler.js
+++ b/src/foam/net/node/Handler.js
@@ -44,6 +44,11 @@ foam.CLASS({
       this.send(res, status, JSON.stringify(json));
     },
 
+    function sendStringAsHTML(res, status, str) {
+      res.setHeader('Content-type', 'text/html; charset=utf-8');
+      this.send(res, status, foam.parsers.html.escapeString(str));
+    },
+
     function send400(req, res, error) {
       this.sendMessage(req, res, 400, 'Bad request');
       this.reportErrorMsg(req, ' Bad request: ' + error);
@@ -60,9 +65,9 @@ foam.CLASS({
     function sendMessage(req, res, status, msg) {
       if ( req.headers.accept &&
           req.headers.accept.indexOf('application/json') !== -1 ) {
-        this.sendJSON(res, status, {message:msg});
+        this.sendJSON(res, status, { message: msg });
       } else {
-        this.send(res, status, msg);
+        this.sendStringAsHTML(res, status, msg);
       }
     },
     function reportWarnMsg(req, msg) {

--- a/test/src/parsers/HTMLlib.js
+++ b/test/src/parsers/HTMLlib.js
@@ -11,15 +11,40 @@ describe('HTML Lib', function() {
     expect(lib.getHtmlEscapeChar('micro')).toBe('µ');
   });
 
+  it('getHTMLEscapeSequence should return escape sequence', function() {
+    expect(lib.getHtmlEscapeSequence('<')).toBe('lt');
+    expect(lib.getHtmlEscapeSequence('ß')).toBe('szlig');
+    expect(lib.getHtmlEscapeSequence('µ')).toBe('micro');
+  });
+
   it('unescapeString should return string with unescaped HTML entities', function() {
-    expect(lib.unescapeString('if (x &lt; 3) return true;')).toBe('if (x < 3) return true;');
-    expect(lib.unescapeString('std::vector<code> Foo;')).toBe('std::vector<code> Foo;');
-    expect(lib.unescapeString('std::vector&lt;code&gt; Foo;')).toBe('std::vector<code> Foo;');
+    expect(lib.unescapeString('if (x &lt; 3) return true;')).
+        toBe('if (x < 3) return true;');
+    expect(lib.unescapeString('std::vector<code> Foo;')).
+        toBe('std::vector<code> Foo;');
+    expect(lib.unescapeString('std::vector&lt;code&gt; Foo;')).
+        toBe('std::vector<code> Foo;');
   });
 
   it('unescapeString should not replace invalid HTML entities', function() {
     expect(lib.unescapeString('&Potato; Foo;')).toBe('&Potato; Foo;');
     expect(lib.unescapeString('&lt')).toBe('&lt');
     expect(lib.unescapeString('lt;')).toBe('lt;');
+  });
+
+  it('escapeString should return string with escaped HTML entities; unescapeString should invert escaping', function() {
+    function checkEscapeAndSymmetry(unescaped, escaped) {
+      var result = lib.escapeString(unescaped);
+      expect(result).toBe(escaped);
+      expect(lib.unescapeString(result)).toBe(unescaped);
+    }
+    checkEscapeAndSymmetry('if (x &lt; 3) return true;',
+                           '&#105;&#102;&#32;&#40;&#120;&#32;&amp;&#108;&#116;&#59;&#32;&#51;&#41;&#32;&#114;&#101;&#116;&#117;&#114;&#110;&#32;&#116;&#114;&#117;&#101;&#59;');
+    checkEscapeAndSymmetry('std::vector<code> Foo;',
+                           '&#115;&#116;&#100;&#58;&#58;&#118;&#101;&#99;&#116;&#111;&#114;&lt;&#99;&#111;&#100;&#101;&gt;&#32;&#70;&#111;&#111;&#59;');
+    checkEscapeAndSymmetry('std::vector<code> Foo;',
+                           '&#115;&#116;&#100;&#58;&#58;&#118;&#101;&#99;&#116;&#111;&#114;&lt;&#99;&#111;&#100;&#101;&gt;&#32;&#70;&#111;&#111;&#59;');
+    checkEscapeAndSymmetry('std::vector&lt;code&gt; Foo;',
+                           '&#115;&#116;&#100;&#58;&#58;&#118;&#101;&#99;&#116;&#111;&#114;&amp;&#108;&#116;&#59;&#99;&#111;&#100;&#101;&amp;&#103;&#116;&#59;&#32;&#70;&#111;&#111;&#59;');
   });
 });


### PR DESCRIPTION
Add support for HTML-escaping, and use it in error message handlers. Prior to this PR, going to `my.foam.server/<script>doEvilStuff</script>` would execute `doEvilStuff` in some browsers that (reasonably) interpreted the error response as HTML.