### PR TITLE
foam.u2.RowFormatter + foam.u2.view.ScrollDAOView updates

### DIFF
--- a/src/foam/u2/RowFormatter.js
+++ b/src/foam/u2/RowFormatter.js
@@ -22,6 +22,6 @@ foam.INTERFACE({
   documentation: 'Base class for markup-generating row formatters.',
 
   methods: [
-    function format(data) {}
+    function format(data, opt_columns) {}
   ]
 });


### PR DESCRIPTION
1. Optionally pass cols to RowFormatter
2. Fix over-optimization causing scroll bug in COUNT()+rerender code
3. Use standard `target` event property (not non-standard `srcElement`)