### PR TITLE
Update link to Google's JavaScript Style Guide

### DIFF
--- a/doc/guides/StyleGuide.md
+++ b/doc/guides/StyleGuide.md
@@ -2,7 +2,7 @@
 
 Except where noted below, FOAM conforms to the Google Javascript Style Guide available at:
 
-https://google.github.io/styleguide/javascriptguide.xml
+https://google.github.io/styleguide/jsguide.html
 
 ## Exceptions
 * One space is required inside the parentheses of `if`, `for`, `while`, and `switch` headers:


### PR DESCRIPTION
We were linking to the outdated styleguide that didn't include ES6 syntax.