### PR TITLE
Fix Stub/ReplyBox interaction for RPCs

### DIFF
--- a/src/lib/Stub.js
+++ b/src/lib/Stub.js
@@ -48,7 +48,7 @@ foam.CLASS({
             })
           });
 
-          msg.attributes.replyBox = replyBox;
+          if ( returns ) msg.attributes.replyBox = replyBox;
 
           this[boxPropName].send(msg);
 

--- a/src/lib/Stub.js
+++ b/src/lib/Stub.js
@@ -23,9 +23,17 @@ foam.CLASS({
         var name            = this.name;
 
         return function() {
-          var replyBox = this.RPCReturnBox.create()
-
+          var replyBox = this.RPCReturnBox.create();
           var ret = replyBox.promise;
+          if ( returns ) {
+            replyBox = this.ReplyBox.create({
+              delegate: replyBox
+            });
+            replyBox = this.registry.register(
+                replyBox.id,
+                this[replyPolicyName],
+                replyBox);
+          }
 
           // Automatically wrap RPCs that return a "PromisedAbc" or similar
           // TODO: Move this into RPCReturnBox ?


### PR DESCRIPTION
RPCs over forks/sockets were broken by eliminating `ReplyBox` wrapping in `Stub`.