### PR TITLE
Automatically load deps in genjava.js

### DIFF
--- a/src/foam/box/HTTPBox.js
+++ b/src/foam/box/HTTPBox.js
@@ -33,6 +33,7 @@ foam.CLASS({
       name: 'Outputter',
       path: 'foam.json.Outputter',
       swiftPath: 'foam.swift.parse.json.output.Outputter',
+      javaPath: '',
     },
     'foam.box.HTTPReplyBox',
   ],

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -1279,7 +1279,7 @@ foam.CLASS({
     {
       name: 'javaReturns',
       expression: function(javaPath) {
-        return this.lookup(javaPath).model_.name;
+        return this.lookup(javaPath).model_.id;
       },
     },
   ]

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -1266,3 +1266,21 @@ foam.CLASS({
     }
   ]
 });
+
+foam.CLASS({
+  refines: 'foam.core.Requires',
+  properties: [
+    {
+      name: 'javaPath',
+      expression: function(path) {
+        return path;
+      },
+    },
+    {
+      name: 'javaReturns',
+      expression: function(javaPath) {
+        return this.lookup(javaPath).model_.name;
+      },
+    },
+  ]
+});

--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -1323,8 +1323,9 @@ foam.CLASS({
   package: 'foam.mlang.expr',
   name: 'Mul',
 
+  extends: 'foam.mlang.predicate.Binary',
+
   implements: [
-    'foam.mlang.predicate.Binary',
     'foam.core.Serializable'
   ],
 

--- a/src/foam/nanos/menu/TabsMenu.js
+++ b/src/foam/nanos/menu/TabsMenu.js
@@ -9,7 +9,12 @@ foam.CLASS({
   name: 'TabsMenu',
   extends: 'foam.nanos.menu.AbstractMenu',
 
-  requires: [ 'foam.u2.Tabs' ],
+  requires: [
+    {
+      path: 'foam.u2.Tabs',
+      javaPath: '',
+    },
+  ],
 
   methods: [
     function createView(X, menu) {

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -200,9 +200,23 @@ var proxies = [
   'foam.nanos.notification.push.PushService'
 ];
 
+var blacklist = [
+  'FObject',
+  'foam.core.AbstractEnum',
+  'foam.core.AbstractInterface',
+  'foam.core.Property',
+  'foam.core.String',
+
+  // TODO: These are missing java impls.
+  'foam.mlang.order.ThenBy',
+  'foam.blob.BlobBlob',
+  'foam.dao.FlowControl',
+];
+
 module.exports = {
     classes: classes,
     abstractClasses: abstractClasses,
     skeletons: skeletons,
-    proxies: proxies
+    proxies: proxies,
+    blacklist: blacklist,
 }

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -207,10 +207,27 @@ var blacklist = [
   'foam.core.Property',
   'foam.core.String',
 
-  // TODO: These are missing java impls.
-  'foam.mlang.order.ThenBy',
+  // These have hand written java impls so we don't want to clobber them.
+  // TODO: Change gen.sh to prefer hand written java files over generated.
+  'foam.dao.AbstractDAO',
+  'foam.dao.FilteredDAO',
+  'foam.dao.LimitedDAO',
+  'foam.dao.NullDAO',
+  'foam.dao.OrderedDAO',
+  'foam.dao.SkipDAO',
+
+  // TODO: These models currently don't compile in java but could be updated to
+  // compile properly.
   'foam.blob.BlobBlob',
+  'foam.dao.CompoundDAODecorator',
+  'foam.dao.DAODecorator',
+  'foam.dao.EasyDAO',
   'foam.dao.FlowControl',
+  'foam.dao.PromisedDAO',
+  'foam.dao.sync.SyncRecord',
+  'foam.dao.sync.VersionedSyncRecord',
+  'foam.mlang.order.ThenBy',
+  'foam.nanos.menu.MenuBar',
 ];
 
 module.exports = {

--- a/tools/genjava.js
+++ b/tools/genjava.js
@@ -179,30 +179,30 @@ function writeFileIfUpdated(outfile, buildJavaSource, opt_result) {
 }
 
 var addDepsToClasses = function() {
-var X = foam.classloader.NodeJsModelExecutor.create({
-  classpaths: [__dirname + '/' + srcPath],
-}).__subContext__;
-  return Promise.all(classes.map(function(cls) {
-    return X.arequire(cls);
-  })).then(function() {
-    var classMap = {};
-    var classQueue = classes.slice(0);
-    while (classQueue.length) {
-      var cls = classQueue.pop();
-      if ( ! classMap[cls] && ! blacklist[cls] ) {
-        classMap[cls] = true;
-        cls = foam.lookup(cls);
-        cls.getAxiomsByClass(foam.core.Requires).forEach(function(r) {
-          r.javaPath && classQueue.push(r.javaPath);
-        });
-        cls.getAxiomsByClass(foam.core.Implements).forEach(function(r) {
-          classQueue.push(r.path);
-        });
-        if (cls.model_.extends) classQueue.push(cls.model_.extends);
+  var X = foam.classloader.NodeJsModelExecutor.create({
+    classpaths: [__dirname + '/' + srcPath],
+  }).__subContext__;
+    return Promise.all(classes.map(function(cls) {
+      return X.arequire(cls);
+    })).then(function() {
+      var classMap = {};
+      var classQueue = classes.slice(0);
+      while ( classQueue.length ) {
+        var cls = classQueue.pop();
+        if ( ! classMap[cls] && ! blacklist[cls] ) {
+          classMap[cls] = true;
+          cls = foam.lookup(cls);
+          cls.getAxiomsByClass(foam.core.Requires).forEach(function(r) {
+            r.javaPath && classQueue.push(r.javaPath);
+          });
+          cls.getAxiomsByClass(foam.core.Implements).forEach(function(r) {
+            classQueue.push(r.path);
+          });
+          if ( cls.model_.extends ) classQueue.push(cls.model_.extends);
+        }
       }
-    }
-    classes = Object.keys(classMap);
-  });
+      classes = Object.keys(classMap);
+    });
 };
 
 addDepsToClasses().then(function() {

--- a/tools/genjava.js
+++ b/tools/genjava.js
@@ -182,13 +182,12 @@ var addDepsToClasses = function() {
   var paths = {};
   paths[srcPath] = true;
   classes.forEach(function(cls) {
-    if (foam.Array.isInstance(cls)) paths[srcPath + cls[0]] = true;
+    if ( foam.Array.isInstance(cls) ) paths[srcPath + cls[0]] = true;
   });
   classes = classes.map(function(cls) {
     return foam.Array.isInstance(cls) ? cls[1] : cls;
   });
 
-  console.log(Object.keys(paths).join(','));
   var X = foam.classloader.NodeJsModelExecutor.create({
     classpaths: Object.keys(paths)
   }).__subContext__;

--- a/tools/genjava.js
+++ b/tools/genjava.js
@@ -10,7 +10,7 @@ global.FOAM_FLAGS = { 'java': true, 'debug': true, 'js': false };
 require('../src/foam.js');
 require('../src/foam/nanos/nanos.js');
 
-var srcPath = "../src/";
+var srcPath = __dirname + "/../src/";
 
 if ( ! (process.argv.length == 4 || process.argv.length == 5) ) {
   console.log("USAGE: genjava.js input-path output-path src-path(optional)");
@@ -179,8 +179,18 @@ function writeFileIfUpdated(outfile, buildJavaSource, opt_result) {
 }
 
 var addDepsToClasses = function() {
+  var paths = {};
+  paths[srcPath] = true;
+  classes.forEach(function(cls) {
+    if (foam.Array.isInstance(cls)) paths[srcPath + cls[0]] = true;
+  });
+  classes = classes.map(function(cls) {
+    return foam.Array.isInstance(cls) ? cls[1] : cls;
+  });
+
+  console.log(Object.keys(paths).join(','));
   var X = foam.classloader.NodeJsModelExecutor.create({
-    classpaths: [__dirname + '/' + srcPath],
+    classpaths: Object.keys(paths)
   }).__subContext__;
     return Promise.all(classes.map(function(cls) {
       return X.arequire(cls);

--- a/tools/genjava.js
+++ b/tools/genjava.js
@@ -179,11 +179,17 @@ function writeFileIfUpdated(outfile, buildJavaSource, opt_result) {
 }
 
 var addDepsToClasses = function() {
+
+  // Determine all of the paths that the modelDAO should search will use when
+  // arequiring all of the classes.
   var paths = {};
   paths[srcPath] = true;
   classes.forEach(function(cls) {
     if ( foam.Array.isInstance(cls) ) paths[srcPath + cls[0]] = true;
   });
+
+  // Remove the paths from the entries in classes because the modelDAO should be
+  // able to find them now.
   classes = classes.map(function(cls) {
     return foam.Array.isInstance(cls) ? cls[1] : cls;
   });


### PR DESCRIPTION
Make the genjava tool automatically pull in dependencies so we don't have to explicitly list everything we want generated.

Adds javaPath to requires so a requires can have a different model for
java than js.

Update a couple of models to generate compileable code in java now that
they're being generated.