### PR TITLE
Add generic search on String properties to ReciprocalSearch

### DIFF
--- a/src/foam/u2/search/TextSearchView.js
+++ b/src/foam/u2/search/TextSearchView.js
@@ -115,16 +115,11 @@ foam.CLASS({
         }
 
         if ( this.richSearch ) {
-          this.predicate = this.filterController.filters
+          this.predicate = this.OR(...this.filterController.filters
             .map((name) => this.of.getAxiomByName(name))
             .filter((property) => foam.core.String.isInstance(property))
-            .reduce(
-              (acc, property) => this.OR(
-                this.CONTAINS_IC(property, value),
-                acc || this.False.create()
-              ),
-              this.queryParser.parseString(value)
-            );
+            .map((property) => this.CONTAINS_IC(property, value))
+            .concat(this.queryParser.parseString(value) || this.False.create()));
           return;
         }
 

--- a/src/foam/u2/search/TextSearchView.js
+++ b/src/foam/u2/search/TextSearchView.js
@@ -51,6 +51,16 @@ foam.CLASS({
       value: false
     },
     {
+      class: 'Boolean',
+      name: 'checkStrictEquality',
+      documentation: `
+        Set this flag if you want to match by strict equality instead of
+        checking if the text contains the string. Doing so should improve
+        performance.
+      `,
+      value: false
+    },
+    {
       name: 'queryParser',
       factory: function() {
         return this.QueryParser.create({ of: this.of });
@@ -108,6 +118,9 @@ foam.CLASS({
       name: 'updateValue',
       code: function() {
         var value = this.view.data;
+        var pred = this.checkStrictEquality ?
+          this.EQ.bind(this) :
+          this.CONTAINS_IC.bind(this);
 
         if ( ! value ) {
           this.predicate = this.True.create();
@@ -118,12 +131,12 @@ foam.CLASS({
           this.predicate = this.OR(...this.filterController.filters
             .map((name) => this.of.getAxiomByName(name))
             .filter((property) => foam.core.String.isInstance(property))
-            .map((property) => this.CONTAINS_IC(property, value))
+            .map((property) => pred(property, value))
             .concat(this.queryParser.parseString(value) || this.False.create()));
           return;
         }
 
-        this.predicate = this.CONTAINS_IC(this.property, value);
+        this.predicate = pred(this.property, value);
       }
     }
   ]

--- a/src/foam/u2/search/TextSearchView.js
+++ b/src/foam/u2/search/TextSearchView.js
@@ -27,10 +27,6 @@ foam.CLASS({
     'foam.u2.tag.Input'
   ],
 
-  imports: [
-    'filterController'
-  ],
-
   implements: [
     'foam.mlang.Expressions'
   ],
@@ -118,25 +114,16 @@ foam.CLASS({
       name: 'updateValue',
       code: function() {
         var value = this.view.data;
-        var pred = this.checkStrictEquality ?
-          this.EQ.bind(this) :
-          this.CONTAINS_IC.bind(this);
-
-        if ( ! value ) {
-          this.predicate = this.True.create();
-          return;
-        }
-
-        if ( this.richSearch ) {
-          this.predicate = this.OR(...this.filterController.filters
-            .map((name) => this.of.getAxiomByName(name))
-            .filter((property) => foam.core.String.isInstance(property))
-            .map((property) => pred(property, value))
-            .concat(this.queryParser.parseString(value) || this.False.create()));
-          return;
-        }
-
-        this.predicate = pred(this.property, value);
+        this.predicate = ! value ?
+          this.True.create() :
+          this.richSearch ?
+            this.OR(
+              this.queryParser.parseString(value) || this.False.create(),
+              this.KEYWORD(value)
+            ) :
+            this.checkStrictEquality ?
+              this.EQ(this.property, value) :
+              this.CONTAINS_IC(this.property, value);
       }
     }
   ]


### PR DESCRIPTION
Lets you type free-form text into the general search box at the top of ReciprocalSearch. Will still use MQL, but will also do a CONTAINS_IC on all columns of type String.

This lets you type in 'account' instead of 'name:account', for example.