### PR TITLE
Validation improvements

### DIFF
--- a/src/foam/core/types.js
+++ b/src/foam/core/types.js
@@ -191,7 +191,7 @@ foam.CLASS({
     [
       'assertValue',
       function(value, prop) {
-        foam.assert(typeof value === 'function', prop.name, 'Cannot set to non function type.');
+        foam.assert(typeof value === 'function', `The value of property '${prop.name}' must be a function. It was set to ${value}. The type of ${value} is '${typeof value}', not 'function'.`);
       }
     ]
   ]

--- a/src/foam/nanos/auth/HumanNameTrait.js
+++ b/src/foam/nanos/auth/HumanNameTrait.js
@@ -66,6 +66,7 @@ foam.INTERFACE({
           ? getFirstName() + " " + getMiddleName() + " " + getLastName()
           : getFirstName() + " " + getLastName();
       `,
+      visibility: foam.u2.Visibility.RO
     }
   ]
 });

--- a/src/foam/u2/PopupView.js
+++ b/src/foam/u2/PopupView.js
@@ -22,14 +22,38 @@ foam.CLASS({
 
   css: `
     ^ {
-      background: #999;
-      box-shadow: 3px 3px 6px 0 gray;
-      color: white;
-      font-size: 18px;
-      opacity: 0.9;
+      background: white;
+      border: 1px solid #ddd;
+      border-radius: 4px;
       position: absolute;
       box-sizing: border-box;
+      box-shadow: 0px 0px 100px rgba(0,0,0,.1);
+      text-align: center;
       z-index: 999;
+    }
+
+    ^:before, ^:after {
+      content: ' ';
+      height: 0;
+      position: absolute;
+      width: 0;
+      border: 10px solid transparent;
+    }
+
+    ^:before {
+      border-bottom-color: #fff;
+      position: absolute;
+      top: -20px;
+      left: calc(50% - 10px);
+      z-index: 2;
+    }
+
+    ^:after {
+      border-bottom-color: #ddd;
+      position: absolute;
+      top: -21px;
+      left: calc(50% - 10px);
+      z-index: 1;
     }
   `,
 

--- a/src/foam/u2/PopupView.js
+++ b/src/foam/u2/PopupView.js
@@ -107,7 +107,7 @@ foam.CLASS({
         }).
         onunload.sub(close);
 
-      parent.style({position: 'relative'});
+      parent.style({ position: 'relative' });
     }
   ]
 });

--- a/src/foam/u2/PopupView.js
+++ b/src/foam/u2/PopupView.js
@@ -76,13 +76,13 @@ foam.CLASS({
         bg.remove();
       };
 
-      if ( ! this.padding ) this.padding = 20;
-      if ( ! this.y       ) this.y = (parent.el().clientHeight - this.height)/2;
-      if ( ! this.x       ) this.x = (parent.el().clientWidth  - this.width )/2;
-      if ( this.width     ) this.style({width    : this.width     + 'px'});
-      if ( this.height    ) this.style({height   : this.height    + 'px'});
-      if ( this.maxWidth  ) this.style({maxWidth : this.maxWidth  + 'px'});
-      if ( this.maxHeight ) this.style({maxHeight: this.maxHeight + 'px'});
+      if ( this.padding == null   ) this.padding = 20;
+      if ( this.y == null         ) this.y = (parent.el().clientHeight - this.height)/2;
+      if ( this.x == null         ) this.x = (parent.el().clientWidth  - this.width )/2;
+      if ( this.width != null     ) this.style({ width     : this.width     + 'px' });
+      if ( this.height != null    ) this.style({ height    : this.height    + 'px' });
+      if ( this.maxWidth != null  ) this.style({ maxWidth  : this.maxWidth  + 'px' });
+      if ( this.maxHeight != null ) this.style({ maxHeight : this.maxHeight + 'px' });
 
       // Make a full-screen transparent background, which when clicked,
       // closes this Popup

--- a/src/foam/u2/TextField.js
+++ b/src/foam/u2/TextField.js
@@ -43,6 +43,10 @@ foam.CLASS({
       if ( prop.visibility ) {
         this.visibility = prop.visibility;
       }
+
+      if ( prop.validateObj ) {
+        this.validateValue = prop.validateObj;
+      }
     }
   ]
 });

--- a/src/foam/u2/tag/Input.js
+++ b/src/foam/u2/tag/Input.js
@@ -20,7 +20,20 @@ foam.CLASS({
   name: 'Input',
   extends: 'foam.u2.View',
 
-  css: '^:read-only { border: none; background: rgba(0,0,0,0); }',
+  css: `
+    ^:read-only {
+      border: none;
+      background: rgba(0,0,0,0);
+    }
+
+    input.invalid {
+      border-color: red;
+    }
+  `,
+
+  requires: [
+    'foam.u2.PopupView'
+  ],
 
   properties: [
     [ 'nodeName', 'input' ],
@@ -32,6 +45,19 @@ foam.CLASS({
           this.warn('Set Input data to non-primitive:' + d);
           return o;
         }
+
+        if ( typeof this.validateValue === 'function' && o != undefined ) {
+          var message = this.validateValue(d);
+          if ( message != null ) {
+            var popup = this.PopupView.create({ y: 32 });
+            popup.add(message);
+            this.parentNode.add(popup);
+            this.addClass('invalid');
+          } else {
+            this.removeClass('invalid');
+          }
+        }
+
         return d;
       }
       /*
@@ -56,7 +82,22 @@ foam.CLASS({
       // documentation: 'When set, will limit the length of the input to a certain number'
     },
     'type',
-    'placeholder'
+    'placeholder',
+    {
+      name: 'validationCheck',
+      documentation: `
+        This should be set to a function that takes a value and validates it. If
+        the value is invalid, the function should return a string containing a
+        message telling the user about the invalid value. If the argument is
+        valid, the function should not return anything, which is the same as
+        returning undefined.
+
+        Usually instead of setting this directly, you will define a
+        'validateObj' function on a property. Doing that will automatically set
+        this property to the validateObj function you defined on the property.
+      `,
+      value: function() {}
+    }
   ],
 
   methods: [

--- a/src/foam/u2/tag/Input.js
+++ b/src/foam/u2/tag/Input.js
@@ -46,7 +46,7 @@ foam.CLASS({
           return o;
         }
 
-        if ( typeof this.validateValue === 'function' && o != undefined ) {
+        if ( o != undefined ) {
           var message = this.validateValue(d);
           if ( message != null ) {
             var popup = this.PopupView.create({ y: 32 });
@@ -84,7 +84,8 @@ foam.CLASS({
     'type',
     'placeholder',
     {
-      name: 'validationCheck',
+      class: 'Function',
+      name: 'validateValue',
       documentation: `
         This should be set to a function that takes a value and validates it. If
         the value is invalid, the function should return a string containing a
@@ -95,8 +96,7 @@ foam.CLASS({
         Usually instead of setting this directly, you will define a
         'validateObj' function on a property. Doing that will automatically set
         this property to the validateObj function you defined on the property.
-      `,
-      value: function() {}
+      `
     }
   ],
 


### PR DESCRIPTION
- If a property on a model has a `validateObj` function, then use that to validate the UI input when that property is used as a viewspec.
- If the value in the ui element is invalid, show a popup with a message returned by the `validateObj` function. Also change the border colour to red to indicate that the value is invalid.

Before entering any text:
<img width="981" alt="screen shot 2018-09-07 at 1 48 00 pm" src="https://user-images.githubusercontent.com/4259165/45235763-f08f3600-b2a7-11e8-8d2f-3134c83bad2d.png">

After entering invalid text and changing focus away from the input:
<img width="991" alt="screen shot 2018-09-07 at 1 48 11 pm" src="https://user-images.githubusercontent.com/4259165/45235761-f08f3600-b2a7-11e8-8f7a-478f90e3add7.png">

After clicking anywhere on the screen to hide the popup, border stays red to show invalid state:
<img width="983" alt="screen shot 2018-09-07 at 1 48 20 pm" src="https://user-images.githubusercontent.com/4259165/45235760-f08f3600-b2a7-11e8-902d-c0fcd4a09dc5.png">

Part of the solution to https://github.com/nanoPayinc/NANOPAY/issues/3451
