### PR TITLE
Add missing SequenceNumberDAO constructor back

### DIFF
--- a/src/foam/dao/SequenceNumberDAO.js
+++ b/src/foam/dao/SequenceNumberDAO.js
@@ -141,6 +141,11 @@ foam.CLASS({
             setValue((long) ( ( (foam.mlang.sink.Max) sink ).getValue() == null ? 1 : ( (Number) ( (foam.mlang.sink.Max) sink ).getValue() ).longValue() + 1.0 ));
           }
 
+          public SequenceNumberDAO(foam.dao.DAO delegate) {
+            System.err.println("Direct constructor use is deprecated. Use Builder instead.");
+            setDelegate(delegate);
+          }
+
           public SequenceNumberDAO(long value, foam.dao.DAO delegate) {
             System.err.println("Direct constructor use is deprecated. Use Builder instead.");
             setDelegate(delegate);

--- a/src/foam/dao/SequenceNumberDAO.js
+++ b/src/foam/dao/SequenceNumberDAO.js
@@ -142,8 +142,7 @@ foam.CLASS({
           }
 
           public SequenceNumberDAO(foam.dao.DAO delegate) {
-            System.err.println("Direct constructor use is deprecated. Use Builder instead.");
-            setDelegate(delegate);
+            this(1, delegate);
           }
 
           public SequenceNumberDAO(long value, foam.dao.DAO delegate) {


### PR DESCRIPTION
It was replaced in a9a5a9068d110df298bc18fdbccce0d450dae0c3 but doing so broke all the places that used the previous interface.