### PR TITLE
Fixed fclone in java

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -521,4 +521,5 @@ FOAM_FILES([
   { name: "foam/crypto/sign/Signable" },
   { name: "foam/crypto/sign/SignableTest" },
   { name: "foam/test/TestObj" },
+  { name: "foam/core/FObjectTest" }
 ]);

--- a/src/foam/core/AbstractFObject.java
+++ b/src/foam/core/AbstractFObject.java
@@ -28,10 +28,11 @@ public abstract class AbstractFObject
 
   public FObject shallowClone() {
     try {
-      FObject ret = (FObject) getClass().newInstance();
+      FObject ret = getClass().newInstance();
       List<PropertyInfo> props = getClassInfo().getAxiomsByClass(PropertyInfo.class);
-      for ( PropertyInfo pi : props ) {
-        pi.set(ret, pi.get(this));
+      for ( PropertyInfo prop : props ) {
+        if ( ! prop.isSet(this) ) continue;
+        prop.set(ret, prop.get(this));
       }
       return ret;
     } catch (IllegalAccessException | InstantiationException e) {
@@ -41,10 +42,11 @@ public abstract class AbstractFObject
 
   public FObject fclone() {
     try {
-      FObject ret = (FObject) getClass().newInstance();
+      FObject ret = getClass().newInstance();
       List<PropertyInfo> props = getClassInfo().getAxiomsByClass(PropertyInfo.class);
-      for( PropertyInfo pi : props ) {
-        pi.cloneProperty(this, ret);
+      for( PropertyInfo prop : props ) {
+        if ( ! prop.isSet(this) ) continue;
+        prop.cloneProperty(this, ret);
       }
       return ret;
     } catch (IllegalAccessException | InstantiationException e) {

--- a/src/foam/core/FObjectTest.js
+++ b/src/foam/core/FObjectTest.js
@@ -1,0 +1,34 @@
+foam.CLASS({
+  package: 'foam.core',
+  name: 'FObjectTest',
+  extends: 'foam.nanos.test.Test',
+
+  documentation: 'FObject interface tests',
+
+  javaImports: [
+    'foam.nanos.auth.User'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+        User input = new User.Builder(x).setId(1000L)
+          .setFirstName("FOAM")
+          .setLastName("USER")
+          .build();
+
+        FObject_fclone_ClonedObjectEqualsOriginal(input);
+      `
+    },
+    {
+      name: 'FObject_fclone_ClonedObjectEqualsOriginal',
+      args: [
+        { class: 'FObjectProperty', name: 'input' }
+      ],
+      javaCode: `
+        test(input.equals(input.fclone()), "Cloned FObject equals original FObject");
+      `
+    }
+  ]
+});

--- a/src/foam/core/tests.jrl
+++ b/src/foam/core/tests.jrl
@@ -1,0 +1,1 @@
+p({"class":"foam.core.FObjectTest","id":"FObject Test","description":"Test FObject features"})

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -268,6 +268,7 @@ var classes = [
   'foam.util.EmailTest',
   'foam.util.PasswordTest',
   'foam.test.TestObj',
+  'foam.core.FObjectTest',
 ];
 
 var abstractClasses = [


### PR DESCRIPTION
1. fclone in java was not producing the correct functionality. Modified the clone functions to not clone a property if it's not set
2. Added a test to verify this functionality.