### PR TITLE
Fix layout bug in ReciprocalSearch

### DIFF
--- a/src/foam/u2/view/SearchViewWrapper.js
+++ b/src/foam/u2/view/SearchViewWrapper.js
@@ -34,7 +34,17 @@ foam.CLASS({
     }
 
     ^ .section {
-      padding: 10px 13px;
+      padding: 13px 16px;
+    }
+
+    ^ .section:first-of-type {
+      display: flex;
+      align-items: center;
+    }
+
+    ^ .section:first-of-type label {
+      position: initial;
+      margin: 0 0 0 8px;
     }
 
     ^ .foam-u2-search-TextSearchView {


### PR DESCRIPTION
New (fixed):

<img width="312" alt="screen shot 2018-08-15 at 12 29 14 pm" src="https://user-images.githubusercontent.com/4259165/44159933-db4b3100-a086-11e8-8229-b937871e47f0.png">

Old (buggy):

<img width="316" alt="screen shot 2018-08-15 at 12 29 51 pm" src="https://user-images.githubusercontent.com/4259165/44159967-f322b500-a086-11e8-9b9d-b51b9f0a621c.png">

Checks off one box in https://github.com/foam-framework/foam2/issues/1443