### PR TITLE
Change the way isEnabledFor calls isEnabled in Action.js

### DIFF
--- a/src/foam/core/Action.js
+++ b/src/foam/core/Action.js
@@ -112,7 +112,7 @@ foam.CLASS({
   methods: [
     function isEnabledFor(data) {
       return this.isEnabled ?
-        foam.Function.withArgs(this.isEnabled, data) :
+        data.slot(this.isEnabled).get() :
         true;
     },
 


### PR DESCRIPTION
Without this fix, using subslots in an action's isEnabled doesn't work right.

e.g.
isEnabled: function(foo$bar) {
  // Stuff
}

(under the hood, foo$bar turns into this.foo$.dot('bar').get())

If data is ever not an FObject this will be problematic but I'm not sure this can ever happen. Alternatively, this fix can go somewhere in foam.Function.withArgs but I didn't want to put FObject specific stuff in there.