### PR TITLE
Force ClassLoaderContextScript to be at the end of generated files.js

### DIFF
--- a/demos/buildtool/.gitignore
+++ b/demos/buildtool/.gitignore
@@ -1,1 +1,2 @@
+NANO_BUILD/*
 build/*

--- a/demos/buildtool/nanos.html
+++ b/demos/buildtool/nanos.html
@@ -1,0 +1,21 @@
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="NANO_BUILD/src/foam-bin.js"></script>
+    <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500" rel="stylesheet">
+  </head>
+  <body>
+    <foam 
+      class="foam.nanos.controller.ApplicationController" 
+      logo="foam_red.png" 
+      webApp="FOAM" 
+      id="ctrl" 
+      signUpEnabled="true"
+      primaryColor="#093649"
+      secondaryColor="#59aadd"
+      tableHoverColor="#e9e9e9"
+      accentColor="#1cc2b7"
+      tableColor="rgba(110, 174, 195, 0.2)">
+    </foam>
+  </body>
+</html>

--- a/src/foam/apploader/ClassLoader.js
+++ b/src/foam/apploader/ClassLoader.js
@@ -55,7 +55,7 @@ have multiple classloaders running alongside eachother`
       name: 'addClassPath',
       code: function(path) {
         var cls = this[foam.isServer ? 'NodeModelFileDAO' : 'WebModelFileDAO'];
-        var modelDAO = cls.create({root: path}, this);
+        var modelDAO = cls.create({root: path});
 
         if ( this.modelDAO ) {
           modelDAO = this.OrDAO.create({
@@ -131,7 +131,7 @@ have multiple classloaders running alongside eachother`
           if ( this.latched[id] ) {
             var json = this.latched[id];
             delete this.latched[id];
-            return this.pending[id] = Promise.all(foam.json.references(this.__context__, json)).then(function() {
+            return this.pending[id] = Promise.all(foam.json.references(foam.__context__, json)).then(function() {
               var cls = json.class ? foam.lookup(json.class) : foam.core.Model;
               return self.modelDeps_(cls.create(json), path);
             }).then(function() {
@@ -143,7 +143,7 @@ have multiple classloaders running alongside eachother`
 
           if ( foam.lookup(id, true) ) return Promise.resolve(foam.lookup(id));
 
-          var x2 = self.SubClassLoader.create({delegate: self, path: path});
+          var x2 = self.SubClassLoader.create({delegate: self, path: path}, foam.__context__);
           return this.pending[id] = this.modelDAO.inX(x2).find(id).then(function(m) {
             if ( ! m ) return Promise.reject(new Error('Model Not Found: ' + id));
             if ( self.Relationship.isInstance(m) ) {

--- a/src/foam/apploader/ClassLoader.js
+++ b/src/foam/apploader/ClassLoader.js
@@ -55,7 +55,7 @@ have multiple classloaders running alongside eachother`
       name: 'addClassPath',
       code: function(path) {
         var cls = this[foam.isServer ? 'NodeModelFileDAO' : 'WebModelFileDAO'];
-        var modelDAO = cls.create({root: path});
+        var modelDAO = cls.create({root: path}, this);
 
         if ( this.modelDAO ) {
           modelDAO = this.OrDAO.create({
@@ -131,7 +131,7 @@ have multiple classloaders running alongside eachother`
           if ( this.latched[id] ) {
             var json = this.latched[id];
             delete this.latched[id];
-            return this.pending[id] = Promise.all(foam.json.references(foam.__context__, json)).then(function() {
+            return this.pending[id] = Promise.all(foam.json.references(this.__context__, json)).then(function() {
               var cls = json.class ? foam.lookup(json.class) : foam.core.Model;
               return self.modelDeps_(cls.create(json), path);
             }).then(function() {
@@ -143,7 +143,7 @@ have multiple classloaders running alongside eachother`
 
           if ( foam.lookup(id, true) ) return Promise.resolve(foam.lookup(id));
 
-          var x2 = self.SubClassLoader.create({delegate: self, path: path}, foam.__context__);
+          var x2 = self.SubClassLoader.create({delegate: self, path: path});
           return this.pending[id] = this.modelDAO.inX(x2).find(id).then(function(m) {
             if ( ! m ) return Promise.reject(new Error('Model Not Found: ' + id));
             if ( self.Relationship.isInstance(m) ) {

--- a/src/foam/build/FilesJsGen.js
+++ b/src/foam/build/FilesJsGen.js
@@ -111,7 +111,9 @@ foam.CLASS({
     {
       name: 'END',
       documentation: `
-        The following models must be added at the end of files.js in this order.
+        The following models must be added at the end of files.js in this order
+        and the outputter will force these to be loaded at the end even if
+        they're discovered as a dependency of something else.
       `,
       value: [
         'foam.apploader.ClassLoaderContextScript',
@@ -253,10 +255,7 @@ foam.CLASS({
         // Remove duplicates.
         files = files.filter(function(id, i) {
           return files.indexOf(id) == i;
-        });
-
-        // Format each line of files.js
-        files = files.map(function(o) {
+        }).map(function(o) {
           return `{ name: "${o.replace(/\./g, '/')}" },`;
         })
 

--- a/src/foam/build/FilesJsGen.js
+++ b/src/foam/build/FilesJsGen.js
@@ -109,6 +109,15 @@ foam.CLASS({
       ],
     },
     {
+      name: 'END',
+      documentation: `
+        The following models must be added at the end of files.js in this order.
+      `,
+      value: [
+        'foam.apploader.ClassLoaderContextScript',
+      ],
+    },
+    {
       name: 'NANOS_MODELS',
       documentation: `
         These are the models needed for booting nanos.
@@ -191,6 +200,7 @@ foam.CLASS({
             ),
             getTreeHead(self.IN(self.Model.REFINES, deps)),
             getTreeHead(self.IN(self.Model.ID, self.required)),
+            getTreeHead(self.IN(self.Model.ID, self.END)),
         ])
       }).then(function(args) {
         return Promise.all(
@@ -233,13 +243,21 @@ foam.CLASS({
         var files = [].concat(
           self.BOOT_FILES,
           self.CORE_MODELS,
-          args).map(function(o) {
-            return `{ name: "${o.replace(/\./g, '/')}" },`;
-          });
+          args);
+
+        // Remove anything that should be forced into the end.
+        files = files.filter(function(id, i) {
+          return self.END.indexOf(id) == -1;
+        }).concat(self.END);
 
         // Remove duplicates.
         files = files.filter(function(id, i) {
           return files.indexOf(id) == i;
+        });
+
+        // Format each line of files.js
+        files = files.map(function(o) {
+          return `{ name: "${o.replace(/\./g, '/')}" },`;
         })
 
         var filesJs = `

--- a/src/foam/build/FilesJsGen.js
+++ b/src/foam/build/FilesJsGen.js
@@ -240,12 +240,8 @@ foam.CLASS({
           })
         );
       }).then(function(args) {
-        // Flatten args.
-        args = [].concat.apply([], args);
-        var files = [].concat(
-          self.BOOT_FILES,
-          self.CORE_MODELS,
-          args);
+        // Args is a 2D array so concat.apply will flatten it.
+        var files = [].concat.apply(self.CORE_MODELS, args);
 
         // Remove anything that should be forced into the end.
         files = files.filter(function(id, i) {
@@ -257,10 +253,12 @@ foam.CLASS({
           return files.indexOf(id) == i;
         });
 
-        // Format each line of files.js
-        files = files.map(function(o) {
-          return `{ name: "${o.replace(/\./g, '/')}" },`;
-        })
+        // Prepend the files needed to boot and adapt the IDs into file names.
+        files = self.BOOT_FILES.concat(files.map(function(o) {
+          return o.replace(/\./g, '/')
+        })).map(function(o) {
+          return `{ name: "${o}" },`;
+        });
 
         var filesJs = `
 if ( typeof window !== 'undefined' ) global = window;

--- a/src/foam/build/FilesJsGen.js
+++ b/src/foam/build/FilesJsGen.js
@@ -255,7 +255,10 @@ foam.CLASS({
         // Remove duplicates.
         files = files.filter(function(id, i) {
           return files.indexOf(id) == i;
-        }).map(function(o) {
+        });
+
+        // Format each line of files.js
+        files = files.map(function(o) {
           return `{ name: "${o.replace(/\./g, '/')}" },`;
         })
 

--- a/src/foam/build/FilesJsGen.js
+++ b/src/foam/build/FilesJsGen.js
@@ -66,6 +66,12 @@ foam.CLASS({
         'foam.core.BooleanScript',
         'foam.core.AxiomArrayScript',
         'foam.core.EndBootScript',
+
+        'foam.core.Requires',
+        'foam.core.ModelRequiresRefines',
+
+        'foam.core.Implements',
+        'foam.core.ImplementsModelRefine',
       ],
     },
     {
@@ -78,13 +84,11 @@ foam.CLASS({
       value: [
         'foam.core.ContextMultipleInheritenceScript',
         'foam.core.DebugDescribeScript',
-        'foam.core.ImplementsModelRefine',
         'foam.core.ImportExportModelRefine',
         'foam.core.ListenerModelRefine',
         'foam.core.MethodArgumentRefine',
         'foam.core.ModelConstantRefine',
         'foam.core.ModelRefinestopics',
-        'foam.core.ModelRequiresRefines',
         'foam.core.ModelActionRefine',
         'foam.core.Promised',
         'foam.core.__Class__',


### PR DESCRIPTION
If the context is replaced after ClassLoaderContextScript runs, issues arise so this helps prevent that. We might want to look into making this not matter.