### PR TITLE
Make the var name in swift overridable

### DIFF
--- a/demos/swift/js/somepackage/Test.js
+++ b/demos/swift/js/somepackage/Test.js
@@ -33,6 +33,10 @@ foam.CLASS({
       expression: function(firstName) { return firstName },
     },
     {
+      class: 'String',
+      name: 'description',
+    },
+    {
       name: 'anyProp',
     },
     {

--- a/src/foam/swift/refines/AbstractDAO.js
+++ b/src/foam/swift/refines/AbstractDAO.js
@@ -21,10 +21,10 @@ foam.CLASS({
         foam.swift.Field.create({
           lazy: true,
           visibility: 'public',
-          name: this.swiftName + '$proxy',
+          name: this.name + '$proxy',
           type: 'ProxyDAO',
           initializer: `
-let d = __context__.create(ProxyDAO.self, args: ["delegate": ${this.swiftName}])!
+let d = __context__.create(ProxyDAO.self, args: ["delegate": ${this.name}])!
 _ = ${this.swiftSlotName}.sub(listener: { sub, topics in
   if let dao = topics.last as? DAO {
     d.delegate = dao

--- a/src/foam/swift/refines/Property.js
+++ b/src/foam/swift/refines/Property.js
@@ -15,8 +15,16 @@ foam.CLASS({
   properties: [
     {
       class: 'String',
-      name: 'swiftName',
-      expression: function(name) { return name; },
+      name: 'swiftVarName',
+      expression: function(name) {
+        var reserved = [
+          'description',
+        ];
+        if ( reserved.indexOf(name) != -1 ) {
+          return 'swift_' + name;
+        }
+        return name;
+      },
     },
     {
       class: 'String',
@@ -25,27 +33,27 @@ foam.CLASS({
     {
       class: 'String',
       name: 'swiftSlotLinkSubName',
-      expression: function(swiftName) { return swiftName + '_Value_Sub_'; },
+      expression: function(name) { return name + '_Value_Sub_'; },
     },
     {
       class: 'String',
       name: 'swiftSlotValueName',
-      expression: function(swiftName) { return swiftName + '_Value_'; },
+      expression: function(name) { return name + '_Value_'; },
     },
     {
       class: 'String',
       name: 'swiftSlotName',
-      expression: function(swiftName) { return swiftName + '$'; },
+      expression: function(name) { return name + '$'; },
     },
     {
       class: 'String',
       name: 'swiftInitedName',
-      expression: function(swiftName) { return '_' + swiftName + '_inited_'; },
+      expression: function(name) { return '_' + name + '_inited_'; },
     },
     {
       class: 'String',
       name: 'swiftValueName',
-      expression: function(swiftName) { return '_' + swiftName + '_'; },
+      expression: function(name) { return '_' + name + '_'; },
     },
     {
       class: 'String',
@@ -70,7 +78,7 @@ foam.CLASS({
     {
       class: 'String',
       name: 'swiftFactoryName',
-      expression: function(swiftName) { return '_' + swiftName + '_factory_'; },
+      expression: function(name) { return '_' + name + '_factory_'; },
     },
     {
       class: 'String',
@@ -90,7 +98,7 @@ foam.CLASS({
     {
       class: 'String',
       name: 'swiftPreSetFuncName',
-      expression: function(swiftName) { return '_' + swiftName + '_preSet_'; },
+      expression: function(name) { return '_' + name + '_preSet_'; },
     },
     {
       class: 'String',
@@ -99,7 +107,7 @@ foam.CLASS({
     {
       class: 'String',
       name: 'swiftPostSetFuncName',
-      expression: function(swiftName) { return '_' + swiftName + '_postSet_'; },
+      expression: function(name) { return '_' + name + '_postSet_'; },
     },
     {
       class: 'String',
@@ -119,7 +127,7 @@ foam.CLASS({
     {
       class: 'String',
       name: 'swiftExpressionSubscriptionName',
-      expression: function(swiftName) { return '_' + swiftName + '_expression_'; },
+      expression: function(name) { return '_' + name + '_expression_'; },
     },
     {
       class: 'String',
@@ -132,17 +140,17 @@ foam.CLASS({
     {
       class: 'String',
       name: 'swiftAdaptFuncName',
-      expression: function(swiftName) { return '_' + swiftName + '_adapt_'; },
+      expression: function(name) { return '_' + name + '_adapt_'; },
     },
     {
       class: 'String',
       name: 'swiftPrivateAxiomName',
-      expression: function(swiftName) { return '_' + foam.String.constantize(swiftName) + '_'; },
+      expression: function(name) { return '_' + foam.String.constantize(name) + '_'; },
     },
     {
       class: 'String',
       name: 'swiftAxiomName',
-      expression: function(swiftName) { return foam.String.constantize(swiftName); },
+      expression: function(name) { return foam.String.constantize(name); },
     },
     {
       class: 'String',
@@ -190,7 +198,7 @@ return v1.hash ?? 0 > v2.hash ?? 0 ? 1 : -1
       cls.fields.push(this.Field.create({
         visibility: 'public',
         override: isOverride,
-        name: this.swiftName,
+        name: this.swiftVarName,
         type: this.swiftType,
         getter: this.swiftGetter || this.swiftGetterTemplate(),
         setter: this.swiftSetter(),
@@ -321,7 +329,7 @@ return v1.hash ?? 0 > v2.hash ?? 0 ? 1 : -1
       template: function() {/*
 let s = PropertySlot([
   "object": self,
-  "propertyName": "<%=this.swiftName%>",
+  "propertyName": "<%=this.name%>",
 ])
 self.onDetach(Subscription(detach: {
   s.detach()
@@ -332,7 +340,7 @@ return s
     {
       name: 'swiftSetter',
       template: function() {/*
-self.set(key: "<%=this.swiftName%>", value: value)
+self.set(key: "<%=this.name%>", value: value)
       */},
     },
     {
@@ -342,7 +350,7 @@ if <%=this.swiftInitedName%> {
   return <%=this.swiftValueName%><% if ( this.swiftType != this.swiftValueType ) { %>!<% } %>
 }
 <% if ( this.swiftFactory ) { %>
-self.set(key: "<%=this.swiftName%>", value: <%=this.swiftFactoryName%>())
+self.set(key: "<%=this.name%>", value: <%=this.swiftFactoryName%>())
 return <%=this.swiftValueName%><% if ( this.swiftRequiresCast ) { %>!<% } %>
 <% } else if ( this.swiftExpression ) { %>
 if <%= this.swiftExpressionSubscriptionName %> != nil { return <%= this.swiftValueName %> }
@@ -358,7 +366,7 @@ let detach: Listener = { [unowned self] _,_ in
     s.detach()
   }
   self.<%=this.swiftExpressionSubscriptionName%> = nil
-  self.clearProperty("<%=this.swiftName%>")
+  self.clearProperty("<%=this.name%>")
 }
 <%=this.swiftExpressionSubscriptionName%> = [
   <% for (var i = 0, arg; arg = this.swiftExpressionArgs[i]; i++) { arg = arg.split('$') %>
@@ -375,7 +383,7 @@ return <%=this.swiftValue%>
 <% } else if ( this.swiftType.match(/[!?]$/) ) { %>
 return nil
 <% } else { %>
-fatalError("No default value for <%=this.swiftName%>")
+fatalError("No default value for <%=this.name%>")
 <% } %>
       */},
     },
@@ -392,7 +400,7 @@ self.onDetach(self.<%=this.swiftSlotLinkSubName%>!)
       args: ['parentCls'],
       template: function() {/*
 class PInfo: PropertyInfo {
-  let name = "<%=this.swiftName%>"
+  let name = "<%=this.name%>"
   let classInfo: ClassInfo
   let transient = <%=!!this.transient%>
   let label = "<%=this.label%>" // TODO localize
@@ -408,17 +416,17 @@ class PInfo: PropertyInfo {
       for s in obj.<%=p.swiftExpressionSubscriptionName%>! { s.detach() }
     }
 <% } %>
-    let oldValue: Any? = obj.<%=p.swiftInitedName%> ? obj.`<%=p.swiftName%>` : nil
+    let oldValue: Any? = obj.<%=p.swiftInitedName%> ? obj.`<%=p.name%>` : nil
     obj.<%=p.swiftValueName%> = obj.<%=p.swiftPreSetFuncName%>(oldValue, obj.<%=p.swiftAdaptFuncName%>(oldValue, value))
     obj.<%=p.swiftInitedName%> = true
     obj.<%=p.swiftPostSetFuncName%>(oldValue, obj.<%=p.swiftValueName%>)
-    if obj.hasListeners(["propertyChange", "<%=p.swiftName%>"]) && !FOAM_utils.equals(oldValue, obj.<%=p.swiftValueName%>) {
-      _ = obj.pub(["propertyChange", "<%=p.swiftName%>", obj.<%=p.swiftSlotName%>])
+    if obj.hasListeners(["propertyChange", "<%=p.name%>"]) && !FOAM_utils.equals(oldValue, obj.<%=p.swiftValueName%>) {
+      _ = obj.pub(["propertyChange", "<%=p.name%>", obj.<%=p.swiftSlotName%>])
     }
   }
   public func get(_ obj: FObject) -> Any? {
     let obj = obj as! <%=parentCls.model_.swiftName%>
-    return obj.<%=this.swiftName%>
+    return obj.<%=this.swiftVarName%>
   }
   public func getSlot(_ obj: FObject) -> Slot {
     let obj = obj as! <%=parentCls.model_.swiftName%>
@@ -445,8 +453,8 @@ class PInfo: PropertyInfo {
 <% } %>
 
     // Only pub if there are listeners.
-    if obj.hasListeners(["propertyChange", "<%=p.swiftName%>"]) {
-      _ = obj.pub(["propertyChange", "<%=p.swiftName%>", obj.<%=p.swiftSlotName%>])
+    if obj.hasListeners(["propertyChange", "<%=p.name%>"]) {
+      _ = obj.pub(["propertyChange", "<%=p.name%>", obj.<%=p.swiftSlotName%>])
     }
   }
   public func compareValues(_ v1: Any?, _ v2: Any?) -> Int {


### PR DESCRIPTION
This was kind of possible before but would also mess with serialization. Now, it should be isolated to just the variable name.