### PR TITLE
Better DAO controller layout

### DIFF
--- a/src/foam/comics/DAOControllerView.js
+++ b/src/foam/comics/DAOControllerView.js
@@ -31,6 +31,12 @@ foam.CLASS({
 
   // TODO: wrong class name, fix when ActionView fixed.
   css: `
+    ^ {
+      width: fit-content;
+      max-width: 100vw;
+      margin: auto;
+    }
+
     .middle-row {
       display: flex;
     }


### PR DESCRIPTION
- Centre DAO Controller in container if less than full page width.

DAO controller is less wide than page:

<img width="1913" alt="screen shot 2018-08-16 at 11 18 13 am" src="https://user-images.githubusercontent.com/4259165/44217779-3f80fa00-a146-11e8-9eb1-47dfa6738175.png">


DAO controller is wider than page (same as current behaviour):

<img width="1915" alt="screen shot 2018-08-16 at 11 18 32 am" src="https://user-images.githubusercontent.com/4259165/44217783-43148100-a146-11e8-8abf-f17fc4e8a6a2.png">
