### PR TITLE
Swift Reference property changes

### DIFF
--- a/demos/swift/SwiftTests/SwiftTestsTests/SwiftTestsTests.swift
+++ b/demos/swift/SwiftTests/SwiftTestsTests/SwiftTestsTests.swift
@@ -802,4 +802,20 @@ class SwiftTestsTests: XCTestCase {
     XCTAssertEqual((a.array[1] as! somepackage_Test).firstName, "Joe2")
     XCTAssertEqual((a.array[2] as! somepackage_Test).firstName, "Joe1")
   }
+
+  func testRefProp() {
+    let languageDAO = self.x.create(foam_swift_dao_ArrayDAO.self, args: [
+      "of": foam_nanos_auth_Language.classInfo(),
+    ])!
+    _ = try! languageDAO.put(self.x.create(foam_nanos_auth_Language.self, args: [
+      "code": "IT"
+    ])!)
+    let x = self.x.createSubContext(args: ["languageDAO": languageDAO])
+
+    let t = x.create(somepackage_Test.self)!
+    try! XCTAssertNil(t.findOptRefProp(x))
+
+    t.optRefProp = "IT"
+    try! XCTAssertNotNil(t.findOptRefProp(x))
+  }
 }

--- a/demos/swift/SwiftTests/SwiftTestsTests/SwiftTestsTests.swift
+++ b/demos/swift/SwiftTests/SwiftTestsTests/SwiftTestsTests.swift
@@ -703,7 +703,7 @@ class SwiftTestsTests: XCTestCase {
     _ = try mike.getCourses(x).add(cs101)
 
     let course = cs101
-    try XCTAssertEqual(course.findProfessor(x).name, "Donald Knuth")
+    try XCTAssertEqual(course.findProfessor(x)!.name, "Donald Knuth")
 
     let donaldsCourses = try donald.getCourses(x).select().array as! [foam_nanos_demo_relationship_Course]
     XCTAssertEqual(donaldsCourses[0].code, "CS 101")
@@ -813,9 +813,9 @@ class SwiftTestsTests: XCTestCase {
     let x = self.x.createSubContext(args: ["languageDAO": languageDAO])
 
     let t = x.create(somepackage_Test.self)!
-    try! XCTAssertNil(t.findOptRefProp(x))
+    try! XCTAssertNil(t.findRefProp(x))
 
-    t.optRefProp = "IT"
-    try! XCTAssertNotNil(t.findOptRefProp(x))
+    t.refProp = "IT"
+    try! XCTAssertNotNil(t.findRefProp(x))
   }
 }

--- a/demos/swift/js/somepackage/Test.js
+++ b/demos/swift/js/somepackage/Test.js
@@ -100,6 +100,12 @@ return ["Hello", "World"]
       of: 'foam.core.FObject',
       name: 'fobjArr',
     },
+    {
+      class: 'Reference',
+      of: 'foam.nanos.auth.Language',
+      required: false,
+      name: 'optRefProp',
+    },
   ],
   actions: [
     {

--- a/demos/swift/js/somepackage/Test.js
+++ b/demos/swift/js/somepackage/Test.js
@@ -103,8 +103,7 @@ return ["Hello", "World"]
     {
       class: 'Reference',
       of: 'foam.nanos.auth.Language',
-      required: false,
-      name: 'optRefProp',
+      name: 'refProp',
     },
   ],
   actions: [

--- a/src/foam/dao/Relationship.js
+++ b/src/foam/dao/Relationship.js
@@ -173,6 +173,7 @@ foam.CLASS({
         targetProp = foam.core.Reference.create({
           name: inverseName,
           of: sourceModel,
+          required: true,
           targetDAOKey: sourceDAOKey
         }).copyFrom(this.targetProperty);
       } else {/* cardinality === '*.*' */

--- a/src/foam/dao/Relationship.js
+++ b/src/foam/dao/Relationship.js
@@ -173,7 +173,6 @@ foam.CLASS({
         targetProp = foam.core.Reference.create({
           name: inverseName,
           of: sourceModel,
-          required: true,
           targetDAOKey: sourceDAOKey
         }).copyFrom(this.targetProperty);
       } else {/* cardinality === '*.*' */

--- a/src/foam/nanos/auth/Group.js
+++ b/src/foam/nanos/auth/Group.js
@@ -101,7 +101,6 @@ foam.CLASS({
     {
       class: 'String',
       name: 'url',
-      value: null
     }
 /*    {
       class: 'FObjectProperty',

--- a/src/foam/swift/SwiftLib.js
+++ b/src/foam/swift/SwiftLib.js
@@ -27,6 +27,8 @@ foam.LIB({
       } else if ( type == foam.core.FObject ) {
         // TODO: Should be able to serialize an FObject to swift.
         return 'nil';
+      } else if ( type == foam.Null ) {
+        return 'nil';
       } else  {
         console.log('Encountered unexpected type while converitng value to string:', v);
         debugger;

--- a/src/foam/swift/refines/Property.js
+++ b/src/foam/swift/refines/Property.js
@@ -761,18 +761,20 @@ foam.CLASS({
       // TODO: copied from java refinements.
       name: 'referencedProperty',
       transient: true,
-      factory: function() {
-        var idProp = this.of.ID.cls_ == foam.core.IDAlias ? this.of.ID.targetProperty : this.of.ID;
+      expression: function(of, name) {
+        var idProp = of.ID.cls_ == foam.core.IDAlias ? of.ID.targetProperty : of.ID;
 
         idProp = idProp.clone();
-        idProp.name = this.name;
+        idProp.name = name;
 
         return idProp;
       }
     },
     {
       name: 'swiftType',
-      factory: function() { return this.referencedProperty.swiftType; }
+      expression: function(referencedProperty) {
+        return referencedProperty.swiftType;
+      },
     },
     {
       name: 'swiftJsonParser',
@@ -789,7 +791,7 @@ foam.CLASS({
         visibility: 'public',
         override: !!parentCls.getSuperClass().getAxiomByName(this.name),
         name: `find${foam.String.capitalize(this.name)}`,
-        returnType: this.of.model_.swiftName,
+        returnType: this.of.model_.swiftName + ( this.required ? '' : '?' ),
         args: [
           {
             localName: 'x',
@@ -799,6 +801,9 @@ foam.CLASS({
         ],
         throws: true,
         body: `
+${this.required ? '' : `
+if !hasOwnProperty("${this.name}") { return nil }
+`}
 let dao = x["${this.targetDAOKey}"] as! foam_dao_DAO
 return try dao.find_(x, ${this.swiftVarName}) as! ${this.of.model_.swiftName}
         `

--- a/src/foam/swift/refines/Property.js
+++ b/src/foam/swift/refines/Property.js
@@ -771,12 +771,6 @@ foam.CLASS({
       }
     },
     {
-      name: 'swiftType',
-      expression: function(referencedProperty) {
-        return referencedProperty.swiftType;
-      },
-    },
-    {
       name: 'swiftJsonParser',
       factory: function() { return this.referencedProperty.swiftJsonParser; }
     },
@@ -787,11 +781,12 @@ foam.CLASS({
       this.SUPER(cls, parentCls);
       if ( ! parentCls.hasOwnAxiom(this.name) ) return;
       if ( ! this.swiftSupport ) return;
+      var r = this.required;
       cls.method({
         visibility: 'public',
         override: !!parentCls.getSuperClass().getAxiomByName(this.name),
         name: `find${foam.String.capitalize(this.name)}`,
-        returnType: this.of.model_.swiftName + ( this.required ? '' : '?' ),
+        returnType: this.of.model_.swiftName + ( r ? '' : '?' ),
         args: [
           {
             localName: 'x',
@@ -801,11 +796,9 @@ foam.CLASS({
         ],
         throws: true,
         body: `
-${this.required ? '' : `
-if !hasOwnProperty("${this.name}") { return nil }
-`}
+${r ? '' : `if !hasOwnProperty("${this.name}") { return nil }`}
 let dao = x["${this.targetDAOKey}"] as! foam_dao_DAO
-return try dao.find_(x, ${this.swiftVarName}) as! ${this.of.model_.swiftName}
+return try dao.find_(x, ${this.swiftVarName}) as${r ? '!' : '?'} ${this.of.model_.swiftName}
         `
       });
     }

--- a/src/foam/swift/refines/Property.js
+++ b/src/foam/swift/refines/Property.js
@@ -781,12 +781,11 @@ foam.CLASS({
       this.SUPER(cls, parentCls);
       if ( ! parentCls.hasOwnAxiom(this.name) ) return;
       if ( ! this.swiftSupport ) return;
-      var r = this.required;
       cls.method({
         visibility: 'public',
         override: !!parentCls.getSuperClass().getAxiomByName(this.name),
         name: `find${foam.String.capitalize(this.name)}`,
-        returnType: this.of.model_.swiftName + ( r ? '' : '?' ),
+        returnType: this.of.model_.swiftName + '?',
         args: [
           {
             localName: 'x',
@@ -796,9 +795,8 @@ foam.CLASS({
         ],
         throws: true,
         body: `
-${r ? '' : `if !hasOwnProperty("${this.name}") { return nil }`}
-let dao = x["${this.targetDAOKey}"] as! foam_dao_DAO
-return try dao.find_(x, ${this.swiftVarName}) as${r ? '!' : '?'} ${this.of.model_.swiftName}
+guard let dao = x["${this.targetDAOKey}"] as? foam_dao_DAO else { return nil }
+return try dao.inX(x).find(${this.swiftVarName}) as? ${this.of.model_.swiftName}
         `
       });
     }

--- a/src/foam/swift/ui/ScrollingViewController.js
+++ b/src/foam/swift/ui/ScrollingViewController.js
@@ -35,7 +35,7 @@ return view$title as? String ?? ""
       swiftExpressionArgs: ['view$view', 'title', 'backgroundColor'],
       swiftExpression: function() {/*
 let vc = VC_()
-vc.innerView = view$view as! UIView
+vc.innerView = view$view as? UIView
 vc.title = title
 vc.backgroundColor = backgroundColor
 return vc


### PR DESCRIPTION
In swift, use `Any?` for the type of the Reference property because it doesn't carry much meaning. It's mostly just be passed into the find function that's generated by a reference property. These changes also make the return type of the find function optional. This change could break any current users of references but the fix is as simple as unwrapping the optional with a `!` or `?`

Other changes:
- Don't set the default value of `url` to `null` in `foam.nanos.auth.Group`. It's a string property so it shouldn't be set to `null`.
- Handle nulls in SwiftLib.js
- Hide a warning in ScrollingViewController