### PR TITLE
PublicKey fingerprint generation

### DIFF
--- a/src/foam/blob/HashingOutputStream.java
+++ b/src/foam/blob/HashingOutputStream.java
@@ -6,6 +6,7 @@
 
 package foam.blob;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.security.MessageDigest;
@@ -21,6 +22,24 @@ public class HashingOutputStream
 {
   protected OutputStream os_;
   protected MessageDigest digest_;
+
+  /**
+   * HashingOutputStream constructor using SHA-256 as the default algorithm
+   * and a ByteArrayOutputStream as the delegate
+   * @throws NoSuchAlgorithmException
+   */
+  public HashingOutputStream() throws NoSuchAlgorithmException {
+    this("SHA-256", new ByteArrayOutputStream());
+  }
+
+  /**
+   * HashingOutputStream constructor with user provided algorithm
+   * that uses a ByteArrayOutputStream as the delegate
+   * @throws NoSuchAlgorithmException
+   */
+  public HashingOutputStream(String algorithm) throws NoSuchAlgorithmException {
+    this(algorithm, new ByteArrayOutputStream());
+  }
 
   /**
    * HashingOutputStream constructor using SHA-256 as the default algorithm

--- a/src/foam/util/SecurityUtil.java
+++ b/src/foam/util/SecurityUtil.java
@@ -29,7 +29,7 @@ public class SecurityUtil {
     }
   }
 
-  private static final char[] DIGITS = "0123456789ABCDEF".toCharArray();
+  private static final char[] DIGITS = "0123456789abcdef".toCharArray();
 
   private static ThreadLocal<StringBuilder> sb_ = new ThreadLocal<StringBuilder>() {
     @Override
@@ -90,10 +90,21 @@ public class SecurityUtil {
     }
   }
 
+  /**
+   * Generates an SSH key fingerprint given a public key and using a default hashing algorithm of SHA-256.
+   * @param key public key to generate fingerprint from
+   * @return the ssh key fingerprint
+   */
   public static String GenerateSSHKeyFingerprintFromPublicKey(PublicKey key) {
     return GenerateSSHKeyFingerprintFromPublicKey("SHA-256", key);
   }
 
+  /**
+   * Generates an SSH key fingerprint given a public key and hashing algorithm
+   * @param algorithm hashing algorithm to use
+   * @param key public key to generate fingerprint from
+   * @return the ssh key fingerprint
+   */
   public static String GenerateSSHKeyFingerprintFromPublicKey(String algorithm, PublicKey key) {
     switch ( key.getAlgorithm() ) {
       case "DSA"  : return GenerateSSHKeyFingerprintFromDSAPublicKey(algorithm, (DSAPublicKey) key);
@@ -102,6 +113,12 @@ public class SecurityUtil {
     }
   }
 
+  /**
+   * Generates an SSH key fingerprint given a DSA public key and hashing algorithm
+   * @param algorithm hashing algorithm
+   * @param key dsa public key
+   * @return ssh key fingerprint
+   */
   protected static String GenerateSSHKeyFingerprintFromDSAPublicKey(String algorithm, DSAPublicKey key) {
     try {
       byte[] tag = "ssh-dss".getBytes(StandardCharsets.UTF_8);
@@ -138,6 +155,12 @@ public class SecurityUtil {
     }
   }
 
+  /**
+   * Generates an SSH key fingerprint given an RSA public key and hashing algorithm
+   * @param algorithm hashing algorithm
+   * @param key rsa public key
+   * @return ssh key fingerprint
+   */
   protected static String GenerateSSHKeyFingerprintFromRSAPublicKey(String algorithm, RSAPublicKey key) {
     try {
       byte[] tag = "ssh-rsa".getBytes(StandardCharsets.UTF_8);
@@ -163,6 +186,14 @@ public class SecurityUtil {
     }
   }
 
+  /**
+   * Generates the SSH key fingerprint string using algorithm and digest.
+   * MD5 is encoded as a hex string delimited by colons
+   * SHA1 and SHA256 is encoded as a base64 string
+   * @param algorithm hashing algorithm
+   * @param digest message digest
+   * @return ssh key fingerprint string
+   */
   protected static String GetSSHKeyFingerPrintString(String algorithm, byte[] digest) {
     switch ( algorithm ) {
       case "MD5"      : return "MD5:"    + ByteArrayToHexString(digest, ':');
@@ -172,10 +203,21 @@ public class SecurityUtil {
     }
   }
 
+  /**
+   * Converts a byte array to a hex string
+   * @param bytes bytes to convert
+   * @return hex string
+   */
   public static String ByteArrayToHexString(byte[] bytes) {
     return ByteArrayToHexString(bytes, '\u0000');
   }
 
+  /**
+   * Converts a byte array to hex string separating each value with a delimiter
+   * @param bytes bytes to convert
+   * @param delimiter delimiter to use
+   * @return hex string delimited with provided delimter
+   */
   public static String ByteArrayToHexString(byte[] bytes, char delimiter) {
     StringBuilder builder = sb_.get();
     for ( int i = 0 ; i < bytes.length ; i++ ) {

--- a/src/foam/util/SecurityUtil.java
+++ b/src/foam/util/SecurityUtil.java
@@ -1,11 +1,19 @@
 package foam.util;
 
+import foam.blob.HashingOutputStream;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.util.encoders.Base64;
+import org.bouncycastle.util.encoders.Hex;
 
+import java.io.OutputStream;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.Security;
+import java.security.interfaces.DSAPublicKey;
+import java.security.interfaces.RSAPublicKey;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -20,6 +28,22 @@ public class SecurityUtil {
       Security.addProvider(provider);
     }
   }
+
+  private static final char[] DIGITS = "0123456789ABCDEF".toCharArray();
+
+  private static ThreadLocal<StringBuilder> sb_ = new ThreadLocal<StringBuilder>() {
+    @Override
+    protected StringBuilder initialValue() {
+      return new StringBuilder();
+    }
+
+    @Override
+    public StringBuilder get() {
+      StringBuilder b = super.get();
+      b.setLength(0);
+      return b;
+    }
+  };
 
   private static Map<String, SecureRandom> srand_ = new ConcurrentHashMap<>();
 
@@ -64,6 +88,120 @@ public class SecurityUtil {
     } catch ( Throwable t ) {
       throw new RuntimeException(t);
     }
+  }
+
+  public static String GenerateSSHKeyFingerprintFromPublicKey(PublicKey key) {
+    return GenerateSSHKeyFingerprintFromPublicKey("SHA-256", key);
+  }
+
+  public static String GenerateSSHKeyFingerprintFromPublicKey(String algorithm, PublicKey key) {
+    switch ( key.getAlgorithm() ) {
+      case "DSA"  : return GenerateSSHKeyFingerprintFromDSAPublicKey(algorithm, (DSAPublicKey) key);
+      case "RSA"  : return GenerateSSHKeyFingerprintFromRSAPublicKey(algorithm, (RSAPublicKey) key);
+      default     : throw new IllegalArgumentException("Unsupported public key encoding: " + key.getAlgorithm());
+    }
+  }
+
+  protected static String GenerateSSHKeyFingerprintFromDSAPublicKey(String algorithm, DSAPublicKey key) {
+    try {
+      byte[] tag = "ssh-dss".getBytes(StandardCharsets.UTF_8);
+      byte[] p = key.getParams().getP().toByteArray();
+      byte[] q = key.getParams().getQ().toByteArray();
+      byte[] g = key.getParams().getG().toByteArray();
+      byte[] y = key.getY().toByteArray();
+
+      HashingOutputStream hos = new HashingOutputStream(algorithm);
+
+      // write tag
+      Set4ByteInt(hos, tag.length);
+      hos.write(tag, 0, tag.length);
+
+      // write p
+      Set4ByteInt(hos, p.length);
+      hos.write(p, 0, p.length);
+
+      // write q
+      Set4ByteInt(hos, q.length);
+      hos.write(q, 0, q.length);
+
+      // write g
+      Set4ByteInt(hos, g.length);
+      hos.write(g, 0, g.length);
+
+      // write y
+      Set4ByteInt(hos, y.length);
+      hos.write(y, 0, y.length);
+
+      return GetSSHKeyFingerPrintString(algorithm, hos.digest());
+    } catch ( Throwable t ) {
+      throw new SecurityException("Unable to generate SSH key fingerprint: " + t.getMessage());
+    }
+  }
+
+  protected static String GenerateSSHKeyFingerprintFromRSAPublicKey(String algorithm, RSAPublicKey key) {
+    try {
+      byte[] tag = "ssh-rsa".getBytes(StandardCharsets.UTF_8);
+      byte[] e = key.getPublicExponent().toByteArray();
+      byte[] n = key.getModulus().toByteArray();
+
+      // write tag
+      HashingOutputStream hos = new HashingOutputStream(algorithm);
+      Set4ByteInt(hos, tag.length);
+      hos.write(tag, 0, tag.length);
+
+      // write public exponent
+      Set4ByteInt(hos, e.length);
+      hos.write(e, 0, e.length);
+
+      // write modulus
+      Set4ByteInt(hos, n.length);
+      hos.write(n, 0, n.length);
+
+      return GetSSHKeyFingerPrintString(algorithm, hos.digest());
+    } catch ( Throwable t ) {
+      throw new SecurityException("Unable to generate SSH key fingerprint: " + t.getMessage());
+    }
+  }
+
+  protected static String GetSSHKeyFingerPrintString(String algorithm, byte[] digest) {
+    switch ( algorithm ) {
+      case "MD5"      : return "MD5:"    + ByteArrayToHexString(digest, ':');
+      case "SHA-1"    : return "SHA1:"   + Base64.toBase64String(digest);
+      case "SHA-256"  : return "SHA256:" + Base64.toBase64String(digest);
+      default         : throw new IllegalArgumentException("Unsupported hashing algorithm");
+    }
+  }
+
+  public static String ByteArrayToHexString(byte[] bytes) {
+    return ByteArrayToHexString(bytes, '\u0000');
+  }
+
+  public static String ByteArrayToHexString(byte[] bytes, char delimiter) {
+    StringBuilder builder = sb_.get();
+    for ( int i = 0 ; i < bytes.length ; i++ ) {
+      builder.append(SecurityUtil.DIGITS[(bytes[i] >> 4) & 0x0F]);
+      builder.append(SecurityUtil.DIGITS[bytes[i] & 0x0F]);
+      if ( delimiter != '\u0000' && i != bytes.length - 1 ) {
+        builder.append(delimiter);
+      }
+    }
+
+    return builder.toString();
+  }
+
+  /**
+   * Writes an integer to the output stream out to 4 bytes big endian encoding
+   * @param os output stream to write to
+   * @param val integer value to write out
+   * @throws java.io.IOException
+   */
+  public static void Set4ByteInt(OutputStream os, int val)
+    throws java.io.IOException
+  {
+    os.write((byte)((val & 0xFF000000) >> 24));
+    os.write((byte)((val & 0x00FF0000) >> 16));
+    os.write((byte)((val & 0x0000FF00) >> 8));
+    os.write((byte)((val & 0x000000FF)));
   }
 
   /**

--- a/src/foam/util/SecurityUtil.java
+++ b/src/foam/util/SecurityUtil.java
@@ -3,7 +3,6 @@ package foam.util;
 import foam.blob.HashingOutputStream;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.util.encoders.Base64;
-import org.bouncycastle.util.encoders.Hex;
 
 import java.io.OutputStream;
 import java.math.BigInteger;
@@ -13,6 +12,7 @@ import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.Security;
 import java.security.interfaces.DSAPublicKey;
+import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Map;
 import java.util.Objects;
@@ -106,10 +106,14 @@ public class SecurityUtil {
    * @return the ssh key fingerprint
    */
   public static String GenerateSSHKeyFingerprintFromPublicKey(String algorithm, PublicKey key) {
-    switch ( key.getAlgorithm() ) {
-      case "DSA"  : return GenerateSSHKeyFingerprintFromDSAPublicKey(algorithm, (DSAPublicKey) key);
-      case "RSA"  : return GenerateSSHKeyFingerprintFromRSAPublicKey(algorithm, (RSAPublicKey) key);
-      default     : throw new IllegalArgumentException("Unsupported public key encoding: " + key.getAlgorithm());
+    if ( key instanceof DSAPublicKey ) {
+      return GenerateSSHKeyFingerprintFromDSAPublicKey(algorithm, (DSAPublicKey) key);
+    } else if ( key instanceof ECPublicKey ) {
+      return GenerateSSHKeyFingerprintFromECPublicKey(algorithm, (ECPublicKey) key);
+    } else if ( key instanceof RSAPublicKey ) {
+      return GenerateSSHKeyFingerprintFromRSAPublicKey(algorithm, (RSAPublicKey) key);
+    } else {
+      throw new IllegalArgumentException("Unsupported public key encoding: " + key.getAlgorithm());
     }
   }
 
@@ -121,7 +125,7 @@ public class SecurityUtil {
    */
   protected static String GenerateSSHKeyFingerprintFromDSAPublicKey(String algorithm, DSAPublicKey key) {
     try {
-      byte[] tag = "ssh-dss".getBytes(StandardCharsets.UTF_8);
+      byte[] tag = "ssh-dss".getBytes(StandardCharsets.US_ASCII);
       byte[] p = key.getParams().getP().toByteArray();
       byte[] q = key.getParams().getQ().toByteArray();
       byte[] g = key.getParams().getG().toByteArray();
@@ -130,24 +134,76 @@ public class SecurityUtil {
       HashingOutputStream hos = new HashingOutputStream(algorithm);
 
       // write tag
-      Set4ByteInt(hos, tag.length);
+      Set4ByteInt(tag.length, hos);
       hos.write(tag, 0, tag.length);
 
       // write p
-      Set4ByteInt(hos, p.length);
+      Set4ByteInt(p.length, hos);
       hos.write(p, 0, p.length);
 
       // write q
-      Set4ByteInt(hos, q.length);
+      Set4ByteInt(q.length, hos);
       hos.write(q, 0, q.length);
 
       // write g
-      Set4ByteInt(hos, g.length);
+      Set4ByteInt(g.length, hos);
       hos.write(g, 0, g.length);
 
       // write y
-      Set4ByteInt(hos, y.length);
+      Set4ByteInt(y.length, hos);
       hos.write(y, 0, y.length);
+
+      return GetSSHKeyFingerPrintString(algorithm, hos.digest());
+    } catch ( Throwable t ) {
+      throw new SecurityException("Unable to generate SSH key fingerprint: " + t.getMessage());
+    }
+  }
+
+  /**
+   * Generates an SSH key fingerprint given an ECDSA public key and hashing algorithm
+   * @param algorithm hashing algorithm
+   * @param key ecdsa public key
+   * @return ssh key fingerprint
+   */
+  protected static String GenerateSSHKeyFingerprintFromECPublicKey(String algorithm, ECPublicKey key) {
+    try {
+      byte[] q = null;
+      String curveName = null;
+      int bitLength = key.getW().getAffineX().bitLength();
+
+      if ( bitLength <= 256 ) {
+        curveName = "nistp256";
+        q = new byte[65];
+      } else if ( bitLength <= 384 ) {
+        curveName = "nistp384";
+        q = new byte[97];
+      } else if ( bitLength <= 521 ) {
+        curveName = "nistp521";
+        q = new byte[133];
+      } else {
+        throw new SecurityException("Unsupported ECDSA bit length: " + bitLength);
+      }
+
+      byte[] tag = ("ecdsa-sha2-" + curveName).getBytes(StandardCharsets.US_ASCII);
+      byte[] curve = curveName.getBytes(StandardCharsets.US_ASCII);
+
+      // copy q value from encoded key
+      byte[] encoded = key.getEncoded();
+      System.arraycopy(encoded, encoded.length - q.length, q, 0, q.length);
+
+      HashingOutputStream hos = new HashingOutputStream(algorithm);
+
+      // write tag
+      Set4ByteInt(tag.length, hos);
+      hos.write(tag, 0, tag.length);
+
+      // write curve
+      Set4ByteInt(curve.length, hos);
+      hos.write(curve, 0, curve.length);
+
+      // write q
+      Set4ByteInt(q.length, hos);
+      hos.write(q, 0, q.length);
 
       return GetSSHKeyFingerPrintString(algorithm, hos.digest());
     } catch ( Throwable t ) {
@@ -163,21 +219,21 @@ public class SecurityUtil {
    */
   protected static String GenerateSSHKeyFingerprintFromRSAPublicKey(String algorithm, RSAPublicKey key) {
     try {
-      byte[] tag = "ssh-rsa".getBytes(StandardCharsets.UTF_8);
+      byte[] tag = "ssh-rsa".getBytes(StandardCharsets.US_ASCII);
       byte[] e = key.getPublicExponent().toByteArray();
       byte[] n = key.getModulus().toByteArray();
 
       // write tag
       HashingOutputStream hos = new HashingOutputStream(algorithm);
-      Set4ByteInt(hos, tag.length);
+      Set4ByteInt(tag.length, hos);
       hos.write(tag, 0, tag.length);
 
       // write public exponent
-      Set4ByteInt(hos, e.length);
+      Set4ByteInt(e.length, hos);
       hos.write(e, 0, e.length);
 
       // write modulus
-      Set4ByteInt(hos, n.length);
+      Set4ByteInt(n.length, hos);
       hos.write(n, 0, n.length);
 
       return GetSSHKeyFingerPrintString(algorithm, hos.digest());
@@ -195,11 +251,14 @@ public class SecurityUtil {
    * @return ssh key fingerprint string
    */
   protected static String GetSSHKeyFingerPrintString(String algorithm, byte[] digest) {
-    switch ( algorithm ) {
-      case "MD5"      : return "MD5:"    + ByteArrayToHexString(digest, ':');
-      case "SHA-1"    : return "SHA1:"   + Base64.toBase64String(digest);
-      case "SHA-256"  : return "SHA256:" + Base64.toBase64String(digest);
-      default         : throw new IllegalArgumentException("Unsupported hashing algorithm");
+    if ( "MD5".equals(algorithm) ) {
+      return "MD5:" + ByteArrayToHexString(digest, ':');
+    } else if ( "SHA-1".equals(algorithm) ) {
+      return "SHA1:" + Base64.toBase64String(digest);
+    } else if ( "SHA-256".equals(algorithm) ) {
+      return "SHA256:" + Base64.toBase64String(digest);
+    } else {
+      throw new IllegalArgumentException("Unsupported hashing algorithm");
     }
   }
 
@@ -233,11 +292,11 @@ public class SecurityUtil {
 
   /**
    * Writes an integer to the output stream out to 4 bytes big endian encoding
-   * @param os output stream to write to
    * @param val integer value to write out
+   * @param os output stream to write to
    * @throws java.io.IOException
    */
-  public static void Set4ByteInt(OutputStream os, int val)
+  public static void Set4ByteInt(int val, OutputStream os)
     throws java.io.IOException
   {
     os.write((byte)((val & 0xFF000000) >> 24));


### PR DESCRIPTION
Added methods to generate ssh key fingerprints given a public key. Generates public key fingerprints for DSA, RSA, and ECDSA public keys. When hashing the public key using MD5 the result is a hex encoded string delimited by `:`. When hashing using SHA1 or SHA256, the result is a Base64 encoded string.