### PR TITLE
Fix enum's value adapt

### DIFF
--- a/src/foam/core/Enum.js
+++ b/src/foam/core/Enum.js
@@ -205,18 +205,24 @@ foam.CLASS({
         for ( var i = 0 ; i < v.length ; i++ ) {
           var def = v[i];
 
+          if ( foam.Object.isInstance(def) && def.class ) {
+            def = this.lookup(def.class).create(def);
+          }
+
           if ( foam.String.isInstance(def) ) {
             def = { label: def, name: foam.String.constantize(def) };
           }
+
+          if ( ! foam.core.internal.EnumValueAxiom.isInstance(def) ) {
+            def = foam.core.internal.EnumValueAxiom.create({definition: def});
+          }
+
+          v[i] = def;
 
           if ( def.ordinal || def.ordinal === 0 ) {
             next = def.ordinal + 1;
           } else {
             def.ordinal = next++;
-          }
-
-          if ( ! foam.core.internal.EnumValueAxiom.isInstance(def) ) {
-            v[i] = def = foam.core.internal.EnumValueAxiom.create({definition: def});
           }
 
           if ( used[def.ordinal] ) {

--- a/src/foam/core/Enum.js
+++ b/src/foam/core/Enum.js
@@ -190,6 +190,10 @@ foam.CLASS({
   name: 'EnumModel',
   extends: 'Model',
 
+  requires: [
+    'foam.core.internal.EnumValueAxiom',
+  ],
+
   documentation: 'Model for defining Enum(erations).',
 
   properties: [
@@ -205,17 +209,13 @@ foam.CLASS({
         for ( var i = 0 ; i < v.length ; i++ ) {
           var def = v[i];
 
-          if ( foam.Object.isInstance(def) && def.class ) {
-            def = this.lookup(def.class).create(def);
-          }
-
           if ( foam.String.isInstance(def) ) {
             def = { label: def, name: foam.String.constantize(def) };
           }
 
-          if ( ! foam.core.internal.EnumValueAxiom.isInstance(def) ) {
-            def = foam.core.internal.EnumValueAxiom.create({definition: def});
-          }
+          def = this.EnumValueAxiom.isInstance(def) ? def :
+            def.class ? this.lookup(def.class).create(def) :
+            this.EnumValueAxiom.create({definition: def});
 
           v[i] = def;
 


### PR DESCRIPTION
The build tool spits out an enum like this:

foam.CLASS({"class":"foam.core.EnumModel","values":[{"class":"foam.core.internal.EnumValueAxiom","definition":{"name":"RW","label":"Read-Write","ordinal":0}},{"class":"foam.core.internal.EnumValueAxiom","definition":{"name":"FINAL","label":"Final","documentation":"FINAL views are editable only in CREATE ControllerMode.","ordinal":1}},{"class":"foam.core.internal.EnumValueAxiom","definition":{"name":"DISABLED","label":"Disabled","documentation":"DISABLED views are visible but not editable.","ordinal":2}},{"class":"foam.core.internal.EnumValueAxiom","definition":{"name":"RO","label":"Read-Only","ordinal":3}},{"class":"foam.core.internal.EnumValueAxiom","definition":{"name":"HIDDEN","label":"Hidden","ordinal":4}}],"package":"foam.u2","name":"Visibility","documentation":"View visibility mode combines with current ControllerModel to determine DisplayMode."});

And without this PR, foam chokes on that.