### PR TITLE
Show 'Welcome' in top nav when not logged in

### DIFF
--- a/src/foam/nanos/u2/navigation/TopNavigation.js
+++ b/src/foam/nanos/u2/navigation/TopNavigation.js
@@ -32,13 +32,15 @@ foam.CLASS({
 
   css: `
     ^ {
-      display: flex;
       background: %PRIMARYCOLOR%;
       width: 100%;
       min-width: 992px;
       height: 60px;
       color: white;
       padding-top: 5px;
+    }
+    ^ .logged-in-container {
+      display: flex;
     }
     ^ .menuBar {
       flex-grow: 2;
@@ -77,6 +79,16 @@ foam.CLASS({
       padding-bottom: 5px;
       text-shadow: 0 0 0px white, 0 0 0px white;
     }
+    ^ .welcome-label {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 16px;
+      line-height: 1.25;
+      letter-spacing: 0.3px;
+      width: 100%;
+      height: calc(100% - 5px); /* Compensate for 5px padding-top of topnav */
+    }
   `,
 
   properties: [
@@ -89,14 +101,19 @@ foam.CLASS({
   methods: [
     function initE() {
       this
-      .addClass(this.myClass())
-      .show(this.loginSuccess$)
-      .start({ class: 'foam.nanos.u2.navigation.BusinessLogoView' })
-      .end()
-      .start({ class: 'foam.nanos.menu.MenuBar' }).addClass('menuBar')
-      .end()
-      .start({ class: 'foam.nanos.u2.navigation.UserView' })
-      .end();
+        .addClass(this.myClass())
+        .start()
+          .addClass('logged-in-container')
+          .show(this.loginSuccess$)
+          .tag({ class: 'foam.nanos.u2.navigation.BusinessLogoView' })
+          .start({ class: 'foam.nanos.menu.MenuBar' })
+            .addClass('menuBar')
+          .end()
+          .tag({ class: 'foam.nanos.u2.navigation.UserView' })
+        .end()
+        .start()
+          .add('Welcome').addClass('welcome-label').hide(this.loginSuccess$)
+        .end();
     }
   ]
 });


### PR DESCRIPTION
To fix https://github.com/nanoPayinc/NANOPAY/issues/2296

[Zeplin Design](https://app.zeplin.io/project/5a9ebc236bd1caa9153f0e2b/screen/5a9f005bf5fed00857d1d0ea)

Note that there is a [possibly conflicting design](https://app.zeplin.io/project/58ed17e322a7ba2e76e55cde/screen/591085151282d3b77fa8115e) that has the text "B2B Portal" instead of "Welcome". Since this is a foam2 fix, "Welcome" seems more appropriate because it's not specific to NANOPAY.