### PR TITLE
Added fix for Skeleton java generation

### DIFF
--- a/src/foam/java/Skeleton.js
+++ b/src/foam/java/Skeleton.js
@@ -125,8 +125,10 @@ foam.CLASS({
     }
 
     if ( replyBox != null ) {
-      foam.box.RPCReturnMessage reply = (foam.box.RPCReturnMessage)getX().create(foam.box.RPCReturnMessage.class);<% if ( m.javaReturns && m.javaReturns != 'void' ) { %>
-      reply.setData(result);<% } %>
+      foam.box.RPCReturnMessage reply = (foam.box.RPCReturnMessage)getX().create(foam.box.RPCReturnMessage.class);
+      if ( result != null ) {
+        reply.setData(result);
+      }
 
       foam.box.Message message1 = getX().create(foam.box.Message.class);
       message1.setObject(reply);


### PR DESCRIPTION
This commit fixes a bug where the result was not being set in the RPCReturnMessage if the last function of the interface was returning void.

Bug reproduction steps:
1. Create an interface where the last method has no javaReturns or javaReturns is set to void
2. Generate a Skeleton from this interface
