### PR TITLE
Modified WebSocketBox

### DIFF
--- a/src/foam/box/WebSocketBox.js
+++ b/src/foam/box/WebSocketBox.js
@@ -77,7 +77,7 @@ foam.CLASS({
 
         return protocol + this.window.location.hostname +
           ( this.window.location.port ? ':' + ( parseInt(this.window.location.port) + 1 ) : '' ) +
-          '/' + url;
+          '/' + url.replace('service', 'socket');
       }
 
       return url;

--- a/src/foam/nanos/tomcat/TomcatRouter.java
+++ b/src/foam/nanos/tomcat/TomcatRouter.java
@@ -31,7 +31,7 @@ public class TomcatRouter
       ((javax.websocket.server.ServerContainer)
        config.getServletContext().getAttribute("javax.websocket.server.ServerContainer")).
         addEndpoint(ServerEndpointConfig.Builder.
-                    create(WebSocketHandler.class, "/service/{service}").
+                    create(WebSocketHandler.class, "/socket/{service}").
                     configurator(new Configurator(getX())).
                     build());
     } catch (javax.websocket.DeploymentException e) {


### PR DESCRIPTION
Modified WebSocketBox to modify url to be /socket/{service} instead of /service/{service}.

The reason behind this change was that the NanoRouter's pathSpec of of "/service/*" was capturing the incoming WebSocket requests instead of the NanoWebSocketServer.