### PR TITLE
Add an fclone method that takes a context

### DIFF
--- a/src/foam/core/AbstractFObject.js
+++ b/src/foam/core/AbstractFObject.js
@@ -82,6 +82,10 @@ foam.CLASS({
             verifier.initVerify(key);
             return this.verify(signature, verifier);
           }
+
+          public foam.core.FObject fclone() {
+            return fclone(getX());
+          }
         `);
       }
     }
@@ -174,10 +178,12 @@ foam.CLASS({
     },
     {
       name: 'fclone',
+      args: [ { name: 'x', javaType: 'foam.core.X' } ],
       javaReturns: 'foam.core.FObject',
       javaCode: `
         try {
           FObject ret = getClass().newInstance();
+          ret.setX(x);
           List<PropertyInfo> props = getClassInfo().getAxiomsByClass(PropertyInfo.class);
           for( PropertyInfo prop : props ) {
             if ( ! prop.isSet(this) ) continue;

--- a/src/foam/core/FObject.java
+++ b/src/foam/core/FObject.java
@@ -17,6 +17,7 @@ public interface FObject extends
   ClassInfo getClassInfo();
   FObject copyFrom(FObject obj);
   FObject fclone();
+  FObject fclone(foam.core.X x);
   FObject deepClone();
   FObject shallowClone();
   Map diff(FObject obj);


### PR DESCRIPTION
So we can call fclone similar to how we call it in js. If no context is given, the object being clone's context is used which is a change of behaviour from what currently happens but, imo is the more correct behavior and also matches JS.