### PR TITLE
Roll back some changes from https://github.com/foam-framework/foam2/pull/1270/files

### DIFF
--- a/src/foam/box/NamedBox.js
+++ b/src/foam/box/NamedBox.js
@@ -74,6 +74,7 @@ return ownClassInfo().create(args: [
     },
     {
       name: 'getBaseName',
+      returns: 'String',
       swiftReturns: 'String',
       code: function getBaseName() {
         return this.name.substring(this.name.lastIndexOf('/') + 1);

--- a/src/foam/core/Proxy.js
+++ b/src/foam/core/Proxy.js
@@ -370,7 +370,7 @@ for (key, child) in children {
           swiftType: 'String',
         },
       ],
-      returns: 'foam.core.EventProxy',
+      swiftReturns: 'foam_core_EventProxy',
       code: function getChild(key) {
         if ( ! this.children[key] ) {
           this.children[key] = this.cls_.create({

--- a/src/foam/dao/AbstractDAO.js
+++ b/src/foam/dao/AbstractDAO.js
@@ -282,7 +282,7 @@ listeners_.add(new DAOListener(sink, listeners_));
 
     {
       name: 'decorateListener_',
-      returns: 'foam.dao.Sink',
+      swiftReturns: 'foam_dao_Sink',
       javaReturns: 'Sink',
       args: [
         {
@@ -330,7 +330,7 @@ return sink;
     */
     {
       name: 'decorateSink_',
-      returns: 'foam.dao.Sink',
+      swiftReturns: 'foam_dao_Sink',
       javaReturns: 'foam.dao.Sink',
       args: [
         {

--- a/src/foam/dao/Relationship.js
+++ b/src/foam/dao/Relationship.js
@@ -293,17 +293,17 @@ foam.INTERFACE({
     {
       name: 'getDAO',
       javaReturns: 'foam.dao.DAO',
-      returns: 'foam.dao.DAO'
+      swiftReturns: 'foam_dao_DAO'
     },
     {
       name: 'getJunctionDAO',
       javaReturns: 'foam.dao.DAO',
-      returns: 'foam.dao.DAO'
+      swiftReturns: 'foam_dao_DAO'
     },
     {
       name: 'getTargetDAO',
       javaReturns: 'foam.dao.DAO',
-      returns: 'foam.dao.DAO'
+      swiftReturns: 'foam_dao_DAO'
     },
   ]
 });

--- a/src/foam/nanos/auth/AuthService.js
+++ b/src/foam/nanos/auth/AuthService.js
@@ -40,7 +40,7 @@ foam.INTERFACE({
     {
       name: 'challengedLogin',
       javaReturns: 'foam.nanos.auth.User',
-      returns: 'foam.nanos.auth.User',
+      swiftReturns: 'foam_nanos_auth_User',
       javaThrows: [ 'javax.naming.AuthenticationException' ],
       swiftThrows: true,
       args: [
@@ -64,7 +64,7 @@ foam.INTERFACE({
     {
       name: 'login',
       javaReturns: 'foam.nanos.auth.User',
-      returns: 'foam.nanos.auth.User',
+      swiftReturns: 'foam_nanos_auth_User',
       javaThrows: [ 'javax.naming.AuthenticationException' ],
       swiftThrows: true,
       args: [
@@ -88,7 +88,7 @@ foam.INTERFACE({
     {
       name: 'loginByEmail',
       javaReturns: 'foam.nanos.auth.User',
-      returns: 'foam.nanos.auth.User',
+      swiftReturns: 'foam_nanos_auth_User',
       javaThrows: [ 'javax.naming.AuthenticationException' ],
       swiftThrows: true,
       args: [

--- a/src/lib/Stub.js
+++ b/src/lib/Stub.js
@@ -129,6 +129,7 @@ foam.CLASS({
                   name: m.name,
                   replyPolicyName: replyPolicyName,
                   boxPropName: name,
+                  // javaReturns: m.javaReturns, TODO Should we do this?
                   swiftReturns: m.swiftReturns,
                   args: m.args,
                   returns: returns


### PR DESCRIPTION
Undo some places I changed swiftReturns to just returns in https://github.com/foam-framework/foam2/pull/1270/files

This was causing methods in a stub to have a different return type.
A method that returns: 'foo.Bar' would get a return type of 'foo.PromisedBar'
and when this is specified, js tries to lookup and create an instance of
that rather than treating it as a promise.