### PR TITLE
Show ReciprocalSearch when searchColumns is empty

### DIFF
--- a/src/foam/u2/view/ReciprocalSearch.js
+++ b/src/foam/u2/view/ReciprocalSearch.js
@@ -134,8 +134,6 @@ foam.CLASS({
       this.
         addClass(self.myClass()).
         add(this.slot(function(filters) {
-          self.show(filters.length);
-
           var searchManager = self.SearchManager.create({
             dao$: self.dao$,
             predicate$: self.data$


### PR DESCRIPTION
  - The general search field can still be used.

Closes https://github.com/foam-framework/foam2/issues/1488