### PR TITLE
ScrollDAOView refactor

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -99,6 +99,7 @@ FOAM_FILES([
   { name: "foam/u2/AttrSlot" },
   { name: "foam/u2/ViewSpec" },
   { name: "foam/u2/Element" },
+  { name: "foam/u2/RowFormatter" },
 //  { name: "foam/u2/AttrSlot", flags: ['web'] },
 //  { name: "foam/u2/Element", flags: ['web'] },
   { name: "foam/u2/ProgressView", flags: ['web'] },

--- a/src/foam/u2/RowFormatter.js
+++ b/src/foam/u2/RowFormatter.js
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2017 The FOAM Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+foam.INTERFACE({
+  package: 'foam.u2',
+  name: 'RowFormatter',
+
+  documentation: 'Base class for markup-generating row formatters.',
+
+  methods: [
+    function format(data) {}
+  ]
+});


### PR DESCRIPTION
Highlights:

- Decouple data fetch and row recycling. This allows for occassionally fetching
  large batches while aggressively updating scroll row anchor.

- Use data => htmlMarkupString function (a `RowFormatter`) to replace row
  contents immediately (no U2 Elements). This means that rows cannot respond
  to U2 events (at least, not via U2), but it significantly improves scroll
  performance.