### PR TITLE
Added Java pre and post set functions

### DIFF
--- a/src/foam/java/Enum.js
+++ b/src/foam/java/Enum.js
@@ -71,6 +71,31 @@ foam.CLASS({
       }
     },
     {
+      name: 'fields',
+      factory: function() {
+        return [
+          {
+            name: 'ordinal_',
+            visibility: 'protected',
+            final: true,
+            type: 'int'
+          },
+          {
+            name: 'label_',
+            visibility: 'protected',
+            final: true,
+            type: 'String'
+          },
+          {
+            name: 'name_',
+            visibility: 'protected',
+            final: true,
+            type: 'String'
+          }
+        ]
+      }
+    },
+    {
       name: 'methods',
       factory: function() {
         return [
@@ -86,7 +111,29 @@ foam.CLASS({
                 type: 'String'
               },
             ],
-            body: 'setOrdinal(ordinal);\nsetLabel(label);\nsetName(name());'
+            body: `
+              ordinal_ = ordinal;
+              label_ = label;
+              name_ = name();
+            `
+          },
+          {
+            name: 'getOrdinal',
+            type: 'int',
+            visibility: 'public',
+            body: `return this.ordinal_;`
+          },
+          {
+            name: 'getLabel',
+            type: 'String',
+            visibility: 'public',
+            body: `return this.label_;`
+          },
+          {
+            name: 'getName',
+            type: 'String',
+            visibility: 'public',
+            body: `return this.name_;`
           },
           {
             name: 'forOrdinal',

--- a/src/foam/java/PropertyInfo.js
+++ b/src/foam/java/PropertyInfo.js
@@ -141,7 +141,14 @@ foam.CLASS({
             type: 'void',
             visibility: 'public',
             args: [{ name: 'o', type: 'Object' }, { name: 'value', type: 'Object' }],
-            body: '((' + this.sourceCls.name + ') o).' + this.setterName + '(cast(value));'
+            body: `
+              ${this.sourceCls.name} obj = (${this.sourceCls.name}) o;
+              obj.assert${foam.String.capitalize(this.propName)}(cast(value));
+              Object oldValue = obj.${this.propName}IsSet_ ? obj.${this.propName}_ : null;
+              obj.${this.propName}_ = obj.${this.propName}PreSet_(oldValue, cast(value));
+              obj.${this.propName}IsSet_ = true;
+              obj.${this.propName}PostSet_(oldValue, obj.${this.propName}_);
+            `
           },
           {
             name: 'cast',

--- a/src/foam/java/Skeleton.js
+++ b/src/foam/java/Skeleton.js
@@ -53,6 +53,25 @@ foam.CLASS({
       cls.name    = this.name;
       cls.extends = 'foam.box.AbstractSkeleton',
 
+      // add class info methods
+      cls.fields.push(foam.java.ClassInfo.create({ id: this.id }));
+
+      cls.method({
+        name: 'getClassInfo',
+        type: 'foam.core.ClassInfo',
+        visibility: 'public',
+        body: 'return classInfo_;'
+      });
+
+      cls.method({
+        name: 'getOwnClassInfo',
+        visibility: 'public',
+        static: true,
+        type: 'foam.core.ClassInfo',
+        body: 'return classInfo_;'
+      });
+
+
       foam.core.Object.create({
         name: 'delegate',
         javaType: this.of.id

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -252,7 +252,7 @@ foam.CLASS({
             }
           ],
           body: this.javaPostSet
-        })
+        });
 
 
       if ( this.javaFactory ) {

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -173,6 +173,7 @@ foam.CLASS({
 
     function buildJavaClass(cls) {
       if ( ! this.generateJava ) return;
+      if ( foam.java.Enum.isInstance(cls) ) return;
 
       // Use javaInfoType as an indicator that this property should be
       // generated to java code.
@@ -950,15 +951,7 @@ foam.CLASS({
           cls.extends = this.extends;
           cls.values = this.VALUES;
 
-          cls.field({
-            name: '__frozen__',
-            visibility: 'protected',
-            type: 'boolean',
-            initializer: 'false'
-          });
-
           var axioms = this.getAxioms();
-
           for ( var i = 0 ; i < axioms.length ; i++ ) {
             axioms[i].buildJavaClass && axioms[i].buildJavaClass(cls);
           }
@@ -1512,6 +1505,7 @@ foam.CLASS({
 
   methods: [
     function buildJavaClass(cls) {
+      if ( foam.java.Enum.isInstance(cls) ) return;
       var info = cls.getField('classInfo_');
       if ( info ) info.addAxiom(cls.name + '.' + this.javaInfoName);
 

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -165,9 +165,7 @@ foam.CLASS({
     function generateSetter_() {
       return this.javaSetter ? this.javaSetter : `
         if ( this.__frozen__ ) throw new UnsupportedOperationException("Object is frozen.");
-        assert${foam.String.capitalize(this.name)}(val);
-        ${this.name}_ = val;
-        ${this.name}IsSet_ = true;
+        setProperty(\"${this.name}\", val);
       `;
     },
 
@@ -213,6 +211,7 @@ foam.CLASS({
         }).
         method({
           name: 'set' + capitalized,
+          type: 'void',
           visibility: 'public',
           args: [
             {
@@ -220,9 +219,41 @@ foam.CLASS({
               name: 'val'
             }
           ],
-          type: 'void',
           body: this.generateSetter_()
-        });
+        }).
+        method({
+          name: this.name + 'PreSet_',
+          type: this.javaType,
+          visibility: 'public',
+          args: [
+            {
+              type: 'Object',
+              name: 'oldValue'
+            },
+            {
+              type: this.javaType,
+              name: 'newValue'
+            }
+          ],
+          body: this.javaPreSet
+        }).
+        method({
+          name: this.name + 'PostSet_',
+          type: 'void',
+          visibility: 'public',
+          args: [
+            {
+              type: 'Object',
+              name: 'oldValue'
+            },
+            {
+              type: this.javaType,
+              name: 'newValue'
+            }
+          ],
+          body: this.javaPostSet
+        })
+
 
       if ( this.javaFactory ) {
         cls.method({

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -61,15 +61,24 @@ foam.CLASS({
     },
     {
       class: 'String',
+      name: 'javaSetter'
+    },
+    {
+      class: 'String',
+      name: 'javaPreSet',
+      value: 'return newValue;'
+    },
+    {
+      class: 'String',
+      name: 'javaPostSet'
+    },
+    {
+      class: 'String',
       name: 'shortName'
     },
     {
       class: 'StringArray',
       name: 'aliases'
-    },
-    {
-      class: 'String',
-      name: 'javaSetter'
     },
     {
       class: 'String',


### PR DESCRIPTION
1. Added the ability to define pre and post set java functions
2. Modified Java property setters to set via PropertyInfo
3. Modified set function for PropertyInfo to call pre and post set functions
4. Significantly reduced the size of generated Enums. I removed the classInfo and setters from Enum's as you are unable to set Enum's in that fashion in Java anyway.
5. Added classInfo to generated Skeleton models.

Modifying the setters to use the PropertyInfo to set the values makes Java more closely resemble Swift as a side effect.