### PR TITLE
HTTPBox & HTTPReplyBox serialization fix

### DIFF
--- a/src/foam/box/HTTPBox.js
+++ b/src/foam/box/HTTPBox.js
@@ -88,6 +88,10 @@ foam.CLASS({
         cls.extras.push(foam.java.Code.create({
           data: `
 protected class Outputter extends foam.lib.json.Outputter {
+  public Outputter() {
+    super(foam.lib.json.OutputterMode.NETWORK);
+  }
+
   protected void outputFObject(foam.core.FObject o) {
     if ( o == getMe() ) {
       o = getX().create(foam.box.HTTPReplyBox.class);

--- a/src/lib/boxJava.js
+++ b/src/lib/boxJava.js
@@ -66,7 +66,7 @@ try {
   javax.servlet.http.HttpServletResponse response = (javax.servlet.http.HttpServletResponse)getX().get("httpResponse");
   response.setContentType("application/json");
   java.io.PrintWriter writer = response.getWriter();
-  writer.print(new foam.lib.json.Outputter().stringify(message));
+  writer.print(new foam.lib.json.Outputter(foam.lib.json.OutputterMode.NETWORK).stringify(message));
   writer.flush();
 } catch(java.io.IOException e) {
   throw new RuntimeException(e);


### PR DESCRIPTION
1. Modified Outputters in HTTPBox and HTTPReplyBox to not send Network transient properties