### PR TITLE
Build tool fixes.

### DIFF
--- a/src/foam/build/FilesJsGen.js
+++ b/src/foam/build/FilesJsGen.js
@@ -107,6 +107,7 @@ foam.CLASS({
         'foam.core.ModelRefinescss',
         'foam.core.WindowScript',
         'foam.net.WebLibScript',
+        'foam.u2.view.TableCellPropertyRefinement',
       ],
     },
     {

--- a/src/foam/build/output/CodeSerializerImpl.js
+++ b/src/foam/build/output/CodeSerializerImpl.js
@@ -1,4 +1,4 @@
-/**
+ /**
  * @license
  * Copyright 2018 The FOAM Authors. All Rights Reserved.
  * http://www.apache.org/licenses/LICENSE-2.0
@@ -100,7 +100,7 @@ foam.CLASS({
 
         for ( var i = 0 ; i < axioms.length ; i++ ) {
           var a = axioms[i];
-          if ( v.hasDefaultValue(a.name) ) continue;
+          if ( ! v.hasOwnProperty(a.name) ) continue;
 
           if ( a.transient ) continue;
 

--- a/src/foam/build/output/replacer/ClassStrip.js
+++ b/src/foam/build/output/replacer/ClassStrip.js
@@ -8,7 +8,7 @@ foam.CLASS({
       value: function(x, v) {
         var ret = {};
         v.cls_.getAxiomsByClass(foam.core.Property).forEach(function(a) {
-          if ( v.hasDefaultValue(a.name) ) return;
+          if ( ! v.hasOwnProperty(a.name) ) return;
           if ( a.transient ) return;
           ret[a.name] = v[a.name];
         });

--- a/src/foam/build/output/replacer/ClassStripAndPropertyOrderer.js
+++ b/src/foam/build/output/replacer/ClassStripAndPropertyOrderer.js
@@ -28,7 +28,7 @@ foam.CLASS({
 
         var order = this.order;
         order.forEach(function(a) {
-          if ( v.hasDefaultValue(a) ) return;
+          if ( ! v.hasOwnProperty(a) ) return;
           if ( v.cls_.getAxiomByName(a).transient ) return;
           outputter.key(a);
           out.output(x, v[a]);
@@ -36,7 +36,7 @@ foam.CLASS({
 
         v.cls_.getAxiomsByClass(foam.core.Property).forEach(function(a) {
           if ( order.indexOf(a.name) != -1 ) return;
-          if ( v.hasDefaultValue(a.name) ) return;
+          if ( ! v.hasOwnProperty(a.name) ) return;
           if ( a.transient ) return;
           outputter.key(a.name);
           out.output(x, v[a.name]);

--- a/src/foam/build/output/replacer/ModelOrderer.js
+++ b/src/foam/build/output/replacer/ModelOrderer.js
@@ -24,6 +24,7 @@ foam.CLASS({
         'exports',
         'constants',
         'messages',
+        'ids',
         'properties',
         'axioms',
         'methods',


### PR DESCRIPTION
Use hasOwnProperty instead of hasDefaultValue because it doesn't capture properties being overwritten in an extending class. For example, if a model has a `Boolean` property with `value: true` and a model extends this model but changes the value to `false`, that will get lost when outputting.

Also add the `TableCellPropertyRefinement` to PHASE_2 so it's loaded earlier in the process. Otherwise tableCellFormatters are more likely to get lost.