### PR TITLE
fixing jetty-server dependency bug

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -121,6 +121,11 @@
             <version>${appengine.sdk.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-maven-plugin</artifactId>
+            <version>9.3.11.v20160721</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
This fixes the
> package org.eclipse.jetty.server does not exist

errors for `HttpServer.java`.