### PR TITLE
Throw exception when trying to modify frozen object

### DIFF
--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -133,14 +133,7 @@ foam.CLASS({
 
     function generateSetter_() {
       return this.javaSetter ? this.javaSetter : `
-        // The next line will eventually be promoted to production
-        // if ( this.__frozen__ ) throw new UnsupportedOperationException("Object is frozen.");
-
-        // But until then, this line helps to detect code which needs to be fixed before then.
-        if ( this.__frozen__ ) {
-          System.err.println("!!!!!!!!!!!!!!!!!!!!!!! INVALID MUTATION OF FROZEN OBJECT, fclone() REQUIRED !!!!!!!!!!!!!!!!!!!!!!!");
-          Thread.dumpStack();
-        }
+        if ( this.__frozen__ ) throw new UnsupportedOperationException("Object is frozen.");
         assert${foam.String.capitalize(this.name)}(val);
         ${this.name}_ = val;
         ${this.name}IsSet_ = true;


### PR DESCRIPTION
Necessary to get the test named "Freeze test" to pass.

Do we still want to output the warning and stack trace before throwing the exception?

Are we ready to make this change yet?

@jlhughes @kgrgreer Please review.