### PR TITLE
Discard empty group permissions

### DIFF
--- a/src/foam/nanos/auth/Group.js
+++ b/src/foam/nanos/auth/Group.js
@@ -49,7 +49,7 @@ foam.CLASS({
       preSet: function(oldVal, newVal) {
         // if old value is undefined, that means save action triggered
         return oldVal !== undefined ? newVal :
-          newVal.filter(permission => {return permission.id});
+          newVal.filter(permission => permission.id);
       }
     },
     {

--- a/src/foam/nanos/auth/Group.js
+++ b/src/foam/nanos/auth/Group.js
@@ -49,7 +49,7 @@ foam.CLASS({
       preSet: function(oldVal, newVal) {
         // if old value is undefined, that means save action triggered
         return oldVal !== undefined ? newVal :
-          newVal.filter(permission => {return Object.keys(permission.instance_).length !== 0});
+          newVal.filter(permission => {return permission.id});
       }
     },
     {

--- a/src/foam/nanos/auth/Group.js
+++ b/src/foam/nanos/auth/Group.js
@@ -45,7 +45,12 @@ foam.CLASS({
       class: 'FObjectArray',
       of: 'foam.nanos.auth.Permission',
       name: 'permissions',
-      documentation: 'Permissions set on group.'
+      documentation: 'Permissions set on group.',
+      preSet: function(oldVal, newVal) {
+        // if old value is undefined, that means save action triggered
+        return oldVal !== undefined ? newVal :
+          newVal.filter(permission => {return Object.keys(permission.instance_).length !== 0});
+      }
     },
     {
       class: 'StringArray',


### PR DESCRIPTION
Refs #4036
On save, filter out all the empty entries in the preset method.