### PR TITLE
Catch and ignore ClassCastExceptions when copying from base class int…

### DIFF
--- a/src/foam/core/AbstractFObject.java
+++ b/src/foam/core/AbstractFObject.java
@@ -58,7 +58,13 @@ public abstract class AbstractFObject
 
   public FObject copyFrom(FObject obj) {
     List<PropertyInfo> props = getClassInfo().getAxiomsByClass(PropertyInfo.class);
-    for ( PropertyInfo p : props ) p.set(this, p.get(obj));
+    for ( PropertyInfo p : props ) {
+      try {
+        p.set(this, p.get(obj));
+      } catch (java.lang.ClassCastException e) {
+        // nop - ignore - only copy common properties.
+      }
+    }
     return this;
   }
 


### PR DESCRIPTION
…o child class.

CopyFrom iterates over all properties of child class to copy 'from' base class.