### PR TITLE
Uncomment the javaReturns setting for StubMethods.

### DIFF
--- a/src/lib/Stub.js
+++ b/src/lib/Stub.js
@@ -136,7 +136,7 @@ foam.CLASS({
                   name: m.name,
                   replyPolicyName: replyPolicyName,
                   boxPropName: name,
-                  // javaReturns: m.javaReturns, TODO Should we do this?
+                  javaReturns: m.javaReturns,
                   swiftReturns: m.swiftReturns,
                   args: m.args,
                   returns: returns


### PR DESCRIPTION
I exposed a bug in https://github.com/foam-framework/foam2/pull/1416 where we never set the return type on java StubMethods. With that PR, `javaReturns` on a StubMethod will always just be the value of `returns` and will lose any `javaReturns` overrides.