### PR TITLE
Undo temporary fix for NamedBox multitons.

### DIFF
--- a/src/foam/box/NamedBox.js
+++ b/src/foam/box/NamedBox.js
@@ -24,6 +24,10 @@ foam.CLASS({
     'foam.box.LookupBox',
   ],
 
+  axioms: [
+    foam.pattern.Multiton.create({ property: 'name' })
+  ],
+
   properties: [
     {
       class: 'String',
@@ -81,13 +85,5 @@ if let index = name.range(of: "/", options: .backwards)?.lowerBound {
 return ""
       */},
     },
-  ],
-
-  // TODO: Java support has a bug where it can create MultitonInfo
-  // before property is defined, moving axiom to bottom of file is a
-  // hacky fix.
-  axioms: [
-    foam.pattern.Multiton.create({ property: 'name' })
   ]
-
 });

--- a/src/foam/java/ClassInfo.js
+++ b/src/foam/java/ClassInfo.js
@@ -33,7 +33,7 @@ foam.CLASS({
     },
     {
       name: 'order',
-      value: 1
+      value: Number.MAX_SAFE_INTEGER
     }
   ],
 

--- a/src/foam/java/ClassInfo.js
+++ b/src/foam/java/ClassInfo.js
@@ -33,7 +33,7 @@ foam.CLASS({
     },
     {
       name: 'order',
-      value: Number.MAX_SAFE_INTEGER
+      value: 2
     }
   ],
 

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -1164,6 +1164,7 @@ foam.CLASS({
         initializer: `
 new foam.core.MultitonInfo("${this.javaName}", ${cls.name}.${foam.String.constantize(this.property)});
         `,
+        order: Number.MAX_SAFE_INTEGER - 1,
       });
     }
   ]

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -1164,7 +1164,7 @@ foam.CLASS({
         initializer: `
 new foam.core.MultitonInfo("${this.javaName}", ${cls.name}.${foam.String.constantize(this.property)});
         `,
-        order: Number.MAX_SAFE_INTEGER - 1,
+        order: 1,
       });
     }
   ]


### PR DESCRIPTION
The fix for this is to define the "order" property of the MULTITON field. Since classInfo_ uses all axioms, its order needed to updated to ensure it is generated after MULTITON.