### PR TITLE
Disabled blob cloning for ProxyBlob classes

### DIFF
--- a/src/foam/blob/AbstractBlobPropertyInfo.java
+++ b/src/foam/blob/AbstractBlobPropertyInfo.java
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2018 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package foam.blob;
+
+import foam.core.AbstractFObjectPropertyInfo;
+import foam.core.FObject;
+
+public abstract class AbstractBlobPropertyInfo
+    extends AbstractFObjectPropertyInfo
+{
+  @Override
+  public void cloneProperty(FObject source, FObject dest) {}
+}

--- a/src/foam/blob/Blob.js
+++ b/src/foam/blob/Blob.js
@@ -240,7 +240,8 @@ foam.CLASS({
       class: 'Proxy',
       of: 'foam.blob.Blob',
       name: 'delegate',
-      forwards: [ 'read', 'getSize' ]
+      forwards: [ 'read', 'getSize' ],
+      javaInfoType: 'foam.blob.AbstractBlobPropertyInfo'
     }
   ]
 });


### PR DESCRIPTION
Added AbstractBlobPropertyInfo which prevents cloning of Blob properties. This aims to fix a bug that occurs when Blob files are read from a journal. When loading the blobs from the journal file the MapDAO would clone the IdentifiedBlob's delegate which resulted in unnecessary network calls.