### PR TITLE
Don't render top nav until logged in

### DIFF
--- a/src/foam/nanos/u2/navigation/TopNavigation.js
+++ b/src/foam/nanos/u2/navigation/TopNavigation.js
@@ -99,7 +99,7 @@ foam.CLASS({
 
   messages: [
     {
-      name: 'Greeting',
+      name: 'GREETING',
       message: 'Welcome'
     }
   ],
@@ -118,7 +118,7 @@ foam.CLASS({
         .start()
           .addClass('welcome-label')
           .hide(this.loginSuccess$)
-          .add(this.Greeting)
+          .add(this.GREETING)
         .end();
 
       this.user.id$.sub(this.userLoggedIn);

--- a/src/foam/nanos/u2/navigation/TopNavigation.js
+++ b/src/foam/nanos/u2/navigation/TopNavigation.js
@@ -97,6 +97,13 @@ foam.CLASS({
     }
   `,
 
+  messages: [
+    {
+      name: 'Greeting',
+      message: 'Welcome'
+    }
+  ],
+
   properties: [
     {
       name: 'dao',
@@ -110,7 +117,9 @@ foam.CLASS({
       this
         .addClass(this.myClass())
         .start('div', null, this.welcome$)
-          .add('Welcome').addClass('welcome-label').hide(this.loginSuccess$)
+          .addClass('welcome-label')
+          .hide(this.loginSuccess$)
+          .add(this.Greeting)
         .end();
 
       this.user.id$.sub(this.userLoggedIn);

--- a/src/foam/nanos/u2/navigation/TopNavigation.js
+++ b/src/foam/nanos/u2/navigation/TopNavigation.js
@@ -108,15 +108,14 @@ foam.CLASS({
     {
       name: 'dao',
       factory: () => this.menuDAO
-    },
-    'welcome'
+    }
   ],
 
   methods: [
     function initE() {
       this
         .addClass(this.myClass())
-        .start('div', null, this.welcome$)
+        .start()
           .addClass('welcome-label')
           .hide(this.loginSuccess$)
           .add(this.Greeting)
@@ -128,7 +127,6 @@ foam.CLASS({
 
   listeners: [
     function userLoggedIn() {
-      this.welcome.remove();
       this
         .start()
           .addClass('logged-in-container')

--- a/src/foam/nanos/u2/navigation/TopNavigation.js
+++ b/src/foam/nanos/u2/navigation/TopNavigation.js
@@ -101,24 +101,33 @@ foam.CLASS({
     {
       name: 'dao',
       factory: () => this.menuDAO
-    }
+    },
+    'welcome'
   ],
 
   methods: [
     function initE() {
       this
         .addClass(this.myClass())
+        .start('div', null, this.welcome$)
+          .add('Welcome').addClass('welcome-label').hide(this.loginSuccess$)
+        .end();
+
+      this.user.id$.sub(this.userLoggedIn);
+    }
+  ],
+
+  listeners: [
+    function userLoggedIn() {
+      this.welcome.remove();
+      this
         .start()
           .addClass('logged-in-container')
-          .show(this.loginSuccess$)
           .tag({ class: 'foam.nanos.u2.navigation.BusinessLogoView' })
           .start({ class: 'foam.nanos.menu.MenuBar' })
             .addClass('menuBar')
           .end()
           .tag({ class: 'foam.nanos.u2.navigation.UserView' })
-        .end()
-        .start()
-          .add('Welcome').addClass('welcome-label').hide(this.loginSuccess$)
         .end();
     }
   ]


### PR DESCRIPTION
Currently the top nav loads even when the user isn't logged in. This
means that the initE method for child views of the top navigation run
before user is set in the context. This makes it so that the views in
the top nav don't load until the user is properly set in the context.

Required by https://github.com/nanoPayinc/NANOPAY/pull/3492