### PR TITLE
Make swift's generated protocols be class-only protocols.

### DIFF
--- a/src/foam/swift/refines/AbstractInterface.js
+++ b/src/foam/swift/refines/AbstractInterface.js
@@ -13,7 +13,7 @@ foam.CLASS({
         cls.toSwiftClass =  function() {
           var cls = foam.lookup('foam.swift.Protocol').create({
             name: this.model_.swiftName,
-            implements: this.model_.swiftAllImplements
+            implements: ['class'].concat(this.model_.swiftAllImplements)
           });
 
           var axioms = this.getAxioms();


### PR DESCRIPTION
Any implementation we generate for a protocol is a class and having class-only protocols gives some benefits when using these objects because we can do things like `===`.