### PR TITLE
Parser/outputter up to Context; *Sockets deal in Strings

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -309,6 +309,7 @@ FOAM_FILES([
   { name: "foam/box/ReturnBox" },
   { name: "foam/box/RawMessagePortBox" },
   { name: "foam/box/WebSocketBox" },
+  { name: "foam/box/BoxJsonOutputter" },
   { name: "foam/box/ClassWhitelistContext" },
   { name: "foam/box/LoggedLookupContext" },
   { name: "foam/box/Context" },

--- a/src/foam/box/BoxJsonOutputter.js
+++ b/src/foam/box/BoxJsonOutputter.js
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2018 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.box',
+  name: 'BoxJsonOutputter',
+  extends: 'foam.json.Outputter',
+
+  requires: [ 'foam.box.ReturnBox' ],
+  imports: [ 'me' ],
+
+  methods: [
+    function output(o) {
+      if ( o === this.me ) {
+        return this.SUPER(this.ReturnBox.create());
+      }
+      return this.SUPER(o);
+    }
+  ]
+});

--- a/src/foam/box/Context.js
+++ b/src/foam/box/Context.js
@@ -21,16 +21,20 @@ foam.CLASS({
   swiftName: 'BoxContext',
 
   requires: [
+    'foam.box.BoxJsonOutputter',
     'foam.box.BoxRegistryBox',
-    'foam.box.NamedBox',
     'foam.box.ClassWhitelistContext',
     'foam.box.LoggedLookupContext',
+    'foam.box.NamedBox',
+    'foam.json.Parser'
   ],
 
   exports: [
     'creationContext',
     'me',
     'messagePortService',
+    'outputter',
+    'parser',
     'registry',
     'root',
     'socketService',
@@ -159,6 +163,25 @@ return ClassWhitelistContext_create([
   "whitelist$": classWhitelist$,
 ]).__subContext__
       `,
+    },
+    {
+      class: 'FObjectProperty',
+      of: 'foam.json.Parser',
+      name: 'parser',
+      factory: function() {
+        return this.Parser.create({
+          strict: true,
+          creationContext: this.creationContext
+        });
+      }
+    },
+    {
+      class: 'FObjectProperty',
+      of: 'foam.box.BoxJsonOutputter',
+      name: 'outputter',
+      factory: function() {
+        return this.BoxJsonOutputter.create().copyFrom(foam.json.Network);
+      }
     }
   ]
 });

--- a/src/foam/box/MessagePortBox.js
+++ b/src/foam/box/MessagePortBox.js
@@ -22,15 +22,15 @@ foam.CLASS({
   extends: 'foam.box.ProxyBox',
 
   requires: [
+    'foam.box.Message',
     'foam.box.RawMessagePortBox',
     'foam.box.RegisterSelfMessage',
-    'foam.box.Message',
-    'foam.json.Outputter'
   ],
 
   imports: [
     'me',
-    'messagePortService'
+    'messagePortService',
+    'outputter'
   ],
 
   properties: [
@@ -51,19 +51,6 @@ foam.CLASS({
             })));
 
 	return this.RawMessagePortBox.create({ port: channel.port1 });
-      }
-    },
-    {
-      class: 'FObjectProperty',
-      of: 'foam.json.Outputter',
-      name: 'outputter',
-      factory: function() {
-        // NOTE: Configuration must be consistent with parser in
-        // foam.messageport.MessagePortService.
-        //
-        // Use default FOAM implementation of Outputter. Do not attempt to
-        // lookup sensitive "foam.json.Outputter" class in box context.
-        return this.Outputter.create().copyFrom(foam.json.Network)
       }
     }
   ]

--- a/src/foam/box/RawMessagePortBox.js
+++ b/src/foam/box/RawMessagePortBox.js
@@ -19,29 +19,16 @@ foam.CLASS({
   package: 'foam.box',
   name: 'RawMessagePortBox',
   implements: [ 'foam.box.Box' ],
-  requires: [
-    'foam.json.Outputter',
-    'foam.box.ReplyBox'
-  ],
+
+  requires: [ 'foam.box.ReplyBox' ],
+  imports: [ 'outputter' ],
 
   properties: [
     {
       name: 'port'
-    },
-    {
-      class: 'FObjectProperty',
-      of: 'foam.json.Outputter',
-      name: 'outputter',
-      factory: function() {
-        // NOTE: Configuration must be consistent with parser in
-        // foam.messageport.MessagePortService.
-        //
-        // Use default FOAM implementation of Outputter. Do not attempt to
-        // lookup sensitive "foam.json.Outputter" class in box context.
-        return this.Outputter.create().copyFrom(foam.json.Network)
-      }
     }
   ],
+
   methods: [
     function send(message) {
       var replyBox = message.attributes.replyBox;

--- a/src/foam/box/RawSocketBox.js
+++ b/src/foam/box/RawSocketBox.js
@@ -23,7 +23,8 @@ foam.CLASS({
   requires: [ 'foam.box.ReplyBox' ],
   imports: [
     'me',
-    'registry',
+    'outputter',
+    'registry'
   ],
 
   properties: [
@@ -31,24 +32,6 @@ foam.CLASS({
       class: 'Object',
       name: 'socket',
       javaType: 'org.java_websocket.WebSocket'
-    }
-  ],
-
-  classes: [
-    {
-      name: 'JSONOutputter',
-      extends: 'foam.json.Outputter',
-
-      requires: [ 'foam.box.ReturnBox' ],
-      imports: [ 'me' ],
-      methods: [
-        function output(o) {
-          if ( o === this.me ) {
-            return this.SUPER(this.ReturnBox.create());
-          }
-          return this.SUPER(o);
-        }
-      ]
     }
   ],
 
@@ -66,12 +49,13 @@ foam.CLASS({
           // property on Message and have custom serialization in it to
           // do the registration.
 
-          msg.attributes.replyBox =
-            this.__context__.registry.register(null, null, msg.attributes.replyBox);
+          msg.attributes.replyBox = this.__context__.registry.
+              register(null, null, msg.attributes.replyBox);
         }
 
+        var payload = this.outputter.stringify(msg);
         try {
-          this.socket.write(msg);
+          this.socket.write(payload);
           if ( replyBox ) {
             msg.attributes.replyBox = replyBox;
           }

--- a/src/foam/box/RawWebSocketBox.js
+++ b/src/foam/box/RawWebSocketBox.js
@@ -19,9 +19,7 @@ foam.CLASS({
   package: 'foam.box',
   name: 'RawWebSocketBox',
   implements: ['foam.box.Box'],
-  requires: [
-    'foam.box.ReplyBox'
-  ],
+  requires: [ 'foam.box.ReplyBox' ],
   imports: [
     {
       name: 'me',
@@ -32,7 +30,8 @@ foam.CLASS({
       key: 'registry',
       name: 'registry',
       javaType: 'foam.box.BoxRegistry',
-    }
+    },
+    'outputter'
   ],
 
   properties: [
@@ -41,30 +40,6 @@ foam.CLASS({
       name: 'socket',
       javaType: 'foam.net.WebSocket'
     }
-  ],
-
-  classes: [
-    foam.core.InnerClass.create({
-      generateJava: false,
-      model: {
-        name: 'JSONOutputter',
-        extends: 'foam.json.Outputter',
-        requires: [
-          'foam.box.ReturnBox'
-        ],
-        imports: [
-          'me'
-        ],
-        methods: [
-          function output(o) {
-            if ( o === this.me ) {
-              return this.SUPER(this.ReturnBox.create());
-            }
-            return this.SUPER(o);
-          }
-        ]
-      }
-    })
   ],
 
   methods: [
@@ -78,12 +53,11 @@ foam.CLASS({
 
           // TODO: Add one-time service policy
 
-          msg.attributes.replyBox =
-            this.__context__.registry.register(null, null, msg.attributes.replyBox);
+          msg.attributes.replyBox = this.__context__.registry.
+              register(null, null, msg.attributes.replyBox);
         }
 
-        var payload = this.JSONOutputter.create().copyFrom(foam.json.Network).stringify(msg);
-
+        var payload = this.outputter.stringify(msg);
         try {
           this.socket.send(payload);
         } catch(e) {

--- a/src/foam/box/SocketBox.js
+++ b/src/foam/box/SocketBox.js
@@ -20,9 +20,7 @@ foam.CLASS({
   name: 'SocketBox',
   extends: 'foam.box.ProxyBox',
 
-  requires: [
-    'foam.box.SocketConnectBox'
-  ],
+  requires: [ 'foam.box.SocketConnectBox' ],
 
   axioms: [
     foam.pattern.Multiton.create({
@@ -43,9 +41,9 @@ foam.CLASS({
       name: 'delegate',
       transient: true,
       factory: function() {
-        return foam.box.SocketConnectBox.create({
+        return this.SocketConnectBox.create({
           address: this.address
-        }, this);
+        });
       },
       swiftFactory: `
 return SocketConnectBox_create([

--- a/src/foam/box/WebSocketBox.js
+++ b/src/foam/box/WebSocketBox.js
@@ -20,9 +20,9 @@ foam.CLASS({
   name: 'WebSocketBox',
 
   requires: [
-    'foam.net.web.WebSocket',
     'foam.box.Message',
-    'foam.box.RawWebSocketBox'
+    'foam.box.RawWebSocketBox',
+    'foam.net.web.WebSocket'
   ],
 
   imports: [

--- a/src/foam/messageport/MessagePortService.js
+++ b/src/foam/messageport/MessagePortService.js
@@ -23,10 +23,10 @@ foam.CLASS({
     'foam.box.NamedBox',
     'foam.box.RawMessagePortBox',
     'foam.box.RegisterSelfMessage',
-    'foam.json.Parser'
   ],
   imports: [
-    'creationContext'
+    'creationContext',
+    'parser',
   ],
 
   topics: [ 'connect' ],
@@ -42,19 +42,6 @@ foam.CLASS({
     {
       name: 'delegate',
       required: true
-    },
-    {
-      class: 'FObjectProperty',
-      of: 'foam.json.Parser',
-      name: 'parser',
-      factory: function() {
-        // NOTE: Configuration must be consistent with outputters in
-        // foam.box.MessagePortBox and foam.box.RawMesagePortBox.
-        return this.Parser.create({
-          strict: true,
-          creationContext: this.creationContext
-        });
-      }
     }
   ],
 

--- a/src/foam/net/node/WebSocket.js
+++ b/src/foam/net/node/WebSocket.js
@@ -20,7 +20,6 @@ foam.CLASS({
   name: 'WebSocket',
 
   requires: [
-    'foam.json.Outputter',
     'foam.net.node.Frame'
   ],
 
@@ -46,29 +45,11 @@ foam.CLASS({
     },
     'opcode',
     'parts',
-    'currentFrame',
-    {
-      class: 'FObjectProperty',
-      of: 'foam.json.Outputter',
-      name: 'outputter',
-      factory: function() {
-        return this.Outputter.create({
-          pretty: false,
-          formatDatesAsNumbers: true,
-          outputDefaultValues: false,
-          strict: true,
-          propertyPredicate: function(o, p) { return ! p.networkTransient; }
-        });
-      }
-    }
+    'currentFrame'
   ],
 
   methods: [
     function send(data) {
-      if ( foam.box.Message.isInstance(data) ) {
-        data = this.outputter.stringify(data);
-      }
-
       if ( typeof data == "string" ) {
         var opcode = 1;
         data = Buffer.from(data);

--- a/src/foam/net/web/WebSocketService.js
+++ b/src/foam/net/web/WebSocketService.js
@@ -16,22 +16,14 @@ foam.CLASS({
     'foam.box.RawWebSocketBox'
   ],
 
-  imports: [ 'creationContext' ],
+  imports: [
+    'creationContext',
+    'parser'
+  ],
 
   properties: [
     {
       name: 'delegate'
-    },
-    {
-      class: 'FObjectProperty',
-      of: 'foam.json.Parser',
-      name: 'parser',
-      factory: function() {
-        return this.Parser.create({
-          strict: true,
-          creationContext: this.creationContext
-        });
-      }
     }
   ],
 


### PR DESCRIPTION
This change facilitates applications that wish to configure different (de)serialization schemes at a high level without having other schemes introduced by lower-level components.

As much as possible parsers and outputters are provided by the enclosing `foam.box.Context`. Whenever possible, lower level `*Socket` components deal with strings, rather than yet-to-be-serialized objects. There are some exceptions required by, for example, the asymmetry of how WebSockets are managed on client and server.