### PR TITLE
SequenceNumberDAO changes

### DIFF
--- a/demos/swift/SwiftTests/SwiftTestsTests/SwiftTestsTests.swift
+++ b/demos/swift/SwiftTests/SwiftTestsTests/SwiftTestsTests.swift
@@ -687,8 +687,8 @@ class SwiftTestsTests: XCTestCase {
       "name": "Alan Kay",
     ])!) as! foam_nanos_demo_relationship_Professor
 
-    let adam = try studentDAO.find(1) as! foam_nanos_demo_relationship_Student
-    let mike = try studentDAO.find(2) as! foam_nanos_demo_relationship_Student
+    let adam = try studentDAO.find(0) as! foam_nanos_demo_relationship_Student
+    let mike = try studentDAO.find(1) as! foam_nanos_demo_relationship_Student
 
     let cs101 = try courseDAO.find("CS 101") as! foam_nanos_demo_relationship_Course
     let cs201 = try courseDAO.find("CS 201") as! foam_nanos_demo_relationship_Course

--- a/src/foam/dao/SequenceNumberDAO.js
+++ b/src/foam/dao/SequenceNumberDAO.js
@@ -37,7 +37,6 @@ foam.CLASS({
       class: 'Long',
       name: 'value_',
       documentation: 'The next value to be used.',
-      value: 1,
       swiftExpressionArgs: ['delegate', 'property_', 'startingValue'],
       swiftExpression: `
         let max = self.Max_create(["arg1": property_])

--- a/src/foam/dao/SequenceNumberDAO.js
+++ b/src/foam/dao/SequenceNumberDAO.js
@@ -57,7 +57,7 @@ foam.CLASS({
       flags: ['js'],
       name: 'calcDelegateMax_',
       hidden: true,
-      expression: function(delegate, property) {
+      expression: function(delegate, property, startingValue) {
         // TODO: validate property self.of[self.property.toUpperCase()]
         var self = this;
         return self.delegate.select( // TODO: make it a pipe?
@@ -65,7 +65,7 @@ foam.CLASS({
         ).then(
           function(max) {
             var v = foam.Number.isInstance(max.value) ? ( max.value + 1 ) : 0;
-            self.value_ = v > self.startingValue ? v : self.startingValue
+            self.value_ = v > startingValue ? v : startingValue
           }
         );
       },

--- a/src/foam/dao/SequenceNumberDAOTest.js
+++ b/src/foam/dao/SequenceNumberDAOTest.js
@@ -18,22 +18,22 @@ foam.CLASS({
 
         // test using default value
         foam.core.FObject user = new foam.nanos.auth.User.Builder(x).setFirstName("Test").build();
-        test(seq.getValue() == 1, "Sequence number value equals 1 before putting to DAO.");
+        test(seq.getValue_() == 1, "Sequence number value equals 1 before putting to DAO.");
         user = seq.put(user);
 
         test(foam.util.SafetyUtil.equals(user.getProperty("id"), 1), "User id equals 1");
-        test(seq.getValue() == 2, "Sequence number value equals 2 after putting to DAO.");
+        test(seq.getValue_() == 2, "Sequence number value equals 2 after putting to DAO.");
 
         // test using starting value of 1000
         user = new foam.nanos.auth.User.Builder(x).setFirstName("Test").build();
         delegate = new foam.dao.MDAO(foam.nanos.auth.User.getOwnClassInfo());
         seq = new SequenceNumberDAO(1000, delegate);
 
-        test(seq.getValue() == 1000, "Sequence number value equals 1 before putting to DAO.");
+        test(seq.getValue_() == 1000, "Sequence number value equals 1 before putting to DAO.");
         user = seq.put(user);
 
         test(foam.util.SafetyUtil.equals(user.getProperty("id"), 1000), "User id equals 1000");
-        test(seq.getValue() == 1001, "Sequence number value equals 1001 after putting to DAO.");
+        test(seq.getValue_() == 1001, "Sequence number value equals 1001 after putting to DAO.");
 
         // test sequence number getting delegate max
         user = new foam.nanos.auth.User.Builder(x).setId(5000).setFirstName("Test").build();
@@ -41,7 +41,7 @@ foam.CLASS({
         delegate.put(user);
 
         seq = new SequenceNumberDAO(delegate);
-        test(seq.getValue() == 5001, "Sequence number value equals 5001 after initializing.");
+        test(seq.getValue_() == 5001, "Sequence number value equals 5001 after initializing.");
       `
     }
   ]

--- a/test/src/lib/dao.js
+++ b/test/src/lib/dao.js
@@ -219,14 +219,14 @@ describe('SequenceNumberDAO', function() {
     sDAO.put(a).then(function() {
       return mDAO.select().then(function (sink) {
         expect(sink.array.length).toEqual(1);
-        expect(sink.array[0].id).toEqual(1);
+        expect(sink.array[0].id).toEqual(0);
         a = test.CompA.create({ a: 6 }, foam.__context__); // id not set
         return sDAO.put(a).then(function() {
           return mDAO.select().then(function (sink) {
             expect(sink.array.length).toEqual(2);
-            expect(sink.array[0].id).toEqual(1);
+            expect(sink.array[0].id).toEqual(0);
             expect(sink.array[0].a).toEqual(4);
-            expect(sink.array[1].id).toEqual(2);
+            expect(sink.array[1].id).toEqual(1);
             expect(sink.array[1].a).toEqual(6);
             done();
           });


### PR DESCRIPTION
- Make behaviour more similar across platforms.
- Fix SequenceNumberDAO.Builder with a starting value in java.
- Rename value to value_ because it's internal to the model.
- Introduce a startingValue property that will be used if the max found isn't greater than it.