### PR TITLE
Changed severity in logs from id to label

### DIFF
--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -847,7 +847,8 @@ foam.CLASS({
     },
     ['javaInfoType', 'foam.core.AbstractEnumPropertyInfo'],
     ['javaJSONParser', 'new foam.lib.json.IntParser()'],
-    ['javaCSVParser', 'new foam.lib.json.IntParser()']
+    ['javaCSVParser', 'new foam.lib.json.IntParser()'],
+    ['javaJSONOutput', `getOrdinal(value)`]
   ],
 
   methods: [
@@ -879,6 +880,7 @@ foam.CLASS({
         ],
         body: `return ${this.of.id}.forOrdinal(ordinal);`
       });
+      
 
       info.method({
         name: 'toJSON',
@@ -894,7 +896,7 @@ foam.CLASS({
             type: 'Object'
           }
         ],
-        body: `outputter.output(getOrdinal(value));`
+        body: `outputter.output(${this.javaJSONOutput});`
       });
 
       info.method({

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -848,7 +848,8 @@ foam.CLASS({
     ['javaInfoType', 'foam.core.AbstractEnumPropertyInfo'],
     ['javaJSONParser', 'new foam.lib.json.IntParser()'],
     ['javaCSVParser', 'new foam.lib.json.IntParser()'],
-    ['javaJSONOutput', `getOrdinal(value)`]
+    ['javaJSONOutput', `getOrdinal(value)`],
+    'javaFromJSON'
   ],
 
   methods: [
@@ -880,7 +881,6 @@ foam.CLASS({
         ],
         body: `return ${this.of.id}.forOrdinal(ordinal);`
       });
-      
 
       info.method({
         name: 'toJSON',
@@ -898,6 +898,21 @@ foam.CLASS({
         ],
         body: `outputter.output(${this.javaJSONOutput});`
       });
+
+      if ( this.javaFromJSON !== undefined) {
+        info.method({
+          name: 'fromJSON',
+          visibility: 'public',
+          type: 'Object',
+          args: [
+            {
+              name: 'value',
+              type: 'String'
+            }
+          ],
+          body: `return ${this.of.id}.forLabel(value);`
+        });
+      }
 
       info.method({
         name: 'toCSV',

--- a/src/foam/nanos/logger/LogMessage.js
+++ b/src/foam/nanos/logger/LogMessage.js
@@ -30,6 +30,7 @@ Implement LastModifiedByAware to suppress 'modified by' comment in journal outpu
       name: 'severity',
       class: 'Enum',
       of: 'foam.nanos.logger.LogLevel',
+      toJSON: function(value) { return value && value.label; },
       javaJSONOutput: `((foam.nanos.logger.LogLevel) value).getLabel()`
     },
     {

--- a/src/foam/nanos/logger/LogMessage.js
+++ b/src/foam/nanos/logger/LogMessage.js
@@ -30,7 +30,7 @@ Implement LastModifiedByAware to suppress 'modified by' comment in journal outpu
       name: 'severity',
       class: 'Enum',
       of: 'foam.nanos.logger.LogLevel',
-      toJSON: function(value) { return value && value.label; }
+      javaJSONOutput: `((foam.nanos.logger.LogLevel) value).getLabel()`
     },
     {
       name: 'id',

--- a/src/foam/nanos/logger/LogMessage.js
+++ b/src/foam/nanos/logger/LogMessage.js
@@ -31,7 +31,8 @@ Implement LastModifiedByAware to suppress 'modified by' comment in journal outpu
       class: 'Enum',
       of: 'foam.nanos.logger.LogLevel',
       toJSON: function(value) { return value && value.label; },
-      javaJSONOutput: `((foam.nanos.logger.LogLevel) value).getLabel()`
+      javaJSONOutput: `((foam.nanos.logger.LogLevel) value).getLabel()`,
+      javaFromJSON: `return forLabel(value);`
     },
     {
       name: 'id',


### PR DESCRIPTION
Added a flag "javaJSONOutput" to refinements.js, and set it in LogMessage.js, so that the "severity" in logs are labels instead of id's.