### PR TITLE
Remove copyFrom warning

### DIFF
--- a/src/foam/core/EndBoot.js
+++ b/src/foam/core/EndBoot.js
@@ -149,7 +149,7 @@ foam.CLASS({
     */
     function initArgs(args, ctx) {
       if ( ctx  ) this.__context__ = ctx;
-      if ( args ) this.copyFrom(args);
+      if ( args ) this.copyFrom(args, true);
     },
 
     /**

--- a/src/foam/core/EndBoot.js
+++ b/src/foam/core/EndBoot.js
@@ -149,7 +149,7 @@ foam.CLASS({
     */
     function initArgs(args, ctx) {
       if ( ctx  ) this.__context__ = ctx;
-      if ( args ) this.copyFrom(args, true);
+      if ( args ) this.copyFrom(args);
     },
 
     /**

--- a/src/foam/core/debug.js
+++ b/src/foam/core/debug.js
@@ -282,7 +282,16 @@ foam.CLASS({
   methods: [
     function unknownArg(key, value) {
       if ( key == 'class' ) return;
-      this.warn('Unknown property ' + this.cls_.id + '.' + key + ': ' + value);
+
+      // Temporarily disable warnings related to generating Java code.
+      var blackList = [
+        'javaThrows',
+        'javaReturns',
+        'javaCode'
+      ];
+      if ( ! blackList.some((keyword) => key.includes(keyword)) ) {
+        this.warn('Unknown property ' + this.cls_.id + '.' + key + ': ' + value);
+      }
     },
 
     function describe(opt_name) {


### PR DESCRIPTION
We get this warning hundreds of times in the console. Having so many
warnings makes all warnings useless, because no developer is going to
look through hundreds of warnings to see if the code they changed
generated a new one or not, they're just going to start ignoring all
warnings.

The intent of the warning seems to be to inform the developer that when
they call `copyFrom`, it won't copy anything other than a
`foam.core.Property`. Please correct me if I'm wrong.

I think the intent of the warning is fine, but the problem is that the
vast majority of the warnings are generated by foam internal code, not
developers *using* foam, who would actually benefit from the warning.
Therefore, the warning is doing more harm than good.