### PR TITLE
Some UI fixes on prop views

### DIFF
--- a/src/foam/u2/CheckBox.js
+++ b/src/foam/u2/CheckBox.js
@@ -30,7 +30,7 @@ foam.CLASS({
     {
       class: 'Boolean',
       name: 'showLabel',
-      value: true
+      expression: function(label) { return !!label },
     },
     { 
       class: 'String', 
@@ -53,6 +53,11 @@ foam.CLASS({
           }.bind(this))
         .end();
       }
+    },
+    function updateMode_(mode) {
+      var disabled = mode === foam.u2.DisplayMode.RO ||
+                     mode === foam.u2.DisplayMode.DISABLED;
+      this.setAttribute('disabled', disabled);
     },
     function link() {
       this.data$.linkTo(this.attrSlot('checked'));

--- a/src/foam/u2/CheckBox.js
+++ b/src/foam/u2/CheckBox.js
@@ -30,7 +30,7 @@ foam.CLASS({
     {
       class: 'Boolean',
       name: 'showLabel',
-      expression: function(label) { return !!label },
+      factory: function() { return !!this.label },
     },
     { 
       class: 'String', 

--- a/src/foam/u2/EnumView.js
+++ b/src/foam/u2/EnumView.js
@@ -25,6 +25,7 @@ foam.CLASS({
 
   methods: [
     function fromProperty(p) {
+      this.SUPER(p);
       if ( ! this.of ) this.of = p.of;
     }
   ]

--- a/src/foam/u2/FloatView.js
+++ b/src/foam/u2/FloatView.js
@@ -52,9 +52,8 @@ foam.CLASS({
     },
 
     function fromProperty(p) {
+      this.SUPER(p);
       this.precision = p.precision;
-      this.min = p.min;
-      this.max = p.max;
     },
 
     function formatNumber(val) {

--- a/src/foam/u2/IntView.js
+++ b/src/foam/u2/IntView.js
@@ -45,6 +45,7 @@ foam.CLASS({
     },
 
     function fromProperty(p) {
+      this.SUPER(p);
       this.min = p.min;
       this.max = p.max;
     }


### PR DESCRIPTION
Makes CheckBox, EnumView, and IntView respect the visibility of the property that they're views of. Also change the default value of CheckBox's showLabel to be true if a label
is present instead of always true.