### PR TITLE
Serialize and deserialize enums like FObjects rather than just using ordinal

### DIFF
--- a/src/foam/core/AbstractEnumPropertyInfo.java
+++ b/src/foam/core/AbstractEnumPropertyInfo.java
@@ -36,7 +36,6 @@ public abstract class AbstractEnumPropertyInfo
 
   public abstract int getOrdinal(Object o);
   public abstract java.lang.Enum forOrdinal(int ordinal);
-  public abstract void toJSON(foam.lib.json.Outputter outputter, Object value);
   public abstract void toCSV(foam.lib.csv.Outputter outputter, Object value);
 
   @Override

--- a/src/foam/core/Enum.js
+++ b/src/foam/core/Enum.js
@@ -268,6 +268,7 @@ foam.CLASS({
     {
       class: 'String',
       name: 'documentation',
+      transient: true,
       adapt: function(_, d) {
         return typeof d === 'function' ? foam.String.multiline(d).trim() : d;
       }
@@ -285,11 +286,13 @@ foam.CLASS({
     {
       class: 'String',
       name: 'name',
+      transient: true,
       final: true
     },
     {
       class: 'String',
       name: 'label',
+      transient: true,
       final: true,
       factory: function() {
         return this.name;

--- a/src/foam/core/Enum.js
+++ b/src/foam/core/Enum.js
@@ -298,9 +298,6 @@ foam.CLASS({
   ],
 
   methods: [
-    function outputFObject(o) {
-      o.out(this.ordinal);
-    },
     function toString() { return this.name; }
   ]
 });
@@ -355,10 +352,6 @@ foam.CLASS({
         throw 'Attempt to set invalid Enum value. Enum: ' + of.id + ', value: ' + n;
       }
     ],
-    {
-      name: 'toJSON',
-      value: function(value) { return value.ordinal; }
-    }
   ]
 });
 

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -775,7 +775,15 @@ foam.CLASS({
       }
     },
     ['javaInfoType', 'foam.core.AbstractEnumPropertyInfo'],
-    ['javaJSONParser', 'new foam.lib.json.IntParser()'],
+    {
+      name: 'javaJSONParser',
+      expression: function(of) {
+        // TODO: Ditch the IntParser and only use FObjectParser.
+        return `new foam.lib.parse.Alt(
+          new foam.lib.json.FObjectParser(${of ? of.id + '.class' : ''}),
+          new foam.lib.json.IntParser())`;
+      }
+    },
     ['javaCSVParser', 'foam.lib.json.IntParser']
   ],
 
@@ -807,23 +815,6 @@ foam.CLASS({
           }
         ],
         body: `return ${this.of.id}.forOrdinal(ordinal);`
-      });
-
-      info.method({
-        name: 'toJSON',
-        visibility: 'public',
-        type: 'void',
-        args: [
-          {
-            name: 'outputter',
-            type: 'foam.lib.json.Outputter'
-          },
-          {
-            name: 'value',
-            type: 'Object'
-          }
-        ],
-        body: `outputter.output(getOrdinal(value));`
       });
 
       info.method({

--- a/test/src/core/Enum.js
+++ b/test/src/core/Enum.js
@@ -71,7 +71,10 @@ describe('Enum tests', function() {
 
     todo.status = TodoStatus.CLOSED;
     expect(todo.status).toBe(TodoStatus.CLOSED);
-    expect(foam.json.objectify(todo).status).toBe(TodoStatus.CLOSED.ordinal);
+    expect(foam.json.objectify(todo).status).toEqual({
+      ordinal: 100,
+      isOpen: false
+    });
 
     expect(function() {
       todo.status = 'invalid enum value';


### PR DESCRIPTION
This cuts down on the ambiguity that happens when using enums in the Constant expression.