### PR TITLE
Add placeholders to temporal inputs

### DIFF
--- a/src/foam/u2/DateTimeView.js
+++ b/src/foam/u2/DateTimeView.js
@@ -28,6 +28,7 @@ foam.CLASS({
     function initE() {
       this.SUPER();
       this.setAttribute('type', 'datetime-local');
+      this.setAttribute('placeholder', 'Eg: 24 Aug 2019 16:00');
     },
 
     function link() {

--- a/src/foam/u2/DateView.js
+++ b/src/foam/u2/DateView.js
@@ -34,6 +34,7 @@ foam.CLASS({
     function initE() {
       this.SUPER();
       this.setAttribute('type', 'date');
+      this.setAttribute('placeholder', 'Eg: 24 Aug 2019');
     },
 
     function link() {


### PR DESCRIPTION
Makes the date format clear on browsers that don't support GUI date or datetime pickers natively, such as Safari.