### PR TITLE
Java Object to Primitive Casting Support

### DIFF
--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -435,10 +435,10 @@ foam.CLASS({
       var m = info.getMethod('cast');
       m.body = 'return ( o instanceof Number ) ?'
             + '((Number)o).intValue() :'
-            + '(int)o;';
+            + '((Integer) o).intValue();';
 
       var c = info.getMethod('comparePropertyToObject');
-      c.body = 'return compareValues((int) key, get_(o));';
+      c.body = 'return compareValues(cast(key), get_(o));';
 
       return info;
     }
@@ -461,10 +461,10 @@ foam.CLASS({
       var m = info.getMethod('cast');
       m.body = 'return ( o instanceof Number ) ?'
             + '((Number)o).byteValue() :'
-            + '(byte)o;';
+            + '((Byte) o).byteValue();';
 
       var c = info.getMethod('comparePropertyToObject');
-      c.body = 'return compareValues((byte) key, get_(o));';
+      c.body = 'return compareValues(cast(key), get_(o));';
 
       return info;
     }
@@ -487,10 +487,10 @@ foam.CLASS({
       var m = info.getMethod('cast');
       m.body = 'return ( o instanceof Number ) ?'
             + '((Number)o).shortValue() :'
-            + '(short)o;';
+            + '((Short) o).shortValue();';
 
       var c = info.getMethod('comparePropertyToObject');
-      c.body = 'return compareValues((short) key, get_(o));';
+      c.body = 'return compareValues(cast(key), get_(o));';
 
       return info;
     }
@@ -513,10 +513,10 @@ foam.CLASS({
       var m = info.getMethod('cast');
       m.body = 'return ( o instanceof Number ) ?'
             + '((Number)o).longValue() :'
-            + '(long)o;';
+            + '((Long) o).longValue();';
 
       var c = info.getMethod('comparePropertyToObject');
-      c.body = 'return compareValues((long) key, get_(o));';
+      c.body = 'return compareValues(cast(key), get_(o));';
 
       return info;
     }
@@ -539,10 +539,10 @@ foam.CLASS({
       var m = info.getMethod('cast');
       m.body = 'return ( o instanceof Number ) ?'
             + '((Number)o).doubleValue() :'
-            + '(double)o;';
+            + '((Double) o).doubleValue();';
 
       var c = info.getMethod('comparePropertyToObject');
-      c.body = 'return compareValues((double) key, get_(o));';
+      c.body = 'return compareValues(cast(key), get_(o));';
 
       return info;
     }

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -926,7 +926,7 @@ foam.CLASS({
     function createJavaPropertyInfo_(cls) {
       var info = this.SUPER(cls);
       var c = info.getMethod('comparePropertyToObject');
-      c.body = 'return compareValues((boolean) key, get_(o));';
+      c.body = 'return compareValues(cast(key), get_(o));';
 
       var m = info.getMethod('cast');
       m.body = 'return ((Boolean) o).booleanValue();'

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -433,9 +433,7 @@ foam.CLASS({
     function createJavaPropertyInfo_(cls) {
       var info = this.SUPER(cls);
       var m = info.getMethod('cast');
-      m.body = 'return ( o instanceof Number ) ?'
-            + '((Number)o).intValue() :'
-            + '((Integer) o).intValue();';
+      m.body = 'return ((Number) o).intValue();';
 
       var c = info.getMethod('comparePropertyToObject');
       c.body = 'return compareValues(cast(key), get_(o));';
@@ -459,9 +457,7 @@ foam.CLASS({
     function createJavaPropertyInfo_(cls) {
       var info = this.SUPER(cls);
       var m = info.getMethod('cast');
-      m.body = 'return ( o instanceof Number ) ?'
-            + '((Number)o).byteValue() :'
-            + '((Byte) o).byteValue();';
+      m.body = 'return ((Number) o).byteValue();';
 
       var c = info.getMethod('comparePropertyToObject');
       c.body = 'return compareValues(cast(key), get_(o));';
@@ -485,9 +481,7 @@ foam.CLASS({
     function createJavaPropertyInfo_(cls) {
       var info = this.SUPER(cls);
       var m = info.getMethod('cast');
-      m.body = 'return ( o instanceof Number ) ?'
-            + '((Number)o).shortValue() :'
-            + '((Short) o).shortValue();';
+      m.body = 'return ((Number) o).shortValue();';
 
       var c = info.getMethod('comparePropertyToObject');
       c.body = 'return compareValues(cast(key), get_(o));';
@@ -511,9 +505,7 @@ foam.CLASS({
     function createJavaPropertyInfo_(cls) {
       var info = this.SUPER(cls);
       var m = info.getMethod('cast');
-      m.body = 'return ( o instanceof Number ) ?'
-            + '((Number)o).longValue() :'
-            + '((Long) o).longValue();';
+      m.body = 'return ((Number) o).longValue();';
 
       var c = info.getMethod('comparePropertyToObject');
       c.body = 'return compareValues(cast(key), get_(o));';
@@ -537,9 +529,7 @@ foam.CLASS({
     function createJavaPropertyInfo_(cls) {
       var info = this.SUPER(cls);
       var m = info.getMethod('cast');
-      m.body = 'return ( o instanceof Number ) ?'
-            + '((Number)o).doubleValue() :'
-            + '((Double) o).doubleValue();';
+      m.body = 'return ((Number) o).doubleValue();';
 
       var c = info.getMethod('comparePropertyToObject');
       c.body = 'return compareValues(cast(key), get_(o));';


### PR DESCRIPTION
Necessary to avoid invalid cast errors from a nullable Object to a primitive.