### PR TITLE
Swift fixes

### DIFF
--- a/src/foam/blob/Blob.js
+++ b/src/foam/blob/Blob.js
@@ -360,7 +360,6 @@ foam.CLASS({
       name: 'id'
     },
     {
-      class: 'Blob',
       name: 'delegate',
       transient: true,
       factory: function() {

--- a/src/foam/swift/refines/Property.js
+++ b/src/foam/swift/refines/Property.js
@@ -341,7 +341,7 @@ self.set(key: "<%=this.swiftName%>", value: <%=this.swiftFactoryName%>())
 return <%=this.swiftValueName%><% if ( this.swiftRequiresCast ) { %>!<% } %>
 <% } else if ( this.swiftExpression ) { %>
 if <%= this.swiftExpressionSubscriptionName %> != nil { return <%= this.swiftValueName %> }
-let valFunc = { [unowned self] () -> <%= this.swiftValueType %> in
+let valFunc = { [unowned self] () -> <%= this.swiftType %> in
   <% for (var i = 0, arg; arg = this.swiftExpressionArgs[i]; i++) { arg = arg.split('$') %>
   let <%=arg.join('$')%> = self.<%=arg[0]%><% if (arg.length > 1) {%>$<% arg.slice(1).forEach(function(a) { %>.dot("<%=a%>")<% }) %>.swiftGet()<% } %>
   <% } %>


### PR DESCRIPTION
- Use swiftType instead of swiftValueType in expression closures to remove a warning.
- Remove "class: 'Blob'" from the 'delegate' property on 'IdentifiedBlob' because it conflicts with the super class' type of that property.