### PR TITLE
JDAO Error reporting

### DIFF
--- a/src/foam/dao/JDAO.java
+++ b/src/foam/dao/JDAO.java
@@ -10,21 +10,23 @@ import foam.core.ClassInfo;
 import foam.core.Detachable;
 import foam.core.FObject;
 import foam.core.X;
+import foam.lib.json.ExprParser;
 import foam.lib.json.JournalParser;
 import foam.lib.json.Outputter;
+import foam.lib.parse.*;
 import foam.mlang.order.Comparator;
 import foam.mlang.predicate.Predicate;
 import java.io.*;
 
 public class JDAO
-  extends ProxyDAO
+    extends ProxyDAO
 {
   protected final File           file_;
   protected final Outputter      outputter_ = new Outputter();
   protected final BufferedWriter out_;
 
   public JDAO(ClassInfo classInfo, String filename)
-    throws IOException
+      throws IOException
   {
     this(new MapDAO().setOf(classInfo), filename);
   }
@@ -41,7 +43,7 @@ public class JDAO
   }
 
   protected void loadJournal()
-    throws IOException
+      throws IOException
   {
     JournalParser  journalParser = new JournalParser();
     BufferedReader br            = new BufferedReader(new FileReader(file_));
@@ -51,12 +53,14 @@ public class JDAO
 
       try {
         char operation = line.charAt(0);
+        // remove first two characters and last character
+        line = line.trim().substring(2, line.trim().length() - 1);
 
         switch ( operation ) {
           case 'p':
             FObject object = journalParser.parseObject(line);
             if ( object == null ) {
-              System.err.println("Journal Error, unable to parse: " + line);
+              System.err.println(getErrorMessage(line));
             } else {
               getDelegate().put(object);
             }
@@ -65,7 +69,7 @@ public class JDAO
           case 'r':
             Object id = journalParser.parseObjectId(line);
             if ( id == null ) {
-              System.err.println("Journal Error, unable to parse: " + line);
+              System.err.println(getErrorMessage(line));
             } else {
               getDelegate().remove(getDelegate().find(id));
             }
@@ -77,6 +81,24 @@ public class JDAO
     }
 
     br.close();
+  }
+
+  /**
+   * Gets the result of a failed parsing of a journal line
+   * @param line the line that was failed to be parse
+   * @return the error message
+   */
+  protected String getErrorMessage(String line) {
+    Parser parser = new ExprParser();
+    PStream ps = new StringPStream();
+    ParserContext x = new ParserContextImpl();
+
+    ((StringPStream) ps).setString(line);
+    x.set("X", getX());
+
+    ErrorReportingPStream eps = new ErrorReportingPStream(ps);
+    ps = eps.apply(parser, x);
+    return eps.getMessage();
   }
 
   /**

--- a/src/foam/dao/JDAO.java
+++ b/src/foam/dao/JDAO.java
@@ -57,7 +57,7 @@ public class JDAO
           case 'p':
             FObject object = journalParser.parseObject(line);
             if ( object == null ) {
-              System.err.println(getErrorMessage(line));
+              System.err.println(getParsingErrorMessage(line));
             } else {
               getDelegate().put(object);
             }
@@ -66,7 +66,7 @@ public class JDAO
           case 'r':
             Object id = journalParser.parseObjectId(line);
             if ( id == null ) {
-              System.err.println(getErrorMessage(line));
+              System.err.println(getParsingErrorMessage(line));
             } else {
               getDelegate().remove(getDelegate().find(id));
             }
@@ -85,7 +85,7 @@ public class JDAO
    * @param line the line that was failed to be parse
    * @return the error message
    */
-  protected String getErrorMessage(String line) {
+  protected String getParsingErrorMessage(String line) {
     Parser parser = new ExprParser();
     PStream ps = new StringPStream();
     ParserContext x = new ParserContextImpl();

--- a/src/foam/dao/JDAO.java
+++ b/src/foam/dao/JDAO.java
@@ -6,10 +6,7 @@
 
 package foam.dao;
 
-import foam.core.ClassInfo;
-import foam.core.Detachable;
-import foam.core.FObject;
-import foam.core.X;
+import foam.core.*;
 import foam.lib.json.ExprParser;
 import foam.lib.json.JournalParser;
 import foam.lib.json.Outputter;
@@ -94,7 +91,7 @@ public class JDAO
     ParserContext x = new ParserContextImpl();
 
     ((StringPStream) ps).setString(line);
-    x.set("X", getX());
+    x.set("X", ( getX() == null ) ? new ProxyX() : getX());
 
     ErrorReportingPStream eps = new ErrorReportingPStream(ps);
     ps = eps.apply(parser, x);

--- a/src/foam/lib/json/JournalParser.java
+++ b/src/foam/lib/json/JournalParser.java
@@ -29,13 +29,8 @@ public class JournalParser
 
 
   // TODO(drish): do not generate a second copy of the journalLine
-  public FObject parseObject(String journalLine) {
-
-    // get the actual object
-    int objectIndex = journalLine.indexOf("{");
-    String object = journalLine.substring(objectIndex, journalLine.lastIndexOf("}") + 1);
-
-    return this.jsonParser.parseString(object);
+  public FObject parseObject(String line) {
+    return this.jsonParser.parseString(line);
   }
 
   public Object parseObjectId(String journalLine) {

--- a/src/foam/lib/parse/ErrorReportingPStream.java
+++ b/src/foam/lib/parse/ErrorReportingPStream.java
@@ -77,6 +77,6 @@ public class ErrorReportingPStream
         "Valid characters include: " +
         validCharacters.stream()
             .map(e -> "'" + e.toString() + "'")
-            .collect(Collectors.joining(","));
+            .collect(Collectors.joining(", "));
   }
 }

--- a/src/foam/lib/parse/ErrorReportingPStream.java
+++ b/src/foam/lib/parse/ErrorReportingPStream.java
@@ -76,7 +76,20 @@ public class ErrorReportingPStream
         "' found at " + errStream.pos_ + "\n" +
         "Valid characters include: " +
         validCharacters.stream()
-            .map(e -> "'" + e.toString() + "'")
+            .map(e -> "'" + getPrintableCharacter(e) + "'")
             .collect(Collectors.joining(", "));
+  }
+
+  public String getPrintableCharacter(Character ch) {
+    switch ( (int) ch ) {
+      case 0x09:
+        return "\\t";
+      case 0x0A:
+        return "\\n";
+      case 0x0D:
+        return "\\r";
+      default:
+        return ch.toString();
+    }
   }
 }


### PR DESCRIPTION
1. Modified JDAO to chop the beginning and end of the journal line before passing it to the JournalParser.
2. Added Error Reporting if JDAO fails to parse a given line.
3. Modified ErrorReportingPStream getMessage function to add a space between valid characters and to not print out certain whitespace characters