### PR TITLE
Added SubdomainRouter

### DIFF
--- a/src/foam/nanos/tomcat/SubdomainRouter.java
+++ b/src/foam/nanos/tomcat/SubdomainRouter.java
@@ -6,10 +6,9 @@
 
 package foam.nanos.tomcat;
 
-import foam.nanos.http.NanoRouter;
-
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -19,12 +18,8 @@ import java.io.IOException;
  * Used to route sub projects to a more easily accessible path
  */
 public class SubdomainRouter
-    extends NanoRouter
+    extends HttpServlet
 {
-  {
-    x_ = new foam.nanos.boot.Boot().getX();
-  }
-
   @Override
   protected synchronized void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
     String path = getServletConfig().getInitParameter("path");

--- a/src/foam/nanos/tomcat/SubdomainRouter.java
+++ b/src/foam/nanos/tomcat/SubdomainRouter.java
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2018 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package foam.nanos.tomcat;
+
+import foam.nanos.http.NanoRouter;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Subdomain Router
+ * Used to route sub projects to a more easily accessible path
+ */
+public class SubdomainRouter
+    extends NanoRouter
+{
+  {
+    x_ = new foam.nanos.boot.Boot().getX();
+  }
+
+  @Override
+  protected synchronized void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+    String path = getServletConfig().getInitParameter("path");
+    RequestDispatcher view = req.getRequestDispatcher(path);
+    view.forward(req, resp);
+  }
+}

--- a/src/foam/nanos/tomcat/TomcatRouter.java
+++ b/src/foam/nanos/tomcat/TomcatRouter.java
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2018 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 package foam.nanos.tomcat;
 
 import foam.nanos.http.NanoRouter;


### PR DESCRIPTION
Added a Subdomain router for Tomcat that can be used to route long URLs used for subprojetts to something more accessible.