### PR TITLE
Changed the way enums are passed to the service's method

### DIFF
--- a/src/foam/java/Skeleton.js
+++ b/src/foam/java/Skeleton.js
@@ -102,7 +102,7 @@ foam.CLASS({
       if ( m.args[j].javaType == 'foam.core.X' ) {
         %>getMessageX(message)<%
       } else if ( foam.core.AbstractEnum.isSubClass(this.lookup(m.args[j].javaType, true)) ) {
-        %><%= m.args[j].javaType%>.forOrdinal(toint(rpc.getArgs() != null && rpc.getArgs().length > <%= j %> ? rpc.getArgs()[<%= j %>] : null))<%
+        %>rpc.getArgs() != null && rpc.getArgs().length > <%= j %> ? (<%= m.args[j].javaType %>) rpc.getArgs()[<%= j %>] : null<%
       } else {
         if ( {byte: 1, double: 1, float: 1, int: 1, long: 1, short: 1 }[m.args[j].javaType] ) {
           %>to<%= m.args[j].javaType %><%


### PR DESCRIPTION
Since we don't transfer enums as  their ordinal values now, but actually transfer Enum objects over network; when a method of a service that takes an enum as an argument is invoked, it causes a **cast exception** as it tries to cast the enum object to an int (or ordinal value). This pr fixes this issue.