### PR TITLE
Default journal creation to true.

### DIFF
--- a/src/foam/dao/JournalJava.js
+++ b/src/foam/dao/JournalJava.js
@@ -155,7 +155,7 @@ foam.CLASS({
       class: 'Boolean',
       name: 'createFile',
       documentation: 'Flag to create file if not present',
-      value: false,
+      value: true,
     },
     {
       class: 'Object',
@@ -166,7 +166,7 @@ foam.CLASS({
           getLogger().log("Loading file: " + getFilename());
           File file = getX().get(Storage.class).get(getFilename());
           if ( ! file.exists() ) {
-            getLogger().warning("Can not find file: " + getFilename());
+            getLogger().warning("Journal not found:" + getFilename());
 
             if ( getCreateFile() ) {
               // if output journal does not exist, create one


### PR DESCRIPTION
- gracefully handle missing dot.zero files
  - generates warning, but no stack trace for files we expect to be missing.
- ensure any missing production journal is created.