### PR TITLE
Fixed dupe parameter in ScrollCView

### DIFF
--- a/src/foam/graphics/ScrollCView.js
+++ b/src/foam/graphics/ScrollCView.js
@@ -151,7 +151,7 @@ foam.CLASS({
   listeners: [
     {
       name: 'onTouch',
-      code: function(_, _, touch) {
+      code: function(_, __, touch) {
         // prevents highlighting of other elements while scrolling
         touch.claimed = true;
       }


### PR DESCRIPTION
This solves a Syntax error from being thrown when using babel 