### PR TITLE
Add context menu to table rows

### DIFF
--- a/src/foam/u2/Element.js
+++ b/src/foam/u2/Element.js
@@ -1674,11 +1674,14 @@ foam.CLASS({
       return this;
     },
 
-    function forEach(a, f) {
-      for ( var i = 0 ; i < a.length ; i++ ) {
-        f.call(this, a[i], i);
-      }
-
+    /**
+     * Call the given function on each element in the array. In the function,
+     * `this` will refer to the element.
+     * @param {Array} array An array to loop over.
+     * @param {Function} fn A function to call for each item in the given array.
+     */
+    function forEach(array, fn) {
+      array.forEach(fn.bind(this));
       return this;
     },
 

--- a/src/foam/u2/md/OverlayDropdown.js
+++ b/src/foam/u2/md/OverlayDropdown.js
@@ -43,8 +43,6 @@ foam.CLASS({
       overflow-x: hidden;
       overflow-y: hidden;
       position: absolute;
-      width: 125px;
-      padding: 10px;
       padding-bottom: -20px;
       margin-bottom: -20px;
       right: 3px;

--- a/src/foam/u2/view/EditColumnsView.js
+++ b/src/foam/u2/view/EditColumnsView.js
@@ -32,6 +32,13 @@ foam.CLASS({
       value: false
     }
   ],
+
+  css: `
+    ^ {
+      padding: 10px;
+      width: 125px;
+    }
+  `,
   
   methods: [
     function initE() {
@@ -43,6 +50,8 @@ foam.CLASS({
       //     return a.label.toLowerCase().compareTo(b.label.toLowerCase());
       //   });
       // } else { ...
+
+      this.addClass(this.myClass());
 
       this.selected = []
 

--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -40,6 +40,11 @@
     },
     'columns',
     {
+      class: 'FObjectArray',
+      of: 'foam.core.Action',
+      name: 'contextMenuActions'
+    },
+    {
       class: 'Int',
       name: 'daoCount'
     },
@@ -59,7 +64,12 @@
         start('tr').
           start('td').
             style({ 'vertical-align': 'top' }).
-            start(this.TableView, {data$: this.scrolledDAO$, columns: this.columns, selection$: this.selection$}).
+            start(this.TableView, {
+              data$: this.scrolledDAO$,
+              columns: this.columns,
+              contextMenuActions: this.contextMenuActions,
+              selection$: this.selection$
+            }).
             end().
           end().
           start('td').style({ 'vertical-align': 'top' }).

--- a/src/foam/u2/view/TableView.js
+++ b/src/foam/u2/view/TableView.js
@@ -46,5 +46,14 @@ foam.CLASS({
       -ms-user-select: none;
       user-select: none;
     }
+
+    ^context-menu-item {
+      padding: 10px;
+    }
+
+    ^context-menu-item:hover {
+      cursor: pointer;
+      background-color: %ACCENTCOLOR%;
+    }
   `,
 });

--- a/src/foam/u2/view/TableView.js
+++ b/src/foam/u2/view/TableView.js
@@ -51,7 +51,11 @@ foam.CLASS({
       padding: 10px;
     }
 
-    ^context-menu-item:hover {
+    ^context-menu-item.disabled {
+      color: #ddd;
+    }
+
+    ^context-menu-item:hover:not(.disabled) {
       cursor: pointer;
       background-color: %ACCENTCOLOR%;
     }

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -220,7 +220,14 @@ foam.CLASS({
                     });
                   }).
                   callIf( ! view.disableUserSelection, function() {
-                    this.on('click', function() {
+                    this.on('click', function(evt) {
+                      // If we're clicking somewhere to close the context menu,
+                      // don't do anything.
+                      if (
+                        evt.target.nodeName === 'DROPDOWN-OVERLAY' ||
+                        evt.target.classList.contains(view.myClass('vertDots'))
+                      ) return;
+
                       view.selection = obj;
                       if ( view.importSelection$ ) view.importSelection = obj;
                       if ( view.editRecord$ ) view.editRecord(obj);
@@ -275,15 +282,14 @@ foam.CLASS({
                     return this.start('td').
                       add(overlay).
                       style({ 'text-align': 'right' }).
-                      on('click', function(e) {
-                        e.stopImmediatePropagation();
-                        view.positionOverlayDropdown(overlay);
-                        overlay.open();
-                      }).
                       start('span').
                         addClass(view.myClass('vertDots')).
                         addClass(view.myClass('noselect')).
                         add(view.vertMenuIcon).
+                        on('click', function(evt) {
+                          view.positionOverlayDropdown(overlay);
+                          overlay.open();
+                        }).
                       end().
                     end();
                   });

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -257,13 +257,19 @@ foam.CLASS({
                     }
 
                     overlay.forEach(availableActions, function(action) {
-                      this.start()
+                      var elm = this.start()
                         .addClass(view.myClass('context-menu-item'))
-                        .add(action.label)
-                        .on('click', function(evt) {
-                          action.code.call(obj);
-                        })
-                      .end();
+                        .add(action.label);
+
+                      if ( action.isEnabledFor(obj) ) {
+                        elm = elm.on('click', function(evt) {
+                          action.maybeCall(view.__subContext__, obj);
+                        });
+                      } else {
+                        elm.addClass('disabled');
+                      }
+
+                      elm.end();
                     });
 
                     return this.start('td').

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -157,7 +157,7 @@ foam.CLASS({
       var boundingBox = origin.getBoundingClientRect();
       var dropdownMenu = current.getBoundingClientRect();
 
-      overlay.style({ top: boundingBox.top - dropdownMenu.top + 'px'});
+      overlay.style({ top: boundingBox.top - dropdownMenu.top + 'px' });
     },
 
     function initE() {
@@ -268,15 +268,17 @@ foam.CLASS({
 
                     return this.start('td').
                       add(overlay).
-                      addClass(view.myClass('th-editColumns')).
+                      style({ 'text-align': 'right' }).
                       on('click', function(e) {
                         e.stopImmediatePropagation();
                         view.positionOverlayDropdown(overlay);
                         overlay.open();
                       }).
-                      add(' ', view.vertMenuIcon).
-                      addClass(view.myClass('vertDots')).
-                      addClass(view.myClass('noselect')).
+                      start('span').
+                        addClass(view.myClass('vertDots')).
+                        addClass(view.myClass('noselect')).
+                        add(view.vertMenuIcon).
+                      end().
                     end();
                   });
               });

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -25,14 +25,6 @@ foam.CLASS({
   ],
 
   imports: [
-    // Each table row has a context menu that contains actions you can perform
-    // on the object in that row. The actions used to populate that menu come
-    // from two different sources. The first source is the 'contextMenuActions'
-    // import. If you want a context menu action to do something in the view,
-    // then you should write the code for that action on the view and export it.
-    // The second source of actions is from the model of the object being shown
-    // in the table.
-    'contextMenuActions',
     'dblclick?',
     'editRecord?',
     'selection? as importSelection'
@@ -93,6 +85,20 @@ foam.CLASS({
             filter(function(p) { return p.tableCellFormatter && ! p.hidden; }).
             map(foam.core.Property.NAME.f);
       }
+    },
+    {
+      class: 'FObjectArray',
+      of: 'foam.core.Action',
+      name: 'contextMenuActions',
+      documentation: `
+        Each table row has a context menu that contains actions you can perform
+        on the object in that row. The actions used to populate that menu come
+        from two different sources. The first source is this property. If you
+        want a context menu action to do something in the view, then you should
+        write the code for that action in the view model and pass it to the
+        table view via this property. The second source of actions is from the
+        model of the object being shown in the table.
+      `
     },
     {
       class: 'Boolean',

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -252,20 +252,18 @@ foam.CLASS({
                     if ( availableActions.length === 0 ) {
                       if ( view.editColumnsEnabled ) {
                         return this.tag('td');
-                      } else {
-                        return;
                       }
+                      return;
                     }
 
-                    availableActions.forEach((action) => {
-                      var option = view.E().start()
+                    overlay.forEach(availableActions, function(action) {
+                      this.start()
                         .addClass(view.myClass('context-menu-item'))
                         .add(action.label)
                         .on('click', function(evt) {
                           action.code.call(obj);
                         })
                       .end();
-                      overlay.add(option);
                     });
 
                     return this.start('td').

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -25,6 +25,14 @@ foam.CLASS({
   ],
 
   imports: [
+    // Each table row has a context menu that contains actions you can perform
+    // on the object in that row. The actions used to populate that menu come
+    // from two different sources. The first source is the 'contextMenuActions'
+    // import. If you want a context menu action to do something in the view,
+    // then you should write the code for that action on the view and export it.
+    // The second source of actions is from the model of the object being shown
+    // in the table.
+    'contextMenuActions',
     'dblclick?',
     'editRecord?',
     'selection? as importSelection'
@@ -247,23 +255,25 @@ foam.CLASS({
                       end();
                   }).
                   call(function() {
-                    var model = view.of;
-                    var actions = model.getAxiomsByClass(foam.core.Action);
-                    var overlay = view.OverlayDropdown.create();
-                    var availableActions = actions.filter(function(action) {
+                    var modelActions = view.of.getAxiomsByClass(foam.core.Action);
+                    var allActions = Array.isArray(view.contextMenuActions) ?
+                      view.contextMenuActions.concat(modelActions) :
+                      modelActions;
+                    var actions = allActions.filter(function(action) {
                       return action.isAvailableFor(obj);
                     });
 
                     // Don't show the context menu if there are no available
                     // actions defined on the model.
-                    if ( availableActions.length === 0 ) {
+                    if ( actions.length === 0 ) {
                       if ( view.editColumnsEnabled ) {
                         return this.tag('td');
                       }
                       return;
                     }
 
-                    overlay.forEach(availableActions, function(action) {
+                    var overlay = view.OverlayDropdown.create();
+                    overlay.forEach(actions, function(action) {
                       var elm = this.start()
                         .addClass(view.myClass('context-menu-item'))
                         .add(action.label);

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -274,19 +274,19 @@ foam.CLASS({
 
                     var overlay = view.OverlayDropdown.create();
                     overlay.forEach(actions, function(action) {
-                      var elm = this.start()
+                      this.start()
                         .addClass(view.myClass('context-menu-item'))
-                        .add(action.label);
-
-                      if ( action.isEnabledFor(obj) ) {
-                        elm = elm.on('click', function(evt) {
-                          action.maybeCall(view.__subContext__, obj);
-                        });
-                      } else {
-                        elm.addClass('disabled');
-                      }
-
-                      elm.end();
+                        .add(action.label)
+                        .call(function() {
+                          if ( action.isEnabledFor(obj) ) {
+                            this.on('click', function(evt) {
+                              action.maybeCall(view.__subContext__, obj);
+                            });
+                          } else {
+                            this.addClass('disabled');
+                          }
+                        })
+                        .end();
                     });
 
                     return this.start('td').


### PR DESCRIPTION
Implementation for https://github.com/nanoPayinc/NANOPAY/issues/3861. Please read that ticket for context.

This PR adds a context menu to table views. That mean that each row gets a button (three vertical dots) at the end of it that when clicked will show a popover that contains actions that can be taken on the object in that row. These actions are defined by the model of the object.

Tony wants this for our tables in Ablii. Here's a screenshot from the lo-fi wireframes:

<img width="1101" alt="screen shot 2018-10-09 at 3 39 14 pm" src="https://user-images.githubusercontent.com/4259165/46694028-956b9e80-cbd9-11e8-933f-0e793861b1cf.png">

and here's a screenshot with this branch running:

<img width="996" alt="screen shot 2018-10-09 at 3 40 12 pm" src="https://user-images.githubusercontent.com/4259165/46694048-aa483200-cbd9-11e8-9171-86d7b73a6d3d.png">


## Future work/will add to this PR if requested

* Ability to style some of the buttons differently
  * I'm thinking we could add a property to Action called `isDestructive`. If that property is set to true, we'll style that button with red text or something.