### PR TITLE
foam.SCRIPT support/fixes

### DIFF
--- a/src/foam/apploader/ClassLoader.js
+++ b/src/foam/apploader/ClassLoader.js
@@ -24,6 +24,7 @@ have multiple classloaders running alongside eachother`
 ],*/
   requires: [
     'foam.classloader.OrDAO',
+    'foam.core.Script',
     'foam.dao.Relationship',
     'foam.apploader.SubClassLoader',
   ],
@@ -142,7 +143,14 @@ have multiple classloaders running alongside eachother`
             if ( self.Relationship.isInstance(m) ) {
               return m.initRelationship();
             }
-
+            if ( self.Script.isInstance(m) ) {
+              return Promise.all(m.requires.map(function(r) {
+                return self.load(r)
+              })).then(function() {
+                m.code()
+                return m;
+              });
+            }
             return this.buildClass_(m, path);
           }.bind(this), function() {
             throw new Error("Failed to load class " + id);

--- a/src/foam/apploader/ClassLoaderContext.js
+++ b/src/foam/apploader/ClassLoaderContext.js
@@ -23,7 +23,8 @@ foam.CLASS({
 });
 
 foam.SCRIPT({
-  id: 'foam.apploader.ClassLoaderContextScript',
+  package: 'foam.apploader',
+  name: 'ClassLoaderContextScript',
   requires: [
     'foam.apploader.ClassLoaderContext',
   ],

--- a/src/foam/apploader/ModelFileDAO.js
+++ b/src/foam/apploader/ModelFileDAO.js
@@ -61,6 +61,11 @@ foam.CLASS({
             context.foam.CLASS(json);
           };
 
+          context.foam.SCRIPT = function(json) {
+            json.class = json.class || 'foam.core.Script';
+            context.foam.CLASS(json);
+          };
+
           context.foam.RELATIONSHIP = function(r) {
             var s = r.sourceModel;
             var si = s.lastIndexOf('.');
@@ -81,12 +86,6 @@ foam.CLASS({
               });
             }
           };
-
-          context.foam.SCRIPT = function(m) {
-            m.class = 'foam.core.Script';
-            json = m;
-          };
-
 
           if ( foam.String.isInstance(text) ) {
             with ( context ) { eval(text); }

--- a/src/foam/apploader/ModelFileDAO.js
+++ b/src/foam/apploader/ModelFileDAO.js
@@ -82,6 +82,12 @@ foam.CLASS({
             }
           };
 
+          context.foam.SCRIPT = function(m) {
+            m.class = 'foam.core.Script';
+            json = m;
+          };
+
+
           if ( foam.String.isInstance(text) ) {
             with ( context ) { eval(text); }
           } else {

--- a/src/foam/core/Script.js
+++ b/src/foam/core/Script.js
@@ -11,7 +11,18 @@ foam.CLASS({
   properties: [
     {
       class: 'String',
-      name: 'id'
+      name: 'id',
+      expression: function(package, name) {
+        return package ? package + '.' + name : name;
+      },
+    },
+    {
+      class: 'String',
+      name: 'package'
+    },
+    {
+      class: 'String',
+      name: 'name'
     },
     {
       class: 'Function',

--- a/src/foam/core/debug.js
+++ b/src/foam/core/debug.js
@@ -141,7 +141,8 @@ foam.CLASS({
 });
 
 foam.SCRIPT({
-  id: 'foam.core.DebugScript',
+  package: 'foam.core',
+  name: 'DebugScript',
   flags: ['debug'],
   code: function() {
 foam.assert(
@@ -309,7 +310,8 @@ foam.CLASS({
 });
 
 foam.SCRIPT({
-  id: 'foam.core.DebugDescribeScript',
+  package: 'foam.core',
+  name: 'DebugDescribeScript',
   flags: ['debug'],
   code: function() {
 /* Add describe support to contexts. */
@@ -364,7 +366,8 @@ foam.CLASS({
 });
 
 foam.SCRIPT({
-  id: 'foam.core.DebugContextScript',
+  package: 'foam.core',
+  name: 'DebugContextScript',
   flags: ['debug'],
   code: function() {
 foam.__context__ = foam.debug.Window.create(null, foam.__context__).__subContext__;
@@ -451,7 +454,8 @@ foam.LIB({
 });
 
 foam.SCRIPT({
-  id: 'foam.core.DebugArgumentScript',
+  package: 'foam.core',
+  name: 'DebugArgumentScript',
   flags: ['debug'],
   code: function() {
 // Access Argument now to avoid circular reference because of lazy model building.
@@ -484,7 +488,8 @@ foam.CLASS({
 });
 
 foam.SCRIPT({
-  id: 'foam.core.DebugUpgradeLibScript',
+  package: 'foam.core',
+  name: 'DebugUpgradeLibScript',
   code: function() {
 // Upgrade a LIBs
 var upgradeLib = function upgradeLib(lib) {

--- a/src/foam/net/node/BaseHTTPRequest.js
+++ b/src/foam/net/node/BaseHTTPRequest.js
@@ -16,7 +16,8 @@
  */
 
 foam.SCRIPT({
-  id: 'foam.net.node.HTTPRequestScript',
+  package: 'foam.net.node',
+  name: 'HTTPRequestScript',
   requires: [
     'foam.net.node.HTTPRequest',
   ],

--- a/src/foam/net/web/BaseHTTPRequest.js
+++ b/src/foam/net/web/BaseHTTPRequest.js
@@ -17,7 +17,8 @@
 
 
 foam.SCRIPT({
-  id: 'foam.net.web.HTTPRequestScript',
+  package: 'foam.net.web',
+  name: 'HTTPRequestScript',
   requires: [
     'foam.net.web.HTTPRequest',
   ],

--- a/src/foam/parsers/html/lib.js
+++ b/src/foam/parsers/html/lib.js
@@ -16,7 +16,8 @@
  */
 
 foam.SCRIPT({
-  id: 'foam.parser.html.LibScript',
+  package: 'foam.parser.html',
+  name: 'LibScript',
   code: function() {
   // By decree of:
   // http://xahlee.info/js/html5_non-closing_tag.html

--- a/src/lib/net.js
+++ b/src/lib/net.js
@@ -16,7 +16,8 @@
  */
 
 foam.SCRIPT({
-  id: 'foam.net.LibScript',
+  package: 'foam.net',
+  name: 'LibScript',
   // TODO: flags/requires?
   code: function() {
   var pkg = 'foam.net.' + (foam.isServer ? 'node' : 'web');


### PR DESCRIPTION
- Give foam.core.Script a package and name and use them to generate the ID.
- Make the ModelFileDAO handle scripts.
- Make classloader support scripts. It will load all requires and execute the script.