### PR TITLE
Polyfill local storage with in memory version if local storage is in a broken state.

### DIFF
--- a/src/foam/core/poly.js
+++ b/src/foam/core/poly.js
@@ -113,3 +113,42 @@ if( ! Object.is ) {
     return x !== x && y !== y;
   };
 }
+
+if ( typeof localStorage != "undefined" ) {
+  try {
+    localStorage.getItem('asdf')
+  } catch(e) {
+    console.warn("Local storage error", e);
+    console.warn("Substituting in memory local storage.");
+
+    Object.defineProperty(this, 'localStorage', {
+      value: (function() {
+        var prototype = {
+          getItem: function(key) {
+            return this[key];
+          },
+          key: function(n) {
+            return Object.keys(this)[n];
+          },
+          setItem: function(key, value) {
+            this[key] = value;
+          },
+          removeItem: function(key) {
+            delete this[key];
+          },
+          clear: function() {
+            var self = this;
+            Object.keys(this).map(function(k) { self.removeItem(k); });
+          },
+          get length() {
+            return Object.keys(this).length;
+          }
+        };
+
+        return Object.create(prototype);
+      })(),
+      configurable: true,
+      enumerable: true
+    });
+  };
+}


### PR DESCRIPTION
Fixes #1289 

I'm open to other suggestions too.  Long term it would be good to display a notification to the user that they should restart their browser or something.

It would also be better to stop using local storage directly and use a modeled foam service provided via context for local storage things, but this fixes a real problem we have now finding and re-writing all localstorage usages.