### PR TITLE
Add notes for setting up environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ While FOAM is written in JavaScript, it can be used to generate code
 for any language or platform, including Android Java and iOS Swift.
 
 # Development
-
+NOTE: Make sure execute **Building Java** first, and then to **Installing Dependencies**, or you could get maven errors.
 ## Building Java
 
 cd src; ./gen.sh; cd ../build; mvn compile; mvn package


### PR DESCRIPTION
Actually during my setting up the environment, I found if I do `npm install` first, and then do the `Building Javas` step, it will fail me with error. However, if I do `Building Javas` first, there will be no errors. Just add notes for new developers. 
```
.......
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.076 s
[INFO] Finished at: 2017-11-23T02:27:58-05:00
[INFO] Final Memory: 7M/309M
[INFO] ------------------------------------------------------------------------
[ERROR] The goal you specified requires a project to execute but there is no POM in this directory (/Users/morganwu/Developer/workspace/temp/foam2/build). Please verify you invoked Maven from the correct directory. -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MissingProjectException
.......
```