### PR TITLE
Fixing sudo for scripts

### DIFF
--- a/src/foam/nanos/script/Script.js
+++ b/src/foam/nanos/script/Script.js
@@ -52,7 +52,10 @@ foam.CLASS({
       class: 'Boolean',
       name: 'enabled',
       tableCellFormatter: function(value) {
-        this.start().style({color: value ? 'green' : 'gray'}).add(value ? 'Y' : 'N').end();
+        this.start()
+          .style({ color: value ? 'green' : 'gray' })
+          .add(value ? 'Y' : 'N')
+        .end();
       },
       value: true
     },
@@ -97,13 +100,21 @@ foam.CLASS({
     {
       class: 'String',
       name: 'code',
-      view: { class: 'foam.u2.tag.TextArea', rows: 20, cols: 80, css: {"font-family": "monospace"} }
+      view: {
+        class: 'foam.u2.tag.TextArea',
+        rows: 20, cols: 80,
+        css: { 'font-family': 'monospace' }
+      }
     },
     {
       class: 'String',
       name: 'output',
       visibility: 'RO',
-      view: { class: 'foam.u2.tag.TextArea', rows: 12, cols: 80, css: {"font-family": "monospace"}  }
+      view: {
+        class: 'foam.u2.tag.TextArea',
+        rows: 12, cols: 80,
+        css: { 'font-family': 'monospace' }
+      }
     },
     {
       class: 'String',
@@ -126,7 +137,7 @@ foam.CLASS({
           shell.set("currentScript", this);
           shell.set("x", x);
           shell.eval("runScript(String name) { script = x.get(\\"scriptDAO\\").find(name); if ( script != null ) eval(script.code); }");
-          shell.eval("sudo(String user) { foam.util.Auth.sudo(x, user); }");
+          shell.eval("foam.core.X sudo(String user) { foam.util.Auth.sudo(x, (String) user); }");
         } catch (EvalError e) {}
 
         return shell;
@@ -179,7 +190,7 @@ foam.CLASS({
                 var notification = self.ScriptRunNotification.create({
                   userId: self.user.id,
                   scriptId: script.id,
-                  notificationType: "Script Execution",
+                  notificationType: 'Script Execution',
                   body: `Status: ${script.status}
                         Script Output: ${script.output}
                         LastDuration: ${script.lastDuration}`
@@ -209,7 +220,10 @@ foam.CLASS({
               }
           });
         } else {
-          var log = function() { this.output = this.output + Array.prototype.join.call(arguments, '') + '\n'; }.bind(this);
+          var log = function() {
+            this.output = this.output +
+              Array.prototype.join.call(arguments, '') + '\n';
+          }.bind(this);
 
           with ( { log: log, print: log, x: self.__context__ } ) {
             this.status = this.ScriptStatus.RUNNING;

--- a/src/foam/nanos/test/Test.js
+++ b/src/foam/nanos/test/Test.js
@@ -21,7 +21,9 @@ foam.CLASS({
   ],
 
   tableColumns: [
-    'id', 'enabled', 'description', 'server', 'passed', 'failed', 'lastRun', 'lastDuration', 'status', 'run'
+    'id', 'enabled', 'description', 'server',
+    'passed', 'failed', 'lastRun', 'lastDuration',
+    'status', 'run'
   ],
 
   searchColumns: [ ],
@@ -39,7 +41,7 @@ foam.CLASS({
       name: 'passed',
       visibility: foam.u2.Visibility.RO,
       tableCellFormatter: function(value) {
-        if ( value ) this.start().style({color: '#0f0'}).add(value).end();
+        if ( value ) this.start().style({ color: '#0f0' }).add(value).end();
       }
     },
     {
@@ -47,7 +49,7 @@ foam.CLASS({
       name: 'failed',
       visibility: foam.u2.Visibility.RO,
       tableCellFormatter: function(value) {
-        if ( value ) this.start().style({color: '#f00'}).add(value).end();
+        if ( value ) this.start().style({ color: '#f00' }).add(value).end();
       }
     }
   ],
@@ -56,6 +58,11 @@ foam.CLASS({
     {
       /** Template method used to add additional code in subclasses. */
       name: 'runTest',
+      args: [
+        {
+          name: 'x', javaType: 'foam.core.X'
+        }
+      ],
       javaReturns: 'void',
       javaCode: '/* NOOP */'
     },
@@ -114,7 +121,7 @@ foam.CLASS({
           // creates the testing method
           shell.eval("test(boolean exp, String message) { if ( exp ) { currentScript.setPassed(currentScript.getPassed()+1); } else { currentScript.setFailed(currentScript.getFailed()+1); } print((exp ? \\"SUCCESS: \\" : \\"FAILURE: \\")+message);}");
           shell.eval(getCode());
-          runTest();
+          runTest(x);
         } catch (Throwable e) {
           setFailed(getFailed()+1);
           ps.println();


### PR DESCRIPTION
Added `x` as an arg for `runTest`, for using `sudo` on the modelled java tests.
Explicitly specifying the return type and the `String user` for the bean shell wrapper of `sudo`, because it does not recognize the correct overridden `sudo` method in `foam.util.Auth`.