### PR TITLE
Have ValidationDAODecorator extend AbstractDAODecorator rather than i…

### DIFF
--- a/src/foam/dao/DAODecorator.js
+++ b/src/foam/dao/DAODecorator.js
@@ -185,7 +185,7 @@ foam.CLASS({
       name: 'remove_',
       code: function(x, obj) {
         var self = this;
-        return this.decorator.remove(x, self.dao, self.obj).then(function(obj) {
+        return this.decorator.remove(x, self.dao, obj).then(function(obj) {
           if ( obj ) return self.delegate.remove_(x, obj);
           return Promise.resolve();
         });

--- a/src/foam/dao/ValidationDAODecorator.js
+++ b/src/foam/dao/ValidationDAODecorator.js
@@ -18,7 +18,7 @@
 foam.CLASS({
   package: 'foam.dao',
   name: 'ValidationDAODecorator',
-  implements: ['foam.dao.DAODecorator'],
+  extends: 'foam.dao.AbstractDAODecorator',
   documentation: 'DAO decorator that rejects puts of objects that are invalid.',
   methods: [
     function write(X, dao, obj, existing) {


### PR DESCRIPTION
…mplement DAODecorator

AbstractDAODecorator provides default implementations for all DAODecorator methods.

Also correct typo on 'obj' parameter in decorator.remove call; replace self.obj with obj.

Resolves: https://github.com/foam-framework/foam2/issues/860