### PR TITLE
Replace deprecated new Date(string) method calls

### DIFF
--- a/src/foam/core/AbstractDatePropertyInfo.java
+++ b/src/foam/core/AbstractDatePropertyInfo.java
@@ -6,12 +6,16 @@
 
 package foam.core;
 
+import freemarker.template.SimpleDate;
+
 import javax.xml.stream.XMLStreamReader;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.Signature;
 import java.security.SignatureException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 public abstract class AbstractDatePropertyInfo
     extends AbstractPropertyInfo
@@ -27,6 +31,15 @@ public abstract class AbstractDatePropertyInfo
       ByteBuffer bb = super.get();
       bb.clear();
       return bb;
+    }
+  };
+
+  protected static final ThreadLocal<SimpleDateFormat> sdf = new ThreadLocal<SimpleDateFormat>() {
+    @Override
+    protected SimpleDateFormat initialValue() {
+      SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.S'Z'");
+      df.setTimeZone(TimeZone.getTimeZone("UTC"));
+      return df;
     }
   };
 

--- a/src/foam/core/AbstractDatePropertyInfo.java
+++ b/src/foam/core/AbstractDatePropertyInfo.java
@@ -6,8 +6,6 @@
 
 package foam.core;
 
-import freemarker.template.SimpleDate;
-
 import javax.xml.stream.XMLStreamReader;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -943,11 +943,18 @@ foam.CLASS({
     function createJavaPropertyInfo_(cls) {
       var info = this.SUPER(cls);
       var m = info.getMethod('cast');
-      m.body = `if ( o instanceof String ) {
-        java.util.Date date = new java.util.Date((String) o);
-        return date;
-        }
-        return (java.util.Date) o;`;
+      m.body = `
+        try {
+          if ( o instanceof Number ) {
+            return new java.util.Date(((Number) o).longValue());
+          } else if ( o instanceof String ) {
+            return sdf.get().parse((String) o);
+          } else {
+            return (java.util.Date) o;
+          }
+        } catch ( Throwable t ) {
+          throw new RuntimeException(t);
+        }`;
 
       return info;
   }
@@ -972,11 +979,18 @@ foam.CLASS({
      function createJavaPropertyInfo_(cls) {
        var info = this.SUPER(cls);
        var m = info.getMethod('cast');
-       m.body = `if ( o instanceof String ) {
-         java.util.Date date = new java.util.Date((String) o);
-         return date;
-         }
-         return (java.util.Date)o;`;
+      m.body = `
+        try {
+          if ( o instanceof Number ) {
+            return new java.util.Date(((Number) o).longValue());
+          } else if ( o instanceof String ) {
+            return sdf.get().parse((String) o);
+          } else {
+            return (java.util.Date) o;
+          }
+        } catch ( Throwable t ) {
+          throw new RuntimeException(t);
+        }`;
 
        return info;
      }


### PR DESCRIPTION
Replaced usage of new Date(string) with SimpleDateFormat parser. 
Also allows for the casting of numbers to Date objects.