### PR TITLE
Create PublicUserInfoDAO

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -515,4 +515,5 @@ FOAM_FILES([
   { name: "foam/crypto/hash/Hashable" },
   { name: "foam/crypto/sign/Signer" },
   { name: "foam/crypto/sign/Signable" },
+  { name: "foam/nanos/auth/PublicUserEntity" },
 ]);

--- a/src/foam/dao/PublicUserInfoDAO.java
+++ b/src/foam/dao/PublicUserInfoDAO.java
@@ -1,0 +1,112 @@
+package foam.dao;
+
+import foam.dao.*;
+import foam.core.FObject;
+import foam.core.PropertyInfo;
+import foam.core.X;
+import foam.dao.DAO;
+import foam.dao.ProxyDAO;
+import foam.dao.Sink;
+import foam.nanos.auth.PublicUserEntity;
+import foam.nanos.auth.User;
+import net.nanopay.tx.model.Transaction;
+import foam.mlang.order.Comparator;
+import foam.mlang.predicate.Predicate;
+import foam.nanos.logger.Logger;
+
+/**
+ * Populate a model returned from find or select with a small subset of public 
+ * user information.
+ *
+ * Example: A call like
+ *
+ *   new foam.dao.PublicUserInfoDAO(x, "payerId", "payer", ...)
+ *
+ * will look for a property named "payerId" on the object being selected and
+ * look up the user associated with that id. It will then set the given property
+ * ("payer") to the object being returned that contains some public properties
+ * of the associated user.
+ *
+ * Requires both properties to already be defined on the model. For example, on
+ * Transaction.js:
+ *
+ *     ...
+ *   },
+ *   {
+ *    class: 'FObjectProperty',
+ *    of: 'net.nanopay.tx.model.TransactionEntity',
+ *    name: 'payee',
+ *    storageTransient: true
+ *   },
+ *   {
+ *    class: 'Long',
+ *    name: 'payeeId'
+ *   },
+ *   {
+ *     ...
+ */
+public class PublicUserInfoDAO
+  extends ProxyDAO
+{
+  private String idPropertyName_;
+  private String propertyNameToSet_;
+
+  public PublicUserInfoDAO(
+      X x,
+      String idPropertyName,
+      String propertyNameToSet,
+      DAO delegate
+  ) {
+    super(x, delegate);
+    idPropertyName_ = idPropertyName;
+    propertyNameToSet_ = propertyNameToSet;
+    userDAO_ = (DAO) x.get("localUserDAO");
+    logger_ = (Logger) x.get("logger");
+  }
+
+  protected DAO userDAO_;
+  protected Logger logger_;
+
+  private class DecoratedSink extends foam.dao.ProxySink {
+    public DecoratedSink(X x, Sink delegate) {
+      super(x, delegate);
+    }
+
+    @Override
+    public void put(Object obj, foam.core.Detachable sub) {
+      obj = fillEntitiesInfo((FObject) obj);
+      getDelegate().put(obj, sub);
+    }
+  }
+
+  @Override
+  public FObject find_(X x, Object id) {
+    FObject obj = getDelegate().find_(x, id);
+    if ( obj != null ) {
+      obj = fillEntitiesInfo(obj);
+    }
+    return obj;
+  }
+
+  @Override
+  public Sink select_(X x, Sink sink, long skip, long limit, Comparator order, Predicate predicate) {
+    Sink decoratedSink = new DecoratedSink(x, sink);
+    getDelegate().select_(x, decoratedSink, skip, limit, order, predicate);
+    return sink;
+  }
+
+  private FObject fillEntitiesInfo(FObject obj) {
+    FObject clone = obj.fclone();
+    long id = (long) clone.getProperty(idPropertyName_);
+    User user = (User) userDAO_.find(id);
+
+    if ( user == null ) {
+      clone.setProperty(propertyNameToSet_, null);
+    }
+
+    PublicUserEntity entity = new PublicUserEntity(user);
+    clone.setProperty(propertyNameToSet_, entity);
+
+    return clone;
+  }
+}

--- a/src/foam/nanos/auth/PublicUserEntity.js
+++ b/src/foam/nanos/auth/PublicUserEntity.js
@@ -1,0 +1,73 @@
+foam.CLASS({
+  package: 'foam.nanos.auth',
+  name: 'PublicUserEntity',
+  documentation: `This model represents a public subset of a user's properties`,
+
+  javaImports: ['foam.nanos.auth.User'],
+
+  properties: [
+    {
+      class: 'Long',
+      name: 'id',
+      visibility: foam.u2.Visibility.RO
+    },
+    {
+      class: 'String',
+      name: 'firstName',
+      visibility: foam.u2.Visibility.RO
+    },
+    {
+      class: 'String',
+      name: 'lastName',
+      visibility: foam.u2.Visibility.RO
+    },
+    {
+      class: 'EMail',
+      name: 'email'
+    },
+    {
+      class: 'foam.nanos.fs.FileProperty',
+      name: 'profilePicture',
+      view: { class: 'foam.nanos.auth.ProfilePictureView' }
+    }
+  ],
+  axioms: [
+    {
+      writeToSwiftClass: function(cls) {
+        cls.method(foam.swift.Method.create({
+          static: true,
+          name: 'fromUser',
+          returnType: 'PublicUserEntity',
+          args: [
+            foam.swift.Argument.create({
+              type: 'User',
+              localName: 'u',
+            }),
+            foam.swift.Argument.create({
+              type: 'Context',
+              externalName: 'x',
+              localName: 'x',
+              defaultValue: 'Context.GLOBAL',
+            })
+          ],
+          body: `
+            let t = x.create(PublicUserEntity.self)!
+            t.copyFrom(u)
+            return t
+          `
+        }))
+      },
+      buildJavaClass: function(cls) {
+        cls.extras.push(`
+          public PublicUserEntity(User user) {
+            setId(user.getId());
+            setFirstName(user.getFirstName());
+            setLastName(user.getLastName());
+            setEmail(user.getEmail());
+            setProfilePicture(user.getProfilePicture());
+          }
+        `);
+      },
+    },
+  ],
+});

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -235,7 +235,9 @@ var classes = [
   'foam.nanos.dig.DUG',
 
   'foam.lib.query.TestModel',
-  'foam.lib.query.FooEnum'
+  'foam.lib.query.FooEnum',
+
+  'foam.nanos.auth.PublicUserEntity'
 ];
 
 var abstractClasses = [


### PR DESCRIPTION
This commit introduces a new generic DAO decorator that decorates the
find and select methods of a DAO. It takes two property names, one that
holds a user id and one that will hold a subset of the properties of
said user. It looks up the user associated with the id and sets the
other property to an object with a few public properties of the user
that was looked up.

See the documentation in the code for example usage and more details.