### PR TITLE
Swift storage and network transient support

### DIFF
--- a/src/foam/swift/parse/json/output/Outputter.js
+++ b/src/foam/swift/parse/json/output/Outputter.js
@@ -18,6 +18,14 @@ foam.CLASS({
       class: 'String',
       value: '"',
     },
+    {
+      swiftType: '((foam_core_FObject, PropertyInfo) -> Bool)',
+      swiftRequiresEscaping: true,
+      name: 'propertyPredicate',
+      swiftValue: `{ (_: foam_core_FObject, p: PropertyInfo) -> Bool in
+        return !p.transient
+      }`,
+    },
   ],
   methods: [
     {
@@ -307,7 +315,8 @@ out.append(":")
 outputString(&out, info.id)
 
 for p in info.axioms(byType: PropertyInfo.self) {
-  if !p.transient && data.hasOwnProperty(p.name) {
+  if !data.hasOwnProperty(p.name) { continue }
+  if propertyPredicate(data, p) {
     out.append(",")
     outputProperty(&out, data, p)
   }

--- a/src/foam/swift/refines/Property.js
+++ b/src/foam/swift/refines/Property.js
@@ -416,6 +416,8 @@ class PInfo: PropertyInfo {
   let name = "<%=this.name%>"
   let classInfo: ClassInfo
   let transient = <%=!!this.transient%>
+  let storageTransient = <%=!!this.storageTransient%>
+  let networkTransient = <%=!!this.networkTransient%>
   let label = "<%=this.label%>" // TODO localize
   lazy private(set) var visibility: <%=foam.u2.Visibility.model_.swiftName%> = {
     return <%=foam.u2.Visibility.model_.swiftName%>.<%=this.visibility.name%>

--- a/swift_src/FOAMSupport.swift
+++ b/swift_src/FOAMSupport.swift
@@ -45,6 +45,8 @@ class ListenerList {
 public protocol PropertyInfo: Axiom, SlotGetterAxiom, SlotSetterAxiom, GetterAxiom, SetterAxiom, foam_mlang_Expr {
   var classInfo: ClassInfo { get }
   var transient: Bool { get }
+  var storageTransient: Bool { get }
+  var networkTransient: Bool { get }
   var label: String { get }
   var visibility: foam_u2_Visibility { get }
   var jsonParser: foam_swift_parse_parser_Parser? { get }


### PR DESCRIPTION
Add storage and network transient fields to PropertyInfo and give the outputter a propertyPredicate that currently defaults to checking the value of transient.