### PR TITLE
Able to run nano.sh from any directory

### DIFF
--- a/tools/nanos.sh
+++ b/tools/nanos.sh
@@ -1,5 +1,7 @@
 # run from parent directory of foam2
-cd foam2/build/
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR/../../foam2/build/
 mvn dependency:build-classpath -Dmdep.outputFile=cp.txt;
 
 cd ../..


### PR DESCRIPTION
So we don't have to execute `nano.sh` under parent directory of `foam2`. 