### PR TITLE
Hide all warnings related to Java code generation

### DIFF
--- a/src/foam/core/debug.js
+++ b/src/foam/core/debug.js
@@ -281,17 +281,9 @@ foam.CLASS({
 
   methods: [
     function unknownArg(key, value) {
-      if ( key == 'class' ) return;
-
       // Temporarily disable warnings related to generating Java code.
-      var blackList = [
-        'javaThrows',
-        'javaReturns',
-        'javaCode'
-      ];
-      if ( ! blackList.some((keyword) => key.includes(keyword)) ) {
-        this.warn('Unknown property ' + this.cls_.id + '.' + key + ': ' + value);
-      }
+      if ( key == 'class' || key.startsWith('java') ) return;
+      this.warn('Unknown property ' + this.cls_.id + '.' + key + ': ' + value);
     },
 
     function describe(opt_name) {


### PR DESCRIPTION
I tried to do this before with a blacklist approach but that didn't end
up catching all of the errors. This commit changes the approach to one
that should catch all cases, so long as the naming convention is
followed.