### PR TITLE
ErrorReportingPStream

### DIFF
--- a/src/foam/lib/parse/ErrorReportingNodePStream.java
+++ b/src/foam/lib/parse/ErrorReportingNodePStream.java
@@ -10,26 +10,28 @@ public class ErrorReportingNodePStream
     extends ProxyPStream
 {
   protected int pos;
+  protected ErrorReportingPStream root;
   protected ErrorReportingNodePStream tail_ = null;
 
-  public ErrorReportingNodePStream(PStream delegate) {
-    this(delegate, 0);
+  public ErrorReportingNodePStream(ErrorReportingPStream root, PStream delegate) {
+    this(root, delegate, 0);
   }
 
-  public ErrorReportingNodePStream(PStream delegate, int pos) {
+  public ErrorReportingNodePStream(ErrorReportingPStream root, PStream delegate, int pos) {
     setDelegate(delegate);
+    this.root = root;
     this.pos = pos;
   }
 
   @Override
   public PStream tail() {
-    if ( tail_ == null ) tail_ = new ErrorReportingNodePStream(super.tail(), pos + 1);
+    if ( tail_ == null ) tail_ = new ErrorReportingNodePStream(root, super.tail(), pos + 1);
     return tail_;
   }
 
   @Override
   public PStream setValue(Object value) {
-    return new ErrorReportingNodePStream(super.setValue(value), pos);
+    return new ErrorReportingNodePStream(root, super.setValue(value), pos);
   }
 
   @Override

--- a/src/foam/lib/parse/ErrorReportingNodePStream.java
+++ b/src/foam/lib/parse/ErrorReportingNodePStream.java
@@ -13,7 +13,7 @@ package foam.lib.parse;
 public class ErrorReportingNodePStream
     extends ProxyPStream
 {
-  protected int pos;
+  protected int pos_;
   protected ErrorReportingPStream root_;
   protected ErrorReportingNodePStream tail_ = null;
 
@@ -24,18 +24,18 @@ public class ErrorReportingNodePStream
   public ErrorReportingNodePStream(ErrorReportingPStream root, PStream delegate, int pos) {
     setDelegate(delegate);
     this.root_ = root;
-    this.pos = pos;
+    this.pos_ = pos;
   }
 
   @Override
   public PStream tail() {
-    if ( tail_ == null ) tail_ = new ErrorReportingNodePStream(root_, super.tail(), pos + 1);
+    if ( tail_ == null ) tail_ = new ErrorReportingNodePStream(root_, super.tail(), pos_ + 1);
     return tail_;
   }
 
   @Override
   public PStream setValue(Object value) {
-    return new ErrorReportingNodePStream(root_, super.setValue(value), pos);
+    return new ErrorReportingNodePStream(root_, super.setValue(value), pos_);
   }
 
   @Override

--- a/src/foam/lib/parse/ErrorReportingNodePStream.java
+++ b/src/foam/lib/parse/ErrorReportingNodePStream.java
@@ -14,7 +14,7 @@ public class ErrorReportingNodePStream
     extends ProxyPStream
 {
   protected int pos;
-  protected ErrorReportingPStream root;
+  protected ErrorReportingPStream root_;
   protected ErrorReportingNodePStream tail_ = null;
 
   public ErrorReportingNodePStream(ErrorReportingPStream root, PStream delegate) {
@@ -23,26 +23,26 @@ public class ErrorReportingNodePStream
 
   public ErrorReportingNodePStream(ErrorReportingPStream root, PStream delegate, int pos) {
     setDelegate(delegate);
-    this.root = root;
+    this.root_ = root;
     this.pos = pos;
   }
 
   @Override
   public PStream tail() {
-    if ( tail_ == null ) tail_ = new ErrorReportingNodePStream(root, super.tail(), pos + 1);
+    if ( tail_ == null ) tail_ = new ErrorReportingNodePStream(root_, super.tail(), pos + 1);
     return tail_;
   }
 
   @Override
   public PStream setValue(Object value) {
-    return new ErrorReportingNodePStream(root, super.setValue(value), pos);
+    return new ErrorReportingNodePStream(root_, super.setValue(value), pos);
   }
 
   @Override
   public PStream apply(Parser ps, ParserContext x) {
     PStream result = ps.parse(this, x);
     if ( result == null ) {
-      root.report(this, ps, x);
+      root_.report(this, ps, x);
     }
     return result;
   }

--- a/src/foam/lib/parse/ErrorReportingNodePStream.java
+++ b/src/foam/lib/parse/ErrorReportingNodePStream.java
@@ -38,7 +38,7 @@ public class ErrorReportingNodePStream
   public PStream apply(Parser ps, ParserContext x) {
     PStream result = ps.parse(this, x);
     if ( result == null ) {
-      root.report(this, ps);
+      root.report(this, ps, x);
     }
     return result;
   }

--- a/src/foam/lib/parse/ErrorReportingNodePStream.java
+++ b/src/foam/lib/parse/ErrorReportingNodePStream.java
@@ -6,6 +6,10 @@
 
 package foam.lib.parse;
 
+/**
+ * This is a PStream decorator that listens for errors when parsing and reports them
+ * to the root ErrorReportingPStream
+ */
 public class ErrorReportingNodePStream
     extends ProxyPStream
 {

--- a/src/foam/lib/parse/ErrorReportingNodePStream.java
+++ b/src/foam/lib/parse/ErrorReportingNodePStream.java
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2017 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package foam.lib.parse;
+
+public class ErrorReportingNodePStream
+    extends ProxyPStream
+{
+  protected int pos;
+  protected ErrorReportingNodePStream tail_ = null;
+
+  public ErrorReportingNodePStream(PStream delegate) {
+    this(delegate, 0);
+  }
+
+  public ErrorReportingNodePStream(PStream delegate, int pos) {
+    setDelegate(delegate);
+    this.pos = pos;
+  }
+
+  @Override
+  public PStream tail() {
+    if ( tail_ == null ) tail_ = new ErrorReportingNodePStream(super.tail(), pos + 1);
+    return tail_;
+  }
+
+  @Override
+  public PStream setValue(Object value) {
+    return new ErrorReportingNodePStream(super.setValue(value), pos);
+  }
+
+  @Override
+  public PStream apply(Parser ps, ParserContext x) {
+    return super.apply(ps, x);
+  }
+}

--- a/src/foam/lib/parse/ErrorReportingNodePStream.java
+++ b/src/foam/lib/parse/ErrorReportingNodePStream.java
@@ -36,6 +36,10 @@ public class ErrorReportingNodePStream
 
   @Override
   public PStream apply(Parser ps, ParserContext x) {
-    return super.apply(ps, x);
+    PStream result = ps.parse(this, x);
+    if ( result == null ) {
+      root.report(this, ps);
+    }
+    return result;
   }
 }

--- a/src/foam/lib/parse/ErrorReportingPStream.java
+++ b/src/foam/lib/parse/ErrorReportingPStream.java
@@ -84,6 +84,7 @@ public class ErrorReportingPStream
   }
 
   public void reportValidCharacter(Character character) {
+    System.out.println("report valid char = " + character);
     validCharacters.add(character);
   }
 
@@ -107,7 +108,9 @@ public class ErrorReportingPStream
         .append(errStream.pos)
         .append("\n")
         .append("Valid characters include: ")
-        .append(validCharacters.stream().map(Object::toString).collect(Collectors.joining(",")));
+        .append(validCharacters.stream()
+            .map(e -> "'" + e.toString() + "'")
+            .collect(Collectors.joining(",")));
 
     return builder.toString();
   }

--- a/src/foam/lib/parse/ErrorReportingPStream.java
+++ b/src/foam/lib/parse/ErrorReportingPStream.java
@@ -34,8 +34,12 @@ public class ErrorReportingPStream
   }
 
   @Override
-  public PStream apply(Parser ps, ParserContext x) {
-    return ps.parse(this, x);
+  public PStream apply(Parser parser, ParserContext x) {
+    PStream result = parser.parse(this, x);
+    if ( result == null ) {
+      this.report(new ErrorReportingNodePStream(this, getDelegate(), pos), parser);
+    }
+    return result;
   }
 
   public void report(ErrorReportingNodePStream ernps, Parser parser) {

--- a/src/foam/lib/parse/ErrorReportingPStream.java
+++ b/src/foam/lib/parse/ErrorReportingPStream.java
@@ -34,6 +34,10 @@ public class ErrorReportingPStream
 
   @Override
   public PStream apply(Parser ps, ParserContext x) {
-    return super.apply(ps, x);
+    return ps.parse(this, x);
+  }
+
+  public void report(ErrorReportingNodePStream ernps, Parser parser) {
+    pos = Math.max(pos, ernps.pos);
   }
 }

--- a/src/foam/lib/parse/ErrorReportingPStream.java
+++ b/src/foam/lib/parse/ErrorReportingPStream.java
@@ -84,7 +84,6 @@ public class ErrorReportingPStream
   }
 
   public void reportValidCharacter(Character character) {
-    System.out.println("report valid char = " + character);
     validCharacters.add(character);
   }
 

--- a/src/foam/lib/parse/ErrorReportingPStream.java
+++ b/src/foam/lib/parse/ErrorReportingPStream.java
@@ -20,20 +20,6 @@ public class ErrorReportingPStream
       .mapToObj(i -> (char) i)
       .collect(Collectors.toList());
 
-  protected ThreadLocal<StringBuilder> sb = new ThreadLocal<StringBuilder>() {
-    @Override
-    protected StringBuilder initialValue() {
-      return new StringBuilder();
-    }
-
-    @Override
-    public StringBuilder get() {
-      StringBuilder b = super.get();
-      b.setLength(0);
-      return b;
-    }
-  };
-
   protected Parser errParser = null;
   protected ParserContext errContext = null;
   protected ErrorReportingNodePStream errStream = null;
@@ -94,17 +80,11 @@ public class ErrorReportingPStream
       trap.apply(errParser, errContext);
     }
 
-    StringBuilder builder = sb.get()
-        .append("Invalid character '")
-        .append(invalid)
-        .append("' found at ")
-        .append(errStream.pos)
-        .append("\n")
-        .append("Valid characters include: ")
-        .append(validCharacters.stream()
+    return "Invalid character '" + invalid +
+        "' found at " + errStream.pos + "\n" +
+        "Valid characters include: " +
+        validCharacters.stream()
             .map(e -> "'" + e.toString() + "'")
-            .collect(Collectors.joining(",")));
-
-    return builder.toString();
+            .collect(Collectors.joining(","));
   }
 }

--- a/src/foam/lib/parse/ErrorReportingPStream.java
+++ b/src/foam/lib/parse/ErrorReportingPStream.java
@@ -38,30 +38,24 @@ public class ErrorReportingPStream
   protected ParserContext errContext = null;
   protected ErrorReportingNodePStream errStream = null;
 
-  protected int pos;
   protected ErrorReportingNodePStream tail_ = null;
   protected Set<Character> validCharacters = new HashSet<>();
 
   public ErrorReportingPStream(PStream delegate) {
-    this(delegate, 0);
-  }
-
-  public ErrorReportingPStream(PStream delegate, int pos) {
     setDelegate(delegate);
-    this.pos = pos;
   }
 
   @Override
   public PStream tail() {
     // tail becomes new node with increased position
-    if ( tail_ == null ) tail_ = new ErrorReportingNodePStream(this, super.tail(), pos + 1);
+    if ( tail_ == null ) tail_ = new ErrorReportingNodePStream(this, super.tail(), 1);
     return tail_;
   }
 
   @Override
   public PStream setValue(Object value) {
     // create a new node
-    return new ErrorReportingNodePStream(this, super.setValue(value), pos);
+    return new ErrorReportingNodePStream(this, super.setValue(value), 0);
   }
 
   @Override
@@ -69,7 +63,7 @@ public class ErrorReportingPStream
     PStream result = parser.parse(this, x);
     if ( result == null ) {
       // if result is null then self report
-      this.report(new ErrorReportingNodePStream(this, getDelegate(), pos), parser, x);
+      this.report(new ErrorReportingNodePStream(this, getDelegate(), 0), parser, x);
     }
     return result;
   }

--- a/src/foam/lib/parse/ErrorReportingPStream.java
+++ b/src/foam/lib/parse/ErrorReportingPStream.java
@@ -50,7 +50,7 @@ public class ErrorReportingPStream
 
   public void report(ErrorReportingNodePStream ernps, Parser parser, ParserContext x) {
     // get the report with the furthest position
-    if ( errStream == null || errStream.pos <= ernps.pos ) {
+    if ( errStream == null || errStream.pos_ <= ernps.pos_ ) {
       errStream = ernps;
       errParser = parser;
       errContext = x;
@@ -73,7 +73,7 @@ public class ErrorReportingPStream
     }
 
     return "Invalid character '" + invalid +
-        "' found at " + errStream.pos + "\n" +
+        "' found at " + errStream.pos_ + "\n" +
         "Valid characters include: " +
         validCharacters.stream()
             .map(e -> "'" + e.toString() + "'")

--- a/src/foam/lib/parse/ErrorReportingPStream.java
+++ b/src/foam/lib/parse/ErrorReportingPStream.java
@@ -10,7 +10,7 @@ public class ErrorReportingPStream
     extends ProxyPStream
 {
   protected int pos;
-  protected char head;
+  protected ErrorReportingNodePStream err = null;
   protected ErrorReportingNodePStream tail_ = null;
 
   public ErrorReportingPStream(PStream delegate) {
@@ -43,11 +43,12 @@ public class ErrorReportingPStream
   }
 
   public void report(ErrorReportingNodePStream ernps, Parser parser) {
-    pos = Math.max(pos, ernps.pos);
-    head = ernps.head();
+    if ( err == null || err.pos < ernps.pos )
+      err = ernps;
   }
 
   public String getMessage() {
-    return "Invalid character '" + head + "' found at " + pos;
+    String invalid = ( err.valid() ) ? String.valueOf(err.head()) : "EOF";
+    return "Invalid character '" + invalid + "' found at " + err.pos;
   }
 }

--- a/src/foam/lib/parse/ErrorReportingPStream.java
+++ b/src/foam/lib/parse/ErrorReportingPStream.java
@@ -76,7 +76,7 @@ public class ErrorReportingPStream
 
   public void report(ErrorReportingNodePStream ernps, Parser parser, ParserContext x) {
     // get the report with the furthest position
-    if ( errStream == null || errStream.pos < ernps.pos ) {
+    if ( errStream == null || errStream.pos <= ernps.pos ) {
       errStream = ernps;
       errParser = parser;
       errContext = x;

--- a/src/foam/lib/parse/ErrorReportingPStream.java
+++ b/src/foam/lib/parse/ErrorReportingPStream.java
@@ -10,6 +10,7 @@ public class ErrorReportingPStream
     extends ProxyPStream
 {
   protected int pos;
+  protected char head;
   protected ErrorReportingNodePStream tail_ = null;
 
   public ErrorReportingPStream(PStream delegate) {
@@ -39,5 +40,10 @@ public class ErrorReportingPStream
 
   public void report(ErrorReportingNodePStream ernps, Parser parser) {
     pos = Math.max(pos, ernps.pos);
+    head = ernps.head();
+  }
+
+  public String getMessage() {
+    return "Invalid character '" + head + "' found at " + pos;
   }
 }

--- a/src/foam/lib/parse/ErrorReportingPStream.java
+++ b/src/foam/lib/parse/ErrorReportingPStream.java
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2017 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package foam.lib.parse;
+
+public class ErrorReportingPStream
+    extends ProxyPStream
+{
+  protected int pos;
+  protected ErrorReportingNodePStream tail_ = null;
+
+  public ErrorReportingPStream(PStream delegate) {
+    this(delegate, 0);
+  }
+
+  public ErrorReportingPStream(PStream delegate, int pos) {
+    setDelegate(delegate);
+    this.pos = pos;
+  }
+
+  @Override
+  public PStream tail() {
+    if ( tail_ == null ) tail_ = new ErrorReportingNodePStream(super.tail(), pos + 1);
+    return tail_;
+  }
+
+  @Override
+  public PStream setValue(Object value) {
+    return new ErrorReportingNodePStream(super.setValue(value), pos);
+  }
+
+  @Override
+  public PStream apply(Parser ps, ParserContext x) {
+    return super.apply(ps, x);
+  }
+}

--- a/src/foam/lib/parse/ErrorReportingPStream.java
+++ b/src/foam/lib/parse/ErrorReportingPStream.java
@@ -35,8 +35,7 @@ public class ErrorReportingPStream
 
   @Override
   public PStream apply(Parser ps, ParserContext x) {
-    PStream result = ps.parse(this, x);
-    return ( result == null ) ? null : new ErrorReportingPStream(result);
+    return ps.parse(this, x);
   }
 
   public void report(ErrorReportingNodePStream ernps, Parser parser) {

--- a/src/foam/lib/parse/ErrorReportingPStream.java
+++ b/src/foam/lib/parse/ErrorReportingPStream.java
@@ -7,18 +7,12 @@
 package foam.lib.parse;
 
 import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 public class ErrorReportingPStream
     extends ProxyPStream
 {
-  public static final List<Character> ASCII_CHARS = IntStream.rangeClosed(0, 255)
-      .mapToObj(i -> (char) i)
-      .collect(Collectors.toList());
 
   protected Parser errParser = null;
   protected ParserContext errContext = null;
@@ -73,10 +67,8 @@ public class ErrorReportingPStream
 
     // get a list of valid characters
     TrapPStream trap = new TrapPStream(this);
-    Iterator i = ASCII_CHARS.iterator();
-    while ( i.hasNext() ) {
-      Character character = (Character) i.next();
-      trap.setHead(character);
+    for ( int i = 0; i <= 255; i++ ) {
+      trap.setHead((char) i);
       trap.apply(errParser, errContext);
     }
 

--- a/src/foam/lib/parse/ErrorReportingPStream.java
+++ b/src/foam/lib/parse/ErrorReportingPStream.java
@@ -85,7 +85,6 @@ public class ErrorReportingPStream
       trap.setHead(character);
       trap.apply(errParser, errContext);
     }
-    
     return "Invalid character '" + invalid + "' found at " + errStream.pos;
   }
 }

--- a/src/foam/lib/parse/ErrorReportingPStream.java
+++ b/src/foam/lib/parse/ErrorReportingPStream.java
@@ -23,13 +23,13 @@ public class ErrorReportingPStream
 
   @Override
   public PStream tail() {
-    if ( tail_ == null ) tail_ = new ErrorReportingNodePStream(super.tail(), pos + 1);
+    if ( tail_ == null ) tail_ = new ErrorReportingNodePStream(this, super.tail(), pos + 1);
     return tail_;
   }
 
   @Override
   public PStream setValue(Object value) {
-    return new ErrorReportingNodePStream(super.setValue(value), pos);
+    return new ErrorReportingNodePStream(this, super.setValue(value), pos);
   }
 
   @Override

--- a/src/foam/lib/parse/ErrorReportingPStream.java
+++ b/src/foam/lib/parse/ErrorReportingPStream.java
@@ -35,7 +35,8 @@ public class ErrorReportingPStream
 
   @Override
   public PStream apply(Parser ps, ParserContext x) {
-    return ps.parse(this, x);
+    PStream result = ps.parse(this, x);
+    return ( result == null ) ? null : new ErrorReportingPStream(result);
   }
 
   public void report(ErrorReportingNodePStream ernps, Parser parser) {

--- a/src/foam/lib/parse/InvalidPStream.java
+++ b/src/foam/lib/parse/InvalidPStream.java
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2017 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package foam.lib.parse;
+
+public class InvalidPStream
+    implements PStream
+{
+  private static InvalidPStream instance_ = null;
+  public static InvalidPStream instance() {
+    if ( instance_ == null ) {
+      instance_ = new InvalidPStream();
+    }
+    return instance_;
+  }
+
+  private InvalidPStream() {}
+
+  @Override
+  public char head() {
+    return 0;
+  }
+
+  @Override
+  public boolean valid() {
+    return false;
+  }
+
+  @Override
+  public PStream tail() {
+    return null;
+  }
+
+  @Override
+  public Object value() {
+    return null;
+  }
+
+  @Override
+  public PStream setValue(Object value) {
+    return null;
+  }
+
+  @Override
+  public String substring(PStream end) {
+    return null;
+  }
+
+  @Override
+  public PStream apply(Parser ps, ParserContext x) {
+    return null;
+  }
+}

--- a/src/foam/lib/parse/TracingPStream.java
+++ b/src/foam/lib/parse/TracingPStream.java
@@ -22,10 +22,6 @@ public class TracingPStream
   protected PrintWriter writer;
   protected TracingPStream tail_ = null;
 
-  public TracingPStream() {
-    this(null);
-  }
-
   public TracingPStream(PStream delegate) {
     this(delegate, new PrintWriter(System.out), 0, 0);
   }

--- a/src/foam/lib/parse/TrapPStream.java
+++ b/src/foam/lib/parse/TrapPStream.java
@@ -6,6 +6,9 @@
 
 package foam.lib.parse;
 
+/**
+ * This PStream is used to test against a single character to check if the parser accepts it or not
+ */
 public class TrapPStream
     implements PStream
 {

--- a/src/foam/lib/parse/TrapPStream.java
+++ b/src/foam/lib/parse/TrapPStream.java
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2017 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package foam.lib.parse;
+
+public class TrapPStream
+    implements PStream
+{
+  protected ErrorReportingPStream root;
+  protected Character head;
+
+  public TrapPStream(ErrorReportingPStream root) {
+    this(root, null);
+  }
+
+  public TrapPStream(ErrorReportingPStream root, Character head) {
+    this.root = root;
+    this.head = head;
+  }
+
+  @Override
+  public char head() {
+    return this.head;
+  }
+
+  public void setHead(char head) {
+    this.head = head;
+  }
+
+  @Override
+  public boolean valid() {
+    return true;
+  }
+
+  @Override
+  public PStream tail() {
+    root.reportValidCharacter(head);
+    return InvalidPStream.instance();
+  }
+
+  @Override
+  public Object value() {
+    return null;
+  }
+
+  @Override
+  public PStream setValue(Object value) {
+    return this;
+  }
+
+  @Override
+  public String substring(PStream end) {
+    return null;
+  }
+
+  @Override
+  public PStream apply(Parser parser, ParserContext x) {
+    return parser.parse(this, x);
+  }
+}


### PR DESCRIPTION
Added ErrorReportingPStream which is able to listen for any errors that the parser throws and can return a message containing the invalid character, position, and a list of characters that would have been accepted. There is a root ErrorReportingPStream which creates ErrorReportingNodePStream's that report to it whenever an error occurs.

Added a TrapPStream which can be used to see whether or not a character would be accepted by a parser. It also reports the valid character to the ErrorReportingPStream.

Added InvalidPStream which is a Singleton PStream in which the valid() function always returns false.

**Example printout of error:**
```
Invalid character '"' found at 0
Valid characters include: '{'
```