### PR TITLE
Popup Width Height Fix

### DIFF
--- a/src/foam/u2/PopupView.js
+++ b/src/foam/u2/PopupView.js
@@ -68,8 +68,8 @@ foam.CLASS({
       var bg = this.E('div').
         style({
           position: 'absolute',
-          width: '10000px',
-          height: '10000px',
+          width: '100%',
+          height: '100%',
           opacity: 0,
           top: 0,
           zIndex: 998


### PR DESCRIPTION
Popup was causing X & Y scrollbars spanning 10000px. Set to width & height to 100%.