### PR TITLE
Add the ID support to PHASE_1 of the file generator

### DIFF
--- a/src/foam/build/FilesJsGen.js
+++ b/src/foam/build/FilesJsGen.js
@@ -93,6 +93,7 @@ foam.CLASS({
         'foam.core.Promised',
         'foam.core.__Class__',
         'foam.core.__Property__',
+        'foam.core.ModelIDRefine',
       ],
     },
     {

--- a/src/foam/core/IDSupport.js
+++ b/src/foam/core/IDSupport.js
@@ -148,8 +148,11 @@ foam.CLASS({
 });
 
 foam.CLASS({
+  package: 'foam.core',
+  name: 'ModelIDRefine',
   refines: 'foam.core.Model',
   requires: [
+    'foam.core.IDAlias',
     'foam.core.MultiPartID',
   ],
   properties: [


### PR DESCRIPTION
This makes it loaded earlier in the process, presumably before anything needs it.

Also add a dep to the model refinement that's used.