### PR TITLE
Made Outputter be flushable and closeable

### DIFF
--- a/src/foam/lib/Outputter.java
+++ b/src/foam/lib/Outputter.java
@@ -8,9 +8,14 @@ package foam.lib;
 
 import foam.core.FObject;
 
+import java.io.Closeable;
+import java.io.Flushable;
+
 // not modelled because method with
 // name stringify is not generated
-public interface Outputter {
+public interface Outputter
+  extends Closeable, Flushable
+{
   String stringify(FObject obj);
   void output(Object value);
 }

--- a/src/foam/lib/csv/Outputter.java
+++ b/src/foam/lib/csv/Outputter.java
@@ -10,6 +10,8 @@ import foam.core.*;
 import foam.dao.AbstractSink;
 import foam.lib.json.OutputterMode;
 import foam.util.SafetyUtil;
+import org.apache.commons.io.IOUtils;
+
 import java.io.*;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -210,5 +212,17 @@ public class Outputter
       isHeadersOutput_ = true;
     }
     outputFObject((FObject)obj);
+  }
+
+  @Override
+  public void close() throws IOException {
+    IOUtils.closeQuietly(stringWriter_);
+    IOUtils.closeQuietly(writer_);
+  }
+
+  @Override
+  public void flush() throws IOException {
+    if ( stringWriter_ != null ) stringWriter_.flush();
+    if ( writer_ != null ) writer_.flush();
   }
 }

--- a/src/foam/lib/html/Outputter.java
+++ b/src/foam/lib/html/Outputter.java
@@ -6,15 +6,19 @@
 
 package foam.lib.html;
 
-import foam.core.*;
+import foam.core.ClassInfo;
+import foam.core.Detachable;
+import foam.core.FObject;
+import foam.core.PropertyInfo;
 import foam.dao.AbstractSink;
 import foam.lib.json.OutputterMode;
 import foam.util.SafetyUtil;
+import org.apache.commons.io.IOUtils;
+
 import java.io.*;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Iterator;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
 
@@ -186,5 +190,17 @@ public class Outputter
   @Override
   public void put(Object obj, Detachable sub) {
     outputFObject((FObject)obj);
+  }
+
+  @Override
+  public void close() throws IOException {
+    IOUtils.closeQuietly(stringWriter_);
+    IOUtils.closeQuietly(writer_);
+  }
+
+  @Override
+  public void flush() throws IOException {
+    if ( stringWriter_ != null ) stringWriter_.flush();
+    if ( writer_ != null ) writer_.flush();
   }
 }

--- a/src/foam/lib/json/Outputter.java
+++ b/src/foam/lib/json/Outputter.java
@@ -6,17 +6,16 @@
 
 package foam.lib.json;
 
-import foam.core.*;
+import foam.core.ClassInfo;
+import foam.core.Detachable;
+import foam.core.FObject;
+import foam.core.PropertyInfo;
 import foam.dao.AbstractSink;
+import org.apache.commons.io.IOUtils;
 import org.bouncycastle.util.encoders.Base64;
-import org.bouncycastle.util.encoders.Hex;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
+import java.io.*;
 import java.security.PrivateKey;
-import java.security.Signature;
 import java.text.SimpleDateFormat;
 import java.util.Iterator;
 import java.util.List;
@@ -354,5 +353,17 @@ public class Outputter
 
   public void setSigningKey(PrivateKey signingKey) {
     signingKey_ = signingKey;
+  }
+
+  @Override
+  public void close() throws IOException {
+    IOUtils.closeQuietly(stringWriter_);
+    IOUtils.closeQuietly(writer_);
+  }
+
+  @Override
+  public void flush() throws IOException {
+    if ( stringWriter_ != null ) stringWriter_.flush();
+    if ( writer_ != null ) writer_.flush();
   }
 }


### PR DESCRIPTION
Certain OutputStreams (ByteArrayOutputStream) do not work unless the writer is flushed. I've added Closeable and Flushable support to the Outputter interface