### PR TITLE
Two CacheHandler updates

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -433,6 +433,7 @@ FOAM_FILES([
   { name: "foam/net/node/PathnamePrefixHandler", flags: ['node'] },
   { name: "foam/net/node/SimpleRouter", flags: ['node'] },
   { name: "foam/net/node/PathnamePrefixRouter", flags: ['node'] },
+  { name: "foam/net/node/RequestIdentifier", flags: ['node'] },
   { name: "foam/net/node/CacheHandler", flags: ['node'] },
   { name: "foam/net/node/FileHandler", flags: ['node'] },
   { name: "foam/net/node/DirTreeHandler", flags: ['node'] },

--- a/src/foam/net/node/CachedResponse.js
+++ b/src/foam/net/node/CachedResponse.js
@@ -23,14 +23,6 @@ foam.CLASS({
 
   imports: [ 'info' ],
 
-  constants: {
-    // TODO(markdittmer): Turn into static method: "idFromReq" once
-    // https://github.com/foam-framework/foam2/issues/613 is fixed.
-    ID_FROM_REQ: function(req) {
-      return req.urlString;
-    }
-  },
-
   properties: [
     {
       class: 'String',

--- a/src/foam/net/node/CachingResponse.js
+++ b/src/foam/net/node/CachingResponse.js
@@ -38,7 +38,7 @@ foam.CLASS({
   properties: [
     {
       name: 'id',
-      factory: function() { return this.CachedResponse.ID_FROM_REQ(this.req); }
+      required: true
     },
     {
       class: 'FObjectProperty',

--- a/src/foam/net/node/RequestIdentifier.js
+++ b/src/foam/net/node/RequestIdentifier.js
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2017 The FOAM Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+foam.CLASS({
+  package: 'foam.net.node',
+  name: 'RequestIdentifier',
+
+  documentation: `An object responsible for generating an identifier for a
+      ServerRequest. This is leveraged by handlers that need to uniquely
+      identify related requests, such as CacheHandler.`,
+
+  methods: [
+    function getId(req) {
+      if ( req.method === 'GET' ) {
+        return Promise.resolve(`GET ${req.urlString}`);
+      }
+      return req.payload.then(function(payload) {
+        return `${req.method} ${req.urlString}\n${payload}`;
+      });
+    },
+  ],
+});


### PR DESCRIPTION
1. Capture return value of delegate handle(), and behave accordingly

2. Use RequestIdentifier to abstract ServerRequest => Id mapping