### PR TITLE
Fix NPE in SendEmailNotificationDAO

### DIFF
--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -1114,6 +1114,7 @@ foam.CLASS({
     ['javaType', 'String[]'],
     ['javaInfoType', 'foam.core.AbstractArrayPropertyInfo'],
     ['javaJSONParser', 'new foam.lib.json.StringArrayParser()'],
+    ['javaFactory', 'return new String[0];'],
     {
       name: 'javaValue',
       expression: function(value) {

--- a/src/foam/nanos/notification/SendEmailNotificationDAO.java
+++ b/src/foam/nanos/notification/SendEmailNotificationDAO.java
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2018 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 package foam.nanos.notification;
 
 import foam.core.FObject;

--- a/src/foam/nanos/notification/SendEmailNotificationDAO.java
+++ b/src/foam/nanos/notification/SendEmailNotificationDAO.java
@@ -1,4 +1,5 @@
 package foam.nanos.notification;
+
 import foam.core.FObject;
 import foam.core.X;
 import foam.dao.DAO;
@@ -8,6 +9,7 @@ import foam.nanos.auth.User;
 import foam.nanos.notification.email.EmailMessage;
 import foam.nanos.notification.email.EmailService;
 import java.util.Arrays;
+import java.util.List;
 
 // If notification's emailEnabled is true, the decorator creates an email based on provided or default emailTemplate, sets the reciever based on notification userId/groupId/broadcasted
 public class SendEmailNotificationDAO extends ProxyDAO {
@@ -35,8 +37,12 @@ public class SendEmailNotificationDAO extends ProxyDAO {
     if ( ! notif.getEmailIsEnabled() )
       return super.put_(x, obj);
 
-    if ( Arrays.asList(user.getDisabledTopicsEmail()).contains(notif.getNotificationType()) )
-      return super.put_(x,obj);
+    if ( user.getDisabledTopicsEmail() != null ) {
+      List disabledTopics = Arrays.asList(user.getDisabledTopicsEmail());
+      if ( disabledTopics.contains(notif.getNotificationType()) ) {
+        return super.put_(x,obj);
+      }
+    }
 
     if ( "notification".equals(notif.getEmailName()) ) {
       notif.getEmailArgs().put("type", notif.getNotificationType());


### PR DESCRIPTION
My first thought was that it might be better if the generated Java code returned an empty `List` by default instead of `null` for `StringArray` foam properties, but I wasn't sure how to do that.

This code is just a simple null check, but I'd happily change it to a more generally applicable fix if anyone else can confirm that would be a better fix and can point me where to make the change.