### PR TITLE
Move Simple property into it's own file.

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -33,6 +33,7 @@ FOAM_FILES([
   { name: "foam/core/FObject" },
   { name: "foam/core/Model" },
   { name: "foam/core/Property" },
+  { name: "foam/core/Simple" },
   { name: "foam/core/Method" },
   { name: "foam/core/Boolean" },
   { name: "foam/core/AxiomArray" },

--- a/src/foam/core/Property.js
+++ b/src/foam/core/Property.js
@@ -636,24 +636,3 @@ foam.CLASS({
     }
   ]
 });
-
-
-/**
-  A Simple Property skips the regular FOAM Property getter/setter/instance_
-  mechanism. In gets installed on the CLASS as a Property constant, but isn't
-  added to the prototype at all. From this point of view, it's mostly just for
-  documentation. Simple Properties are used only in special cases to maximize
-  performance and/or minimize memory use.
-  Used for MDAO indices and Slots.
-
-  USE WITH EXTREME CAUTION (OR NOT AT ALL).
-*/
-foam.CLASS({
-  package: 'foam.core',
-  name: 'Simple',
-  extends: 'Property',
-
-  methods: [
-    function installInProto(proto) {}
-  ]
-});

--- a/src/foam/core/Simple.js
+++ b/src/foam/core/Simple.js
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2018 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+  A Simple Property skips the regular FOAM Property getter/setter/instance_
+  mechanism. In gets installed on the CLASS as a Property constant, but isn't
+  added to the prototype at all. From this point of view, it's mostly just for
+  documentation. Simple Properties are used only in special cases to maximize
+  performance and/or minimize memory use.
+  Used for MDAO indices and Slots.
+
+  USE WITH EXTREME CAUTION (OR NOT AT ALL).
+*/
+foam.CLASS({
+  package: 'foam.core',
+  name: 'Simple',
+  extends: 'Property',
+
+  methods: [
+    function installInProto(proto) {}
+  ]
+});


### PR DESCRIPTION
The motivation here is to avoid a special case in the build tool.