### PR TITLE
Support http content type json on post

### DIFF
--- a/src/foam/nanos/dig/DigPostParameters.js
+++ b/src/foam/nanos/dig/DigPostParameters.js
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2018 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.nanos.dig',
+  name: 'DigPostParameters',
+
+  documentation: 'PUT or POST parameters passed to DIG in the HTTP content which require explicit processing when the Content-Type is application/json or application/xml',
+
+  properties: [
+    {
+      name: 'cmd',
+      class: 'String'
+    },
+    {
+      name: 'dao',
+      class: 'String'
+    },
+    {
+      name: 'data',
+      class: 'Object'
+    },
+    {
+      name: 'email',
+      class: 'String'
+    },
+    {
+      name: 'format',
+      class: 'String'
+    },
+    {
+      name: 'id',
+      class: 'String'
+    }
+  ]
+});

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -206,7 +206,8 @@ var classes = [
   'foam.crypto.sign.SignedFObject',
 
   'foam.nanos.dig.Format',
-  'foam.nanos.dig.DUG'
+  'foam.nanos.dig.DUG',
+  'foam.nanos.dig.DigPostParameters',
 ];
 
 var abstractClasses = [


### PR DESCRIPTION
Summary:
When content-type is other than application/x-www-form-urlencoded, the HttpServletRequest.reader stream must be processes manually to extract parameters from the body.

These updates are required for the Interac integration which is in progress.  I suspect there will be further abstraction of the POST processing logic with review of the pending ExchangeRateService and AcceptRateService. 

If there are significant concerns/critiques, we'll put this on an interac branch so we can deploy and not block the interac team this week (Mar 12). 

NOTE: there is one known bug:  
            DAO dao = (DAO) x.get(daoName);
            // test for null dao is not working, so invalid DAOs are not trapped. 

