### PR TITLE
Modified includeInDigest and includeInSignature functions to only generate method if set to false

### DIFF
--- a/src/foam/core/AbstractPropertyInfo.java
+++ b/src/foam/core/AbstractPropertyInfo.java
@@ -132,7 +132,17 @@ public abstract class AbstractPropertyInfo
   public void validate(X x, FObject obj) throws IllegalStateException {}
 
   @Override
+  public boolean includeInDigest() {
+    return true;
+  }
+
+  @Override
   public void updateDigest(FObject obj, MessageDigest md) {}
+
+  @Override
+  public boolean includeInSignature() {
+    return true;
+  }
 
   @Override
   public void updateSignature(FObject obj, Signature sig) throws SignatureException {}

--- a/src/foam/java/PropertyInfo.js
+++ b/src/foam/java/PropertyInfo.js
@@ -240,18 +240,6 @@ foam.CLASS({
             args: [ { name: 'o', type: 'Object' } ],
             /* TODO: revise when/if expression support is added to Java */
             body: `return foam.util.SafetyUtil.compare(get_(o), ${this.propValue}) == 0;`
-          },
-          {
-            name: 'includeInDigest',
-            visibility: 'public',
-            type: 'boolean',
-            body: `return ${this.includeInDigest};`
-          },
-          {
-            name: 'includeInSignature',
-            visibility: 'public',
-            type: 'boolean',
-            body: `return ${this.includeInSignature};`
           }
         ];
 
@@ -276,6 +264,26 @@ foam.CLASS({
                     { type: 'java.util.Map',          name: 'diff' },
                     { type: 'foam.core.PropertyInfo', name: 'prop' }],
             body: this.diffProperty
+          });
+        }
+
+        // default value is true, only generate if value is false
+        if ( ! this.includeInDigest ) {
+          m.push({
+            name: 'includeInDigest',
+            visibility: 'public',
+            type: 'boolean',
+            body: `return ${this.includeInDigest};`
+          });
+        }
+
+        // default value is true, only generate if value is false
+        if ( ! this.includeInSignature ) {
+          m.push({
+            name: 'includeInSignature',
+            visibility: 'public',
+            type: 'boolean',
+            body: `return ${this.includeInSignature};`
           });
         }
 


### PR DESCRIPTION
The default value is true, by generating the methods for properties when the property is explicitly set to false we reduce the amount of generated code:

#### Results
Lines before : 384242 total
Lines after : 366650 total