### PR TITLE
Fixed bug with enum getters returning the first value of the enum

### DIFF
--- a/src/foam/core/Enum.js
+++ b/src/foam/core/Enum.js
@@ -320,12 +320,6 @@ foam.CLASS({
         return of && of.VALUES[0];
       },
     },
-    {
-      name: 'javaValue',
-      expression: function(of, value) {
-        return of.id + '.' + value;
-      },
-    },
     [
       'adapt',
       function(o, n, prop) {

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -95,7 +95,6 @@ foam.CLASS({
       var constantize = foam.String.constantize(this.name);
       var isSet       = this.name + 'IsSet_';
       var factoryName = capitalized + 'Factory_';
-      var isEnum      = this.javaType === 'java.lang.Enum';
 
       cls.
         field({
@@ -116,7 +115,7 @@ foam.CLASS({
           body: this.javaGetter || ('if ( ! ' + isSet + ' ) {\n' +
             ( this.hasOwnProperty('javaFactory') ?
                 '  set' + capitalized + '(' + factoryName + '());\n' :
-                ' return ' + ( ! isEnum ? this.javaValue : 'null' ) + ';\n' ) +
+                ' return ' + this.javaValue + ';\n' ) +
             '}\n' +
             'return ' + privateName + ';')
         }).
@@ -651,6 +650,7 @@ foam.CLASS({
   refines: 'foam.core.Enum',
 
   properties: [
+    ['javaValue', null],
     ['javaType', 'java.lang.Enum'],
     ['javaInfoType', 'foam.core.AbstractEnumPropertyInfo'],
     ['javaJSONParser', 'foam.lib.json.IntParser'],

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -95,6 +95,7 @@ foam.CLASS({
       var constantize = foam.String.constantize(this.name);
       var isSet       = this.name + 'IsSet_';
       var factoryName = capitalized + 'Factory_';
+      var isEnum      = this.javaType === 'java.lang.Enum';
 
       cls.
         field({
@@ -115,7 +116,7 @@ foam.CLASS({
           body: this.javaGetter || ('if ( ! ' + isSet + ' ) {\n' +
             ( this.hasOwnProperty('javaFactory') ?
                 '  set' + capitalized + '(' + factoryName + '());\n' :
-                ' return ' + this.javaValue  + ';\n' ) +
+                ' return ' + ( ! isEnum ? this.javaValue : 'null' ) + ';\n' ) +
             '}\n' +
             'return ' + privateName + ';')
         }).


### PR DESCRIPTION
Getter functions for Enum properties were returning the first value defined in the Enum. This was causing those default values to be marshalled even if not explicitly set. This PR makes the getters return null if not set.