### PR TITLE
Log permission failures so an admin/support can inspect and fix.

### DIFF
--- a/src/foam/nanos/http/AuthWebAgent.java
+++ b/src/foam/nanos/http/AuthWebAgent.java
@@ -197,6 +197,7 @@ public class AuthWebAgent
       } else {
         PrintWriter out = x.get(PrintWriter.class);
         out.println("Access denied. Need permission: " + permission_);
+        ((foam.nanos.logger.Logger)x.get("logger")).debug("Access denied, requires permission:", permission_);
       }
     } else {
       templateLogin(x);


### PR DESCRIPTION
Presently, failures are being reported back to the user who in most cases
doesn't see the error response because of page redirects caused by the
permission failures.

see https://github.com/nanoPayinc/NANOPAY/issues/3218