### PR TITLE
Swift - Add context param to require create

### DIFF
--- a/src/foam/swift/refines/Requires.js
+++ b/src/foam/swift/refines/Requires.js
@@ -37,6 +37,11 @@ foam.CLASS({
             defaultValue: '[:]',
             type: '[String:Any?]',
           }),
+          this.Argument.create({
+            localName: 'x',
+            defaultValue: 'nil',
+            type: 'Context?',
+          }),
         ],
       }));
     },
@@ -46,7 +51,7 @@ foam.CLASS({
       name: 'swiftInitializer',
       args: [],
       template: function() {/*
-return __subContext__.create(<%=this.swiftReturns%>.self, args: args)!
+return (x ?? __subContext__).create(<%=this.swiftReturns%>.self, args: args)!
       */},
     },
   ],


### PR DESCRIPTION
Add 2nd parameter to create that's generated for requires that allows you to overwrite context.