### PR TITLE
Rich choice view

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -409,6 +409,7 @@ FOAM_FILES([
   { name: "foam/u2/view/FObjectView", flags: ['web'] },
   { name: "foam/u2/view/FObjectArrayView", flags: ['web'] },
   { name: "foam/u2/view/ChoiceView", flags: ['web'] },
+  { name: "foam/u2/view/RichChoiceView", flags: ['web'] },
   { name: "foam/u2/view/RadioView", flags: ['web'] },
   { name: "foam/u2/view/TextField", flags: ['web'] },
   { name: "foam/u2/view/TreeView", flags: ['web'] },

--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -43,51 +43,47 @@ foam.CLASS({
   css: `
     ^ {
       position: relative;
+      display: inline-block;
     }
 
     ^container {
       position: absolute;
-      top: 40px; // 36px for height of select input, plus 4px bottom margin
+      top: 18px;
       left: 0;
       background: white;
       border: 1px solid #bdbdbd;
-      border-radius: 4px;
-      width: 488px;
       max-height: 378px;
       overflow-y: scroll;
       box-sizing: border-box;
+      width: 100%;
+      min-width: fit-content;
+      -webkit-appearance: textfield;
     }
 
     ^heading {
-      font-weight: bold;
       border-bottom: 1px solid #f4f4f9;
-      line-height: 24px;
-      font-size: 14px;
-      color: #333;
+      font-size: 12px;
       font-weight: 900;
-      padding: 6px 16px;
+      padding: 1px 2px;
     }
 
     ^selection-view {
-      height: 36px;
-      width: 488px;
-      border-radius: 4px;
-      border: solid 1px #bdbdbd;
-      background-color: #ffffff;
-      display: flex;
+      background-color: white;
+      display: inline-flex;
       align-items: center;
       justify-content: space-between;
-      padding: 0 8px;
-      font-size: 12px;
+      font-size: 11px;
       box-sizing: border-box;
-      margin-bottom: 4px;
+      -webkit-appearance: textfield;
+      padding: 1px 2px;
+      cursor: default;
+      border: 1px solid;
+      min-width: 94px;
     }
 
     ^chevron::before {
       content: '▾';
-      color: #bdbdbd;
-      font-size: 17px;
-      padding-left: 8px;
+      padding-left: 4px;
     }
 
     ^custom-selection-view {
@@ -242,7 +238,8 @@ foam.CLASS({
       css: `
         ^row {
           background: white;
-          padding: 8px 16px;
+          padding: 1px 2px;
+          font-size: 12px;
         }
 
         ^row:hover {

--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -1,0 +1,194 @@
+/**
+ * @license
+ * Copyright 2018 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.u2.view',
+  name: 'RichChoiceView',
+  extends: 'foam.u2.View',
+
+  documentation: `
+  
+  `,
+
+  exports: [
+    'of'
+  ],
+
+  css: `
+    ^container {
+      background: white;
+      border: 1px solid #bdbdbd;
+      border-radius: 4px;
+      max-width: 488px;
+      max-height: 378px;
+      overflow-y: scroll;
+      box-sizing: border-box;
+    }
+
+    ^heading {
+      font-weight: bold;
+      border-bottom: 1px solid #f4f4f9;
+      line-height: 24px;
+      font-size: 14px;
+      color: #333;
+      font-weight: 900;
+      padding: 6px 16px;
+    }
+
+    ^button {
+      height: 36px;
+      width: 488px;
+      border-radius: 4px;
+      border: solid 1px #bdbdbd;
+      background-color: #ffffff;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0 8px;
+      font-size: 12px;
+      box-sizing: border-box;
+      margin-bottom: 4px;
+    }
+
+    ^caret::before {
+      content: '▾';
+      color: #bdbdbd;
+      font-size: 17px;
+      padding-left: 8px;
+    }
+
+    ^custom-button {
+      flex-grow: 1;
+    }
+  `,
+
+  properties: [
+    {
+      class: 'foam.u2.ViewSpec',
+      name: 'rowView',
+      value: { class: 'foam.u2.CitationView' }
+    },
+    {
+      name: 'data',
+      documentation: `` // TODO
+    },
+    {
+      class: 'Boolean',
+      name: 'isOpen_',
+      documentation: `
+        An internal property used to determine whether the options list is
+        visible or not.
+      `
+    },
+    {
+      class: 'foam.u2.ViewSpec',
+      name: 'buttonView',
+      factory: function() {
+        return this.DefaultButtonView;
+      }
+    },
+    {
+      class: 'Array',
+      name: 'sections',
+      documentation: '' // TODO
+    },
+    {
+      class: 'FObjectProperty',
+      name: 'of',
+      expression: function(sections) {
+        if ( ! Array.isArray(sections) || sections.length === 0 ) {
+          return null;
+        }
+        return ctrl.__subContext__[sections[0].dao].of; // FIXME
+      }
+    },
+    {
+      class: 'FObjectProperty',
+      name: 'fullObject'
+    }
+  ],
+
+  methods: [
+    function initE() {
+      var self = this;
+      this
+        .addClass(this.myClass())
+        .start()
+          .addClass(this.myClass('button'))
+          .on('click', function() {
+            self.isOpen_ = ! self.isOpen_;
+          })
+          .start()
+            .addClass(this.myClass('custom-button'))
+            .add(this.slot((data) => {
+              return this.E().add(self.buttonView.create({
+                data: data,
+                fullObject: this.fullObject
+              }));
+            }))
+          .end()
+          .start()
+            .addClass(this.myClass('caret'))
+          .end()
+        .end()
+        .start()
+          .addClass(this.myClass('container'))
+          .show(self.isOpen_$)
+          .forEach(this.sections, function(section) {
+            var dao = ctrl.__subContext__[section.dao]; // FIXME
+            this
+              .start()
+                .addClass(self.myClass('heading'))
+                .add(section.heading)
+              .end()
+              .start()
+                .select(dao, function(obj) {
+                  return this.E()
+                    .start(self.rowView, { data: obj })
+                      .on('click', () => {
+                        self.fullObject = obj;
+                        self.data = obj;
+                        self.isOpen_ = false;
+                      })
+                    .end();
+                })
+              .end();
+          })
+        .end();
+    }
+  ],
+
+  classes: [
+    {
+      name: 'DefaultButtonView',
+      extends: 'foam.u2.Element',
+
+      imports: [
+        'of'
+      ],
+
+      messages: [
+        {
+          name: 'DEFAULT_BUTTON_LABEL',
+          message: 'Choose from '
+        }
+      ],
+
+      properties: [
+        {
+          name: 'data'
+        }
+      ],
+
+      methods: [
+        function initE() {
+          return this
+            .add(this.data || this.DEFAULT_BUTTON_LABEL + this.of.model_.plural.toLowerCase());
+        }
+      ]
+    }
+  ]
+});

--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -114,6 +114,12 @@ foam.CLASS({
   methods: [
     function initE() {
       var self = this;
+      if ( this.data ) {
+        // FIXME
+        ctrl.__subContext__[this.sections[0].dao].find(this.data).then((result) => {
+          this.fullObject = result;
+        });
+      }
       this
         .addClass(this.myClass())
         .start()
@@ -126,8 +132,8 @@ foam.CLASS({
             .add(this.slot((data) => {
               return this.E().tag(self.buttonContentView, {
                 data: data,
-                fullObject: this.fullObject
-              }));
+                fullObject$: this.fullObject$
+              });
             }))
           .end()
           .start()

--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -41,11 +41,18 @@ foam.CLASS({
   ],
 
   css: `
+    ^ {
+      position: relative;
+    }
+
     ^container {
+      position: absolute;
+      top: 40px; // 36px for height of button, plus 4px bottom margin
+      left: 0;
       background: white;
       border: 1px solid #bdbdbd;
       border-radius: 4px;
-      max-width: 488px;
+      width: 488px;
       max-height: 378px;
       overflow-y: scroll;
       box-sizing: border-box;

--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -99,10 +99,7 @@ foam.CLASS({
       class: 'FObjectProperty',
       name: 'of',
       expression: function(sections) {
-        if ( ! Array.isArray(sections) || sections.length === 0 ) {
-          return null;
-        }
-        return ctrl.__subContext__[sections[0].dao].of; // FIXME
+        return sections[0].dao.of;
       }
     },
     {
@@ -114,9 +111,13 @@ foam.CLASS({
   methods: [
     function initE() {
       var self = this;
+
+      if ( ! Array.isArray(this.sections) || this.sections.length === 0 ) {
+        throw new Error(`You must provide an array of sections. See documentation on the 'sections' property in RichTextView.js.`);
+      }
+
       if ( this.data ) {
-        // FIXME
-        ctrl.__subContext__[this.sections[0].dao].find(this.data).then((result) => {
+        this.sections[0].dao.find(this.data).then((result) => {
           this.fullObject = result;
         });
       }
@@ -144,7 +145,7 @@ foam.CLASS({
           .addClass(this.myClass('container'))
           .show(self.isOpen_$)
           .forEach(this.sections, function(section) {
-            var dao = ctrl.__subContext__[section.dao]; // FIXME
+            var dao = section.dao;
             this
               .start()
                 .addClass(self.myClass('heading'))

--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -11,7 +11,7 @@ foam.CLASS({
 
   documentation: `
     This is similar to foam.u2.view.ChoiceView, but lets you provide views for
-    the button content and options instead of strings. This allows you to create
+    the selection and options instead of strings. This allows you to create
     dropdowns with rich content like images and formatting using CSS.
 
     Example usage for a Reference property on a model:
@@ -23,7 +23,7 @@ foam.CLASS({
         view: function(_, X) {
           return {
             class: 'foam.u2.view.RichChoiceView',
-            buttonContentView: { class: 'a.b.c.MyCustomButtonView' }, // Optional
+            selectionView: { class: 'a.b.c.MyCustomSelectionView' }, // Optional
             rowView: { class: 'a.b.c.MyCustomCitationView' }, // Optional
             sections: [
               {
@@ -47,7 +47,7 @@ foam.CLASS({
 
     ^container {
       position: absolute;
-      top: 40px; // 36px for height of button, plus 4px bottom margin
+      top: 40px; // 36px for height of select input, plus 4px bottom margin
       left: 0;
       background: white;
       border: 1px solid #bdbdbd;
@@ -68,7 +68,7 @@ foam.CLASS({
       padding: 6px 16px;
     }
 
-    ^button {
+    ^selection-view {
       height: 36px;
       width: 488px;
       border-radius: 4px;
@@ -90,7 +90,7 @@ foam.CLASS({
       padding-left: 8px;
     }
 
-    ^custom-button {
+    ^custom-selection-view {
       flex-grow: 1;
     }
   `,
@@ -123,14 +123,14 @@ foam.CLASS({
     },
     {
       class: 'foam.u2.ViewSpec',
-      name: 'buttonContentView',
+      name: 'selectionView',
       documentation: `
-        Set this to override the default view used for the button content. It
+        Set this to override the default view used for the input content. It
         will be instantiated with an object from the DAO as the 'fullObject'
         property and that object's id as the 'data' property.
       `,
       factory: function() {
-        return this.DefaultButtonContentView;
+        return this.DefaultSelectionView;
       }
     },
     {
@@ -175,9 +175,8 @@ foam.CLASS({
       // rendered, the 'data' property on this model will be set to an id for
       // the object being referenced by the Reference property being rendered.
       // Custom views might need the full object to render though, not just the
-      // id, so we do a lookup at the beginning of initE for the full object and
-      // set it here when found. This then gets passed to the button view to use
-      // it if it wants to.
+      // id, so we do a lookup here for the full object here. This then gets
+      // passed to the selectionView to use it if it wants to.
       if ( this.data ) {
         this.sections[0].dao.find(this.data).then((result) => {
           this.fullObject_ = result;
@@ -187,14 +186,14 @@ foam.CLASS({
       this
         .addClass(this.myClass())
         .start()
-          .addClass(this.myClass('button'))
+          .addClass(this.myClass('selection-view'))
           .on('click', function() {
             self.isOpen_ = ! self.isOpen_;
           })
           .start()
-            .addClass(this.myClass('custom-button'))
+            .addClass(this.myClass('custom-selection-view'))
             .add(this.slot((data) => {
-              return this.E().tag(self.buttonContentView, {
+              return this.E().tag(self.selectionView, {
                 data: data,
                 fullObject$: this.fullObject_$
               });
@@ -270,20 +269,20 @@ foam.CLASS({
       ]
     },
     {
-      name: 'DefaultButtonContentView',
+      name: 'DefaultSelectionView',
       extends: 'foam.u2.Element',
 
       documentation: `
-        This is the view that gets rendered inside the button. It is put to the
-        left of the chevron (the triangle at the far right side of the button).
-        This is an Element instead of a simple string, meaning the button can
-        contain "rich" content like images and make use of CSS for styling and
-        layout.
+        This is the view that gets rendered inside the select input. It is put
+        to the left of the chevron (the triangle at the far right side of the
+        select input). This is an Element instead of a simple string, meaning
+        the select input can contain "rich" content like images and make use of
+        CSS for styling and layout.
         As an example of why this is useful, imagine you wanted to show a
         dropdown to select a country. You could choose to display the flag of
         the selected country alongside its name after the user makes a
         selection by creating that custom view and providing it in place of this
-        one by setting the buttonContentView property on RichChoiceView.
+        one by setting the selectionView property on RichChoiceView.
       `,
 
       imports: [
@@ -305,10 +304,10 @@ foam.CLASS({
         {
           name: 'fullObject',
           documentation: `
-            The full object. It's not used here in the default button view, but
-            this property is included to let you know that if you create a
-            custom button content view, it will be passed the id of the object
-            (data) as well as the full object.
+            The full object. It's not used here in the default selection view,
+            but this property is included to let you know that if you create a
+            custom selection view, it will be passed the id of the object (data)
+            as well as the full object.
           `
         }
       ],

--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -53,7 +53,7 @@ foam.CLASS({
       margin-bottom: 4px;
     }
 
-    ^caret::before {
+    ^chevron::before {
       content: '▾';
       color: #bdbdbd;
       font-size: 17px;
@@ -85,9 +85,9 @@ foam.CLASS({
     },
     {
       class: 'foam.u2.ViewSpec',
-      name: 'buttonView',
+      name: 'buttonContentView',
       factory: function() {
-        return this.DefaultButtonView;
+        return this.DefaultButtonContentView;
       }
     },
     {
@@ -124,14 +124,14 @@ foam.CLASS({
           .start()
             .addClass(this.myClass('custom-button'))
             .add(this.slot((data) => {
-              return this.E().add(self.buttonView.create({
+              return this.E().tag(self.buttonContentView, {
                 data: data,
                 fullObject: this.fullObject
               }));
             }))
           .end()
           .start()
-            .addClass(this.myClass('caret'))
+            .addClass(this.myClass('chevron'))
           .end()
         .end()
         .start()
@@ -163,7 +163,7 @@ foam.CLASS({
 
   classes: [
     {
-      name: 'DefaultButtonView',
+      name: 'DefaultButtonContentView',
       extends: 'foam.u2.Element',
 
       imports: [
@@ -172,7 +172,7 @@ foam.CLASS({
 
       messages: [
         {
-          name: 'DEFAULT_BUTTON_LABEL',
+          name: 'CHOOSE_FROM',
           message: 'Choose from '
         }
       ],
@@ -185,8 +185,8 @@ foam.CLASS({
 
       methods: [
         function initE() {
-          return this
-            .add(this.data || this.DEFAULT_BUTTON_LABEL + this.of.model_.plural.toLowerCase());
+          var plural = this.of.model_.plural.toLowerCase();
+          return this.add(this.data || this.CHOOSE_FROM + plural);
         }
       ]
     }

--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -96,7 +96,9 @@ foam.CLASS({
         Set this to override the default view used for each row. It will be
         instantiated with an object from the DAO as the 'data' property.
       `,
-      value: { class: 'foam.u2.CitationView' },
+      factory: function() {
+        return this.DefaultRowView;
+      }
     },
     {
       name: 'data',
@@ -223,6 +225,43 @@ foam.CLASS({
   ],
 
   classes: [
+    {
+      name: 'DefaultRowView',
+      extends: 'foam.u2.View',
+
+      documentation: `
+        This is the view that gets rendered for each item in the list.
+      `,
+
+      css: `
+        ^row {
+          background: white;
+          padding: 8px 16px;
+        }
+
+        ^row:hover {
+          background: #f4f4f9;
+          cursor: pointer;
+        }
+      `,
+
+      properties: [
+        {
+          name: 'data',
+          documentation: 'The selected object.'
+        }
+      ],
+
+      methods: [
+        function initE() {
+          return this
+            .start()
+              .addClass(this.myClass('row'))
+              .add(this.data.id)
+            .end();
+        }
+      ]
+    },
     {
       name: 'DefaultButtonContentView',
       extends: 'foam.u2.Element',

--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -166,6 +166,19 @@ foam.CLASS({
       name: 'DefaultButtonContentView',
       extends: 'foam.u2.Element',
 
+      documentation: `
+        This is the view that gets rendered inside the button. It is put to the
+        left of the chevron (the triangle at the far right side of the button).
+        This is an Element instead of a simple string, meaning the button can
+        contain "rich" content like images and make use of CSS for styling and
+        layout.
+        As an example of why this is useful, imagine you wanted to show a
+        dropdown to select a country. You could choose to display the flag of
+        the selected country alongside its name after the user makes a
+        selection by creating that custom view and providing it in place of this
+        one by setting the buttonContentView property on RichChoiceView.
+      `,
+
       imports: [
         'of'
       ],
@@ -179,7 +192,17 @@ foam.CLASS({
 
       properties: [
         {
-          name: 'data'
+          name: 'data',
+          documentation: 'The id of the selected object.'
+        },
+        {
+          name: 'fullObject',
+          documentation: `
+            The full object. It's not used here in the default button view, but
+            this property is included to let you know that if you create a
+            custom button content view, it will be passed the id of the object
+            (data) as well as the full object.
+          `
         }
       ],
 


### PR DESCRIPTION
Adds a choice view that lets you specify views for item rows and button content, enabling us to make dropdowns with rich content.

* The dropdown is on top of the content. It doesn't push other things in the page down.
* There can be multiple sections
* The dropdown is fixed height and scrollable

## Default views

### No selection

<img width="712" alt="screen shot 2018-11-07 at 12 24 08 pm" src="https://user-images.githubusercontent.com/4259165/48148626-3bb5cd00-e288-11e8-98e8-fc468fb235fb.png">

### Dropdown open

<img width="714" alt="screen shot 2018-11-07 at 12 24 23 pm" src="https://user-images.githubusercontent.com/4259165/48148625-3bb5cd00-e288-11e8-8695-cfb6e1fb7f2e.png">

### After selection

<img width="711" alt="screen shot 2018-11-07 at 12 25 12 pm" src="https://user-images.githubusercontent.com/4259165/48148620-3b1d3680-e288-11e8-9bba-f1b3b3352328.png">

## Custom views

### No selection

<img width="497" alt="screen shot 2018-11-07 at 12 29 27 pm" src="https://user-images.githubusercontent.com/4259165/48148871-cdbdd580-e288-11e8-9712-03ec91817c32.png">


### Dropdown open

<img width="504" alt="screen shot 2018-11-07 at 12 28 17 pm" src="https://user-images.githubusercontent.com/4259165/48148829-b252ca80-e288-11e8-89ca-5a09e61b8d22.png">

### After selection

<img width="501" alt="screen shot 2018-11-07 at 12 28 26 pm" src="https://user-images.githubusercontent.com/4259165/48148842-b8e14200-e288-11e8-9886-c0181be2b9c8.png">

