### PR TITLE
Use foam.lookup() for core services in (potential) box contexts

### DIFF
--- a/src/foam/box/MessagePortBox.js
+++ b/src/foam/box/MessagePortBox.js
@@ -24,8 +24,7 @@ foam.CLASS({
   requires: [
     'foam.box.RawMessagePortBox',
     'foam.box.RegisterSelfMessage',
-    'foam.box.Message',
-    'foam.json.Outputter'
+    'foam.box.Message'
   ],
 
   imports: [
@@ -60,13 +59,16 @@ foam.CLASS({
       factory: function() {
         // NOTE: Configuration must be consistent with parser in
         // foam.messageport.MessagePortService.
-        return this.Outputter.create({
+        //
+        // Use default FOAM implementation of Outputter. Do not attempt to
+        // lookup sensitive "foam.json.Outputter" class in box context.
+        return foam.lookup('foam.json.Outputter').create({
           pretty: false,
           formatDatesAsNumbers: true,
           outputDefaultValues: false,
           strict: true,
           propertyPredicate: function(o, p) { return ! p.networkTransient; }
-        });
+        }, this);
       }
     }
   ]

--- a/src/foam/box/RawMessagePortBox.js
+++ b/src/foam/box/RawMessagePortBox.js
@@ -20,8 +20,6 @@ foam.CLASS({
   name: 'RawMessagePortBox',
   implements: [ 'foam.box.Box' ],
 
-  requires: [ 'foam.json.Outputter' ],
-
   properties: [
     {
       name: 'port'
@@ -33,13 +31,16 @@ foam.CLASS({
       factory: function() {
         // NOTE: Configuration must be consistent with parser in
         // foam.messageport.MessagePortService.
-        return this.Outputter.create({
+        //
+        // Use default FOAM implementation of Outputter. Do not attempt to
+        // lookup sensitive "foam.json.Outputter" class in box context.
+        return foam.lookup('foam.json.Outputter').create({
           pretty: false,
           formatDatesAsNumbers: true,
           outputDefaultValues: false,
           strict: true,
           propertyPredicate: function(o, p) { return ! p.networkTransient; }
-        });
+        }, this);
       }
     }
   ],

--- a/src/foam/box/SocketConnectBox.js
+++ b/src/foam/box/SocketConnectBox.js
@@ -21,7 +21,6 @@ foam.CLASS({
   extends: 'foam.box.PromisedBox',
 
   requires: [
-    'foam.net.node.Socket',
     'foam.box.RawSocketBox'
   ],
 
@@ -32,9 +31,12 @@ foam.CLASS({
     {
       name: 'delegate',
       factory: function() {
-        return this.Socket.create().connectTo(this.address).then(function(s) {
-          return this.RawSocketBox.create({ socket: s });
-        }.bind(this));
+        // Use default FOAM implementation of Socket. Do not attempt to lookup
+        // sensitive "foam.net.node.Socket" class in box context.
+        return foam.lookup('foam.net.node.Socket').create(null, this).
+            connectTo(this.address).then(function(s) {
+              return this.RawSocketBox.create({ socket: s });
+            }.bind(this));
       }
     }
   ]

--- a/src/lib/node/net.js
+++ b/src/lib/node/net.js
@@ -247,10 +247,7 @@ foam.CLASS({
     'socketService'
   ],
 
-  requires: [
-    'foam.box.RegisterSelfMessage',
-    'foam.json.Outputter'
-  ],
+  requires: [ 'foam.box.RegisterSelfMessage' ],
 
   topics: [
     'message',
@@ -300,13 +297,15 @@ foam.CLASS({
       of: 'foam.json.Outputter',
       name: 'outputter',
       factory: function() {
-        return this.Outputter.create({
+        // Use default FOAM implementation of Outputter. Do not attempt to
+        // lookup sensitive "foam.json.Outputter" class in box context.
+        return foam.lookup('foam.json.Outputter').create({
           pretty: false,
           formatDatesAsNumbers: true,
           outputDefaultValues: false,
           strict: true,
           propertyPredicate: function(o, p) { return ! p.networkTransient; }
-        });
+        }, this);
       }
     }
   ],

--- a/src/lib/web/net.js
+++ b/src/lib/web/net.js
@@ -19,8 +19,6 @@ foam.CLASS({
   package: 'foam.net.web',
   name: 'WebSocket',
 
-  requires: [ 'foam.json.Outputter' ],
-
   topics: [
     'message',
     'connected',
@@ -40,13 +38,15 @@ foam.CLASS({
       of: 'foam.json.Outputter',
       name: 'outputter',
       factory: function() {
-        return this.Outputter.create({
+        // Use default FOAM implementation of Outputter. Do not attempt to
+        // lookup sensitive "foam.json.Outputter" class in box context.
+        return foam.lookup('foam.json.Outputter').create({
           pretty: false,
           formatDatesAsNumbers: true,
           outputDefaultValues: false,
           strict: true,
           propertyPredicate: function(o, p) { return ! p.networkTransient; }
-        });
+        }, this);
       }
     }
   ],


### PR DESCRIPTION
A `foam.box.Context` that uses a `foam.box.ClassWhitelistContext` should not
be forced to whitelist core service classes (that do not need to be
(de)serialized and transported) in order to work. This change eliminates
`foam.net.node.Socket` and `foam.json.Outputter` instantiations that are
often invoked in a `foam.box.Context`. These instantiations now use
`foam.lookup()` instead.