### PR TITLE
added javafactory to FObjectArray so the val defaults to empty array

### DIFF
--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -1313,6 +1313,12 @@ foam.CLASS({
       }
     },
     {
+      name: 'javaFactory',
+      expression: function(of) {
+        return `return new ${of}[0];`;
+      }
+    },
+    {
       name: 'javaJSONParser',
       expression: function(of) {
         var id = of ? of.id ? of.id : of : null;


### PR DESCRIPTION
Currently, a prop of type FObjectArray defaults to null when not set (on the java side).
Since it's an array the default value should be an empty array rather than null (similar to js side).
Added a Java factory to return an empty array of type `of` specified in the model.