### PR TITLE
Adapt axioms to objects if possible.

### DIFF
--- a/src/foam/core/Model.js
+++ b/src/foam/core/Model.js
@@ -73,7 +73,18 @@ foam.CLASS({
       name: 'axioms',
       hidden: true,
       factory: function() { return []; },
-      postSet: function(_, a) { this.axioms_.push.apply(this.axioms_, a); }
+      postSet: function(_, a) { this.axioms_.push.apply(this.axioms_, a); },
+      adapt: function(_, v) {
+        if ( ! Array.isArray(v) ) return v;
+        var copy;
+        for ( var i = 0 ; i < v.length ; i++ ) {
+          if ( v[i].class ) {
+            if ( ! copy ) copy = v.slice();
+            copy[i] = foam.lookup(v[i].class).create(v[i]);
+          }
+        }
+        return copy || v;
+      }
     },
     {
       // Is upgraded to an AxiomArray later.


### PR DESCRIPTION
Adapt 'axioms' on foam.core.Model to build objects that have a 'class' property. This is needed to ensure the axiom names are gettable otherwise foam will complain about axiom name conflicts. I encountered this when doing something like:
```
foam.CLASS({
...
  axioms: [
    { class: 'foam.u2.CSS', code: 'foo' },
    { class: 'foam.u2.CSS', code: 'bar' },
  ],
})
```