### PR TITLE
Genjava Optimise #737

### DIFF
--- a/tools/genjava.js
+++ b/tools/genjava.js
@@ -159,11 +159,7 @@ function copyJavaClassesToBuildFolder(startPath) {
 
       result = result.concat(copyJavaClassesToBuildFolder(filePath));
     } else if (f.search('.js') < 0) {
-      var readFilePath = fs_.readFileSync(filePath);
-        if (! ( fs_.existsSync(outputPath) && (fs_.readFileSync(outputPath).toString() == readFilePath.toString()))) {
-          fs_.writeFileSync(outputPath, readFilePath);
-          result.push(outputPath);
-        } //else the source haven't been changed
+      writeFileIfUpdated(outputPath, fs_.readFileSync(filePath).toString());
     }
   });
 
@@ -173,6 +169,9 @@ function copyJavaClassesToBuildFolder(startPath) {
 function writeFileIfUpdated(outfile,buildJavaSource) {
   if (! ( fs_.existsSync(outfile) && (fs_.readFileSync(outfile).toString() == buildJavaSource))) {
     fs_.writeFileSync(outfile, buildJavaSource);
+    if (result !==undefined) {
+      result.push(outputPath);
+    }
   }
 }
 

--- a/tools/genjava.js
+++ b/tools/genjava.js
@@ -58,18 +58,18 @@ function ensurePath(p) {
 
 function loadClass(c) {
   var path = srcPath;
-  
+
   if ( foam.Array.isInstance(c) ) {
     path = path + c[0];
-    c = c[1];  
+    c = c[1];
   }
-  if ( ! foam.lookup(c, true) ) require(path + c.replace(/\./g, '/') + '.js');  
+  if ( ! foam.lookup(c, true) ) require(path + c.replace(/\./g, '/') + '.js');
   return foam.lookup(c);
 }
 
 function generateClass(cls) {
   if ( foam.Array.isInstance(cls) ) {
-    cls = cls[1];  
+    cls = cls[1];
   }
   if ( typeof cls === 'string' )
     cls = foam.lookup(cls);
@@ -79,12 +79,15 @@ function generateClass(cls) {
 
   ensurePath(outfile);
 
-  fs_.writeFileSync(outfile, cls.buildJavaClass().toJavaSource());
+  var buildJavaSource = cls.buildJavaClass().toJavaSource();
+  if (! ( fs_.existsSync(outfile) && (fs_.readFileSync(outfile).toString() == buildJavaSource))) {
+    fs_.writeFileSync(outfile, buildJavaSource);
+  }
 }
 
 function generateAbstractClass(cls) {
   if ( foam.Array.isInstance(cls) ) {
-    cls = cls[1];  
+    cls = cls[1];
   }
   cls = foam.lookup(cls);
 
@@ -96,12 +99,15 @@ function generateAbstractClass(cls) {
   var javaclass = cls.buildJavaClass();
   javaclass.abstract = true;
 
-  fs_.writeFileSync(outfile, javaclass.toJavaSource());
+  var buildAbstractJavaSource = javaclass.toJavaSource();
+  if (! ( fs_.existsSync(outfile) && (fs_.readFileSync(outfile).toString() == buildAbstractJavaSource))) {
+    fs_.writeFileSync(outfile, buildAbstractJavaSource);
+  }
 }
 
 function generateSkeleton(cls) {
   if ( foam.Array.isInstance(cls) ) {
-    cls = cls[1];  
+    cls = cls[1];
   }
   cls = foam.lookup(cls);
 
@@ -111,14 +117,15 @@ function generateSkeleton(cls) {
 
   ensurePath(outfile);
 
-  fs_.writeFileSync(
-    outfile,
-    foam.java.Skeleton.create({ of: cls }).buildJavaClass().toJavaSource());
+  var buildSkeletonJavaSource = foam.java.Skeleton.create({ of: cls }).buildJavaClass().toJavaSource();
+  if (! ( fs_.existsSync(outfile) && (fs_.readFileSync(outfile).toString() == buildSkeletonJavaSource))) {
+    fs_.writeFileSync(outfile,buildSkeletonJavaSource);
+  }
 }
 
 function generateProxy(intf) {
   if ( foam.Array.isInstance(intf) ) {
-    intf = intf[1];  
+    intf = intf[1];
   }
   intf = foam.lookup(intf);
 
@@ -161,8 +168,11 @@ function copyJavaClassesToBuildFolder(startPath) {
 
       result = result.concat(copyJavaClassesToBuildFolder(filePath));
     } else if (f.search('.js') < 0) {
-      fs_.writeFileSync(outputPath, fs_.readFileSync(filePath));
-      result.push(outputPath);
+      var readFilePath = fs_.readFileSync(filePath)
+        if (! ( fs_.existsSync(outputPath) && (fs_.readFileSync(outputPath).toString() == readFilePath.toString()))) {
+          fs_.writeFileSync(outputPath, readFilePath);
+          result.push(outputPath);
+        } //else the source haven't been changed
     }
   });
 

--- a/tools/genjava.js
+++ b/tools/genjava.js
@@ -79,10 +79,7 @@ function generateClass(cls) {
 
   ensurePath(outfile);
 
-  var buildJavaSource = cls.buildJavaClass().toJavaSource();
-  if (! ( fs_.existsSync(outfile) && (fs_.readFileSync(outfile).toString() == buildJavaSource))) {
-    fs_.writeFileSync(outfile, buildJavaSource);
-  }
+  writeFileIfUpdated(outfile, cls.buildJavaClass().toJavaSource());
 }
 
 function generateAbstractClass(cls) {
@@ -99,10 +96,7 @@ function generateAbstractClass(cls) {
   var javaclass = cls.buildJavaClass();
   javaclass.abstract = true;
 
-  var buildAbstractJavaSource = javaclass.toJavaSource();
-  if (! ( fs_.existsSync(outfile) && (fs_.readFileSync(outfile).toString() == buildAbstractJavaSource))) {
-    fs_.writeFileSync(outfile, buildAbstractJavaSource);
-  }
+    writeFileIfUpdated(outfile, javaclass.toJavaSource());
 }
 
 function generateSkeleton(cls) {
@@ -117,10 +111,7 @@ function generateSkeleton(cls) {
 
   ensurePath(outfile);
 
-  var buildSkeletonJavaSource = foam.java.Skeleton.create({ of: cls }).buildJavaClass().toJavaSource();
-  if (! ( fs_.existsSync(outfile) && (fs_.readFileSync(outfile).toString() == buildSkeletonJavaSource))) {
-    fs_.writeFileSync(outfile,buildSkeletonJavaSource);
-  }
+  writeFileIfUpdated(outfile, foam.java.Skeleton.create({ of: cls }).buildJavaClass().toJavaSource());
 }
 
 function generateProxy(intf) {
@@ -168,7 +159,7 @@ function copyJavaClassesToBuildFolder(startPath) {
 
       result = result.concat(copyJavaClassesToBuildFolder(filePath));
     } else if (f.search('.js') < 0) {
-      var readFilePath = fs_.readFileSync(filePath)
+      var readFilePath = fs_.readFileSync(filePath);
         if (! ( fs_.existsSync(outputPath) && (fs_.readFileSync(outputPath).toString() == readFilePath.toString()))) {
           fs_.writeFileSync(outputPath, readFilePath);
           result.push(outputPath);
@@ -177,6 +168,12 @@ function copyJavaClassesToBuildFolder(startPath) {
   });
 
   return result;
+}
+
+function writeFileIfUpdated(outfile,buildJavaSource) {
+  if (! ( fs_.existsSync(outfile) && (fs_.readFileSync(outfile).toString() == buildJavaSource))) {
+    fs_.writeFileSync(outfile, buildJavaSource);
+  }
 }
 
 classes.forEach(loadClass);


### PR DESCRIPTION
we propose to generate all of the java files, but then don't actually write them if they have the same contents as the file that's already there. This will prevent the timestamp of the file from updating despite
its contents not changing, which will then prevent the code from being recompiled.