### PR TITLE
foam.mlang.predicate.ArrayBinary: Cope w/empty array serialized as undefined

### DIFF
--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -833,7 +833,13 @@ foam.CLASS({
       adapt: function(old, nu, prop) {
         var value = prop.adaptValue(nu);
         var arg1 = this.arg1;
-        if ( foam.mlang.Constant.isInstance(value) && arg1 && arg1.adapt ) {
+
+        // Adapt constant array elements when:
+        // (1) Value is a constant (array);
+        // (2) Value is truthy (empty arrays can be serialized as undefined);
+        // (3) Arg1 has an adapt().
+        if ( foam.mlang.Constant.isInstance(value) && value.value &&
+             arg1 && arg1.adapt ) {
           var arrayValue = value.value;
           for ( var i = 0; i < arrayValue.length; i++ ) {
             arrayValue[i] = arg1.adapt.call(null, old && old[i], arrayValue[i], arg1);


### PR DESCRIPTION
I'm not entirely sure this is the right fix. Should we instead by serializing `ArrrayConstant`s to deal with the symptoms that led me to this fix?