### PR TITLE
Give javaReturns a default value

### DIFF
--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -443,7 +443,11 @@ foam.CLASS({
     },
     {
       class: 'String',
-      name: 'javaReturns'
+      name: 'javaReturns',
+      expression: function(returns) {
+        var of = foam.lookup(returns, true);
+        return of ? of.id : '';
+      },
     },
     {
       class: 'Boolean',

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -444,10 +444,7 @@ foam.CLASS({
     {
       class: 'String',
       name: 'javaReturns',
-      expression: function(returns) {
-        var of = foam.lookup(returns, true);
-        return of ? of.id : '';
-      },
+      expression: function(returns) { return returns || '' },
     },
     {
       class: 'Boolean',


### PR DESCRIPTION
Look at the value of `returns` to fill in a default for the `javaReturns`. This allows us to shorten something like:
```
returns: 'foam.foo.Bar',
javaReturns: 'foam.foo.Bar',
```
into just
```
returns: 'foam.foo.Bar',
```