### PR TITLE
Remove the factory on a model's flags

### DIFF
--- a/src/foam/core/Model.js
+++ b/src/foam/core/Model.js
@@ -36,7 +36,10 @@ foam.CLASS({
     'name',
     {
       name: 'flags',
-      factory: function() { return {}; }
+      documentation: `
+        When set, marks the model with the given flags. This can be used for
+        things like stripping out platform specific models when building.
+      `,
     },
     {
       name: 'label',


### PR DESCRIPTION
I don't see this being used anywhere and using a string array is easier to work with.