### PR TITLE
Fork-based integration test for Javascript stubs

### DIFF
--- a/test/src/lib/Stub.js
+++ b/test/src/lib/Stub.js
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2017 The FOAM Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe('Stub', function() {
+  it('should support stubbing remote registry and registered service', function(done) {
+    require('./StubShared.js');
+
+    var sf = foam.core.StubFactorySingleton.create();
+    var ctx = foam.box.Context.create();
+
+    // Stub out registry in forked process.
+    var remoteRegistry = sf.get(foam.box.BoxRegistry).create({
+      delegate: foam.box.node.ForkBox.create({
+        critical: true,
+        nodeParams: ['--inspect', '--debug-brk'],
+        childScriptPath: `${__dirname}/StubForkScript.js`
+      }, ctx)
+    }, ctx);
+
+    // Register skeleton for "Square" service (in StubShared.js).
+    var squareSkeleton = foam.box.SkeletonBox.create({
+      data: test.Square.create()
+    });
+    // Stub registered box.
+    var squareStub = sf.get(test.Square).create({
+      delegate: remoteRegistry.register('square', null, squareSkeleton)
+    }, ctx);
+
+    // Confirm that service invocation works as expected.
+    squareStub.square(2).then(function(four) {
+      expect(four).toBe(4);
+      done();
+    });
+  });
+});

--- a/test/src/lib/StubForkScript.js
+++ b/test/src/lib/StubForkScript.js
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2017 The FOAM Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Use default forkScript; also load test-specific shared code.
+require('../../../src/foam/box/node/forkScript.js');
+require('./StubShared.js');

--- a/test/src/lib/StubShared.js
+++ b/test/src/lib/StubShared.js
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2017 The FOAM Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Shared code for Stub integration tests.
+foam.CLASS({
+  package: 'test',
+  name: 'Square',
+
+  methods: [
+    {
+      returns: 'Promise',
+      name: 'square',
+      code: function(x) { return Promise.resolve(x * x); }
+    }
+  ]
+});


### PR DESCRIPTION
Test to lock-in behaviour from #761. This fork-based test currently fails, but passes with #761 merged in.