### PR TITLE
Add appConfig to the ClientBuilder context

### DIFF
--- a/src/foam/nanos/client/ClientBuilder.js
+++ b/src/foam/nanos/client/ClientBuilder.js
@@ -61,8 +61,17 @@ foam.CLASS({
           // Force hard reload when app version updates
           self.nSpecDAO.find("appConfig").then(function(spec) {
             var appConfig = spec.service;
-            var version   = appConfig.version;
 
+            client.exports.push(spec.name);
+            references = references.concat(foam.json.references(self.__context__, appConfig));
+            client.properties.push({
+              name: spec.name,
+              factory: function() {
+                return foam.json.parse(appConfig, null, this);
+              }
+            });
+
+            var version   = appConfig.version;
             if ( "CLIENT_VERSION" in localStorage ) {
               var oldVersion = localStorage.CLIENT_VERSION;
               if ( version != oldVersion ) {

--- a/src/foam/nanos/controller/ApplicationController.js
+++ b/src/foam/nanos/controller/ApplicationController.js
@@ -52,6 +52,7 @@ foam.CLASS({
 
   exports: [
     'as ctrl',
+    'appConfig',
     'group',
     'loginSuccess',
     'logo',
@@ -109,6 +110,12 @@ foam.CLASS({
     },
     {
       name: 'client',
+    },
+    {
+      name: 'appConfig',
+      expression: function(client) {
+        return client && client.appConfig || null;
+      }
     },
     {
       name: 'stack',


### PR DESCRIPTION
Nanos keeps complaining about a lack of appConfig and this should fix that up.