### PR TITLE
Make enum value adapt able to handle an Object with class specified.

### DIFF
--- a/src/foam/core/Enum.js
+++ b/src/foam/core/Enum.js
@@ -329,6 +329,8 @@ foam.CLASS({
       name: 'value',
       adapt: function(_, n) {
         if ( foam.String.isInstance(n) ) n = this.of[n];
+        if ( foam.Object.isInstance(n) && n.class )
+          n = foam.lookup(n.class).create(n);
         return n
       },
       expression: function(of) {


### PR DESCRIPTION
Build tool outputs enums like this:
```
    {
      class: 'foam.core.Enum',
      of: 'foam.u2.Visibility',
      name: 'visibility',
      value: {
        class: 'foam.u2.Visibility',
        ordinal: 0
      }
    }
```
And this PR ensures those are adapted properly.