### PR TITLE
Refactor Email service interface

### DIFF
--- a/src/foam/nanos/auth/Group.js
+++ b/src/foam/nanos/auth/Group.js
@@ -102,7 +102,22 @@ foam.CLASS({
       class: 'String',
       name: 'url',
       value: null
-    }
+    },
+    {
+      class: 'String',
+      name: 'from',
+      value: null
+    },
+    {
+      class: 'String',
+      name: 'displayName',
+      value: null
+    },
+    {
+      class: 'String',
+      name: 'replyTo',
+      value: null
+    },
 /*    {
       class: 'FObjectProperty',
       of: 'foam.nanos.app.AppConfig',

--- a/src/foam/nanos/auth/email/EmailDocService.js
+++ b/src/foam/nanos/auth/email/EmailDocService.js
@@ -61,7 +61,7 @@ foam.CLASS({
         HashMap<String, Object> args = new HashMap<>();
         args.put("doc", doc.getBody());
       
-        email.sendEmailFromTemplate(user, message, "docEmail", args);
+        email.sendEmailFromTemplate(getX(), user, message, "docEmail", args);
         return true;
       }catch(Throwable t){
         ((Logger) getLogger()).error("Error retrieving Terms and Conditions.", t);

--- a/src/foam/nanos/auth/email/EmailTokenService.js
+++ b/src/foam/nanos/auth/email/EmailTokenService.js
@@ -51,7 +51,7 @@ message.setTo(new String[]{user.getEmail()});
 HashMap<String, Object> args = new HashMap<>();
 args.put("name", user.getFirstName());
 args.put("link", url + "/service/verifyEmail?userId=" + user.getId() + "&token=" + token.getData() + "&redirect=/" );
-email.sendEmailFromTemplate(user, message, "verifyEmail", args);
+email.sendEmailFromTemplate(x, user, message, "verifyEmail", args);
 return true;
 } catch(Throwable t) {
   t.printStackTrace();

--- a/src/foam/nanos/auth/resetPassword/ResetPasswordTokenService.js
+++ b/src/foam/nanos/auth/resetPassword/ResetPasswordTokenService.js
@@ -91,7 +91,7 @@ HashMap<String, Object> args = new HashMap<>();
 args.put("name", String.format("%s %s", user.getFirstName(), user.getLastName()));
 args.put("link", url +"?token=" + token.getData() + "#reset");
 
-email.sendEmailFromTemplate(user, message, "reset-password", args);
+email.sendEmailFromTemplate(x, user, message, "reset-password", args);
 return true;`
     },
     {
@@ -165,7 +165,7 @@ EmailMessage message = new EmailMessage();
 message.setTo(new String[] { userResult.getEmail() });
 HashMap<String, Object> args = new HashMap<>();
 args.put("name", userResult.getFirstName());
-email.sendEmailFromTemplate(userResult, message, "password-changed", args);
+email.sendEmailFromTemplate(x, userResult, message, "password-changed", args);
 return true;`
     }
   ]

--- a/src/foam/nanos/dig/DigWebAgent.java
+++ b/src/foam/nanos/dig/DigWebAgent.java
@@ -387,7 +387,7 @@ public class DigWebAgent
 
       message.setBody(newData);
 
-      emailService.sendEmail(message);
+      emailService.sendEmail(x, message);
     }
   }
 

--- a/src/foam/nanos/notification/SendEmailNotificationDAO.java
+++ b/src/foam/nanos/notification/SendEmailNotificationDAO.java
@@ -62,9 +62,9 @@ public class SendEmailNotificationDAO extends ProxyDAO {
       if ( foam.util.SafetyUtil.isEmpty(notif.getEmailName()) ) {
         message.setSubject(notif.getTemplate());
         message.setBody(notif.getBody());
-        email.sendEmail(message);
+        email.sendEmail(x, message);
       } else {
-        email.sendEmailFromTemplate(user, message, notif.getEmailName(), notif.getEmailArgs());
+        email.sendEmailFromTemplate(x, user, message, notif.getEmailName(), notif.getEmailArgs());
       }
     } catch(Throwable t) {
       System.err.println("Error sending notification email message: "+message+". Error: " + t);

--- a/src/foam/nanos/notification/email/DAOEmailService.js
+++ b/src/foam/nanos/notification/email/DAOEmailService.js
@@ -91,23 +91,11 @@ return config_;`
     {
       name: 'sendEmail',
       javaCode: `
-        getDao().put(emailMessage);
-`
-    },
-    {
-      name: 'sendEmailWithX',
-      javaCode: `
         getDao().put_(x, emailMessage);
 `
     },
     {
       name: 'sendEmailFromTemplate',
-      javaCode: `
-sendEmailFromTemplateWithX(getX(), user,  emailMessage, name, templateArgs);
-`
-    },
-    {
-      name: 'sendEmailFromTemplateWithX',
       javaCode: `
 String group = user != null ? (String) user.getGroup() : null;
 EmailTemplate emailTemplate = DAOResourceLoader.findTemplate(getX(), name, group);
@@ -135,7 +123,7 @@ if (foam.util.SafetyUtil.isEmpty(emailMessage.getSubject())) {
   emailMessage.setSubject(templateSubject.render(model));
 }
 
-sendEmailWithX(x, emailMessage);
+sendEmail(x, emailMessage);
 `
     }
   ]

--- a/src/foam/nanos/notification/email/DAOEmailService.js
+++ b/src/foam/nanos/notification/email/DAOEmailService.js
@@ -91,7 +91,7 @@ return config_;`
     {
       name: 'sendEmail',
       javaCode: `
-        getDao().put_(x, emailMessage);
+        getDao().inX(x).put(emailMessage);
 `
     },
     {

--- a/src/foam/nanos/notification/email/EmailMessage.js
+++ b/src/foam/nanos/notification/email/EmailMessage.js
@@ -52,6 +52,21 @@ foam.CLASS({
       name: 'body'
     },
     {
+      class: 'String',
+      name: 'from',
+      value: null
+    },
+    {
+      class: 'String',
+      name: 'displayName',
+      value: null
+    },
+    {
+      class: 'String',
+      name: 'replyTo',
+      value: null
+    },
+    {
       class: 'Reference',
       of: 'foam.nanos.auth.User',
       name: 'lastModifiedBy',

--- a/src/foam/nanos/notification/email/EmailService.js
+++ b/src/foam/nanos/notification/email/EmailService.js
@@ -23,10 +23,64 @@ foam.INTERFACE({
       ]
     },
     {
+      name: 'sendEmailWithX',
+      javaReturns: 'void',
+      returns: 'Promise',
+      args: [
+        {
+          name: 'x',
+          javaType: 'foam.core.X'
+        },
+        {
+          class: 'FObjectProperty',
+          of: 'foam.nanos.notification.email.EmailMessage',
+          name: 'emailMessage',
+          javaType: 'foam.nanos.notification.email.EmailMessage'
+        }
+      ]
+    },
+    {
       name: 'sendEmailFromTemplate',
       javaReturns: 'void',
       returns: 'Promise',
       args: [
+        {
+          class: 'FObjectProperty',
+          of: 'foam.nanos.auth.User',
+          name: 'user',
+          javaType: 'foam.nanos.auth.User',
+          documentation: 'User sending the email'
+        },
+        {
+          class: 'FObjectProperty',
+          of: 'foam.nanos.notification.email.EmailMessage',
+          name: 'emailMessage',
+          javaType: 'foam.nanos.notification.email.EmailMessage',
+          documentation: 'Email message'
+        },
+        {
+          class: 'String',
+          name: 'name',
+          javaType: 'String',
+          documentation: 'Template name'
+        },
+        {
+          class: 'Map',
+          name: 'templateArgs',
+          javaType: 'java.util.Map<String, Object>',
+          documentation: 'Template arguments'
+        }
+      ]
+    },
+    {
+      name: 'sendEmailFromTemplateWithX',
+      javaReturns: 'void',
+      returns: 'Promise',
+      args: [
+        {
+          name: 'x',
+          javaType: 'foam.core.X'
+        },
         {
           class: 'FObjectProperty',
           of: 'foam.nanos.auth.User',

--- a/src/foam/nanos/notification/email/EmailService.js
+++ b/src/foam/nanos/notification/email/EmailService.js
@@ -15,19 +15,6 @@ foam.INTERFACE({
       returns: 'Promise',
       args: [
         {
-          class: 'FObjectProperty',
-          of: 'foam.nanos.notification.email.EmailMessage',
-          name: 'emailMessage',
-          javaType: 'foam.nanos.notification.email.EmailMessage'
-        }
-      ]
-    },
-    {
-      name: 'sendEmailWithX',
-      javaReturns: 'void',
-      returns: 'Promise',
-      args: [
-        {
           name: 'x',
           javaType: 'foam.core.X'
         },
@@ -41,39 +28,6 @@ foam.INTERFACE({
     },
     {
       name: 'sendEmailFromTemplate',
-      javaReturns: 'void',
-      returns: 'Promise',
-      args: [
-        {
-          class: 'FObjectProperty',
-          of: 'foam.nanos.auth.User',
-          name: 'user',
-          javaType: 'foam.nanos.auth.User',
-          documentation: 'User sending the email'
-        },
-        {
-          class: 'FObjectProperty',
-          of: 'foam.nanos.notification.email.EmailMessage',
-          name: 'emailMessage',
-          javaType: 'foam.nanos.notification.email.EmailMessage',
-          documentation: 'Email message'
-        },
-        {
-          class: 'String',
-          name: 'name',
-          javaType: 'String',
-          documentation: 'Template name'
-        },
-        {
-          class: 'Map',
-          name: 'templateArgs',
-          javaType: 'java.util.Map<String, Object>',
-          documentation: 'Template arguments'
-        }
-      ]
-    },
-    {
-      name: 'sendEmailFromTemplateWithX',
       javaReturns: 'void',
       returns: 'Promise',
       args: [

--- a/src/foam/nanos/notification/email/NullEmailService.js
+++ b/src/foam/nanos/notification/email/NullEmailService.js
@@ -17,7 +17,17 @@ foam.CLASS({
       code: function() { return Promise.resolve(); }
     },
     {
+      name: 'sendEmailWithX',
+      javaCode: '// NOOP',
+      code: function() { return Promise.resolve(); }
+    },
+    {
       name: 'sendEmailFromTemplate',
+      javaCode: '// NOOP',
+      code: function() { return Promise.resolve(); }
+    },
+    {
+      name: 'sendEmailFromTemplateWithX',
       javaCode: '// NOOP',
       code: function() { return Promise.resolve(); }
     }

--- a/src/foam/nanos/notification/email/NullEmailService.js
+++ b/src/foam/nanos/notification/email/NullEmailService.js
@@ -17,17 +17,7 @@ foam.CLASS({
       code: function() { return Promise.resolve(); }
     },
     {
-      name: 'sendEmailWithX',
-      javaCode: '// NOOP',
-      code: function() { return Promise.resolve(); }
-    },
-    {
       name: 'sendEmailFromTemplate',
-      javaCode: '// NOOP',
-      code: function() { return Promise.resolve(); }
-    },
-    {
-      name: 'sendEmailFromTemplateWithX',
       javaCode: '// NOOP',
       code: function() { return Promise.resolve(); }
     }

--- a/src/foam/nanos/notification/email/SMTPEmailMessageDAO.js
+++ b/src/foam/nanos/notification/email/SMTPEmailMessageDAO.js
@@ -16,7 +16,7 @@ foam.CLASS({
         EmailService service = (EmailService) x.get("smtpEmailService");
         if ( service != null ) {
           try {
-            service.sendEmail((EmailMessage) obj);
+            service.sendEmailWithX(x, (EmailMessage) obj);
           } catch (RuntimeException e) {
             e.printStackTrace();
           }

--- a/src/foam/nanos/notification/email/SMTPEmailMessageDAO.js
+++ b/src/foam/nanos/notification/email/SMTPEmailMessageDAO.js
@@ -16,7 +16,7 @@ foam.CLASS({
         EmailService service = (EmailService) x.get("smtpEmailService");
         if ( service != null ) {
           try {
-            service.sendEmailWithX(x, (EmailMessage) obj);
+            service.sendEmail(x, (EmailMessage) obj);
           } catch (RuntimeException e) {
             e.printStackTrace();
           }

--- a/src/foam/nanos/notification/email/SMTPEmailService.js
+++ b/src/foam/nanos/notification/email/SMTPEmailService.js
@@ -231,16 +231,14 @@ return config_;`
       name: 'sendEmail',
       args: [
         {
+          name: 'x',
+          javaType: 'foam.core.X'
+        },
+        {
           name: 'emailMessage',
           javaType: 'final foam.nanos.notification.email.EmailMessage'
         }
       ],
-      javaCode: `
-sendEmailWithX(getX(), emailMessage);
-      `
-    },
-    {
-      name: 'sendEmailWithX',
       javaCode: `
 if ( ! this.getEnabled() ) return;
 
@@ -266,11 +264,6 @@ if ( ! this.getEnabled() ) return;
     },
     {
       name: 'sendEmailFromTemplate',
-      javaCode: `
-sendEmailFromTemplateWithX(getX(), user,  emailMessage, name, templateArgs);`
-    },
-    {
-      name: 'sendEmailFromTemplateWithX',
       javaCode: `
 if ( ! this.getEnabled() ) return;
 
@@ -300,7 +293,7 @@ if (SafetyUtil.isEmpty(emailMessage.getSubject())) {
   emailMessage.setSubject(templateSubject.render(model));
 }
 
-sendEmailWithX(x, emailMessage);`
+sendEmail(x, emailMessage);`
     },
     {
       name: 'start',

--- a/src/foam/nanos/notification/email/SMTPEmailService.js
+++ b/src/foam/nanos/notification/email/SMTPEmailService.js
@@ -332,23 +332,18 @@ DAO groupDAO        = (DAO) x.get("groupDAO");
 
 User user           = (User) userDAO.find(session.getUserId());
 Group group         = (Group) groupDAO.find(user.getGroup());
-AppConfig appConfig = group.getAppConfig(x);
-
-String domain = appConfig.getUrl().contains("ablii") ? "ablii.com" : "nanopay.net";
 
 if ( SafetyUtil.isEmpty(emailMessage.getFrom()) ) {
   emailMessage.setFrom(
     ! SafetyUtil.isEmpty(group.getFrom()) ?
-      group.getFrom() :
-      getFrom().substring(0, getFrom().indexOf("@") + 1) + domain
+      group.getFrom() : getFrom()
   );
 }
 
 if ( SafetyUtil.isEmpty(emailMessage.getReplyTo()) ) {
   emailMessage.setReplyTo(
     ! SafetyUtil.isEmpty(group.getReplyTo()) ?
-      group.getReplyTo() :
-      getFrom().substring(0, getFrom().indexOf("@") + 1) + domain
+      group.getReplyTo() : getReplyTo()
   );
 }
 

--- a/src/foam/nanos/notification/email/SMTPEmailService.js
+++ b/src/foam/nanos/notification/email/SMTPEmailService.js
@@ -36,7 +36,11 @@ foam.CLASS({
     'org.jtwig.environment.EnvironmentConfigurationBuilder',
     'org.jtwig.JtwigModel',
     'org.jtwig.JtwigTemplate',
-    'org.jtwig.resource.loader.TypedResourceLoader'
+    'org.jtwig.resource.loader.TypedResourceLoader',
+    'foam.dao.DAO',
+    'foam.nanos.auth.User',
+    'foam.nanos.auth.Group',
+    'foam.nanos.app.AppConfig'
   ],
 
   axioms: [
@@ -158,12 +162,12 @@ return config_;`
   MimeMessage message = new MimeMessage(session_);
 
   // don't send email if no sender
-  String from = getFrom();
+  String from = emailMessage.getFrom();
   if ( SafetyUtil.isEmpty(from) )
     return null;
 
   // add display name if present
-  String displayName = getDisplayName();
+  String displayName = emailMessage.getDisplayName();
   if ( SafetyUtil.isEmpty(displayName) ) {
     message.setFrom(new InternetAddress(from));
   } else {
@@ -171,7 +175,7 @@ return config_;`
   }
 
   // attach reply to if present
-  String replyTo = getReplyTo();
+  String replyTo = emailMessage.getReplyTo();
   if ( ! SafetyUtil.isEmpty(replyTo) ) {
     message.setReplyTo(InternetAddress.parse(replyTo));
   }
@@ -232,13 +236,19 @@ return config_;`
         }
       ],
       javaCode: `
+sendEmailWithX(getX(), emailMessage);
+      `
+    },
+    {
+      name: 'sendEmailWithX',
+      javaCode: `
 if ( ! this.getEnabled() ) return;
 
-((FixedThreadPool) getThreadPool()).submit(getX(), new ContextAgent() {
+((FixedThreadPool) getThreadPool()).submit(x, new ContextAgent() {
   @Override
   public void execute(X x) {
     try {
-      MimeMessage message = createMimeMessage(emailMessage);
+      MimeMessage message = createMimeMessage(finalizeEmailConfig(x, emailMessage));
       if ( message == null ) {
         return;
       }
@@ -257,6 +267,11 @@ if ( ! this.getEnabled() ) return;
     {
       name: 'sendEmailFromTemplate',
       javaCode: `
+sendEmailFromTemplateWithX(getX(), user,  emailMessage, name, templateArgs);`
+    },
+    {
+      name: 'sendEmailFromTemplateWithX',
+      javaCode: `
 if ( ! this.getEnabled() ) return;
 
 String group = user != null ? (String) user.getGroup() : null;
@@ -273,11 +288,19 @@ for ( String key : templateArgs.keySet() ) {
 }
 
 EnvironmentConfiguration config = getConfig(group);
-JtwigTemplate template = JtwigTemplate.inlineTemplate(emailTemplate.getBody(), config);
 JtwigModel model = JtwigModel.newModel(templateArgs);
-emailMessage.setSubject(emailTemplate.getSubject());
-emailMessage.setBody(template.render(model));
-sendEmail(emailMessage);`
+emailMessage = (EmailMessage) emailMessage.fclone();
+
+JtwigTemplate templateBody =    JtwigTemplate.inlineTemplate(emailTemplate.getBody(), config);
+emailMessage.setBody(templateBody.render(model));
+
+// If subject has already provided, then we don't want to use template subject.
+if (SafetyUtil.isEmpty(emailMessage.getSubject())) {
+  JtwigTemplate templateSubject = JtwigTemplate.inlineTemplate(emailTemplate.getSubject(), config);
+  emailMessage.setSubject(templateSubject.render(model));
+}
+
+sendEmailWithX(x, emailMessage);`
     },
     {
       name: 'start',
@@ -293,6 +316,57 @@ if ( getAuthenticate() ) {
 } else {
   session_ = Session.getInstance(props);
 }`
+    },
+    {
+      name: 'finalizeEmailConfig',
+      javaReturns: 'foam.nanos.notification.email.EmailMessage',
+      args: [
+        {
+          name: 'x',
+          javaType: 'foam.core.X'
+        },
+        {
+          name: 'emailMessage',
+          javaType: 'final foam.nanos.notification.email.EmailMessage'
+        }
+      ],
+      javaCode:
+        `
+foam.nanos.session.Session session = x.get(foam.nanos.session.Session.class);
+
+DAO userDAO         = (DAO) x.get("localUserDAO");
+DAO groupDAO        = (DAO) x.get("groupDAO");
+
+User user           = (User) userDAO.find(session.getUserId());
+Group group         = (Group) groupDAO.find(user.getGroup());
+AppConfig appConfig = group.getAppConfig(x);
+
+String domain = appConfig.getUrl().contains("ablii") ? "ablii.com" : "nanopay.net";
+
+if ( SafetyUtil.isEmpty(emailMessage.getFrom()) ) {
+  emailMessage.setFrom(
+    ! SafetyUtil.isEmpty(group.getFrom()) ?
+      group.getFrom() :
+      getFrom().substring(0, getFrom().indexOf("@") + 1) + domain
+  );
+}
+
+if ( SafetyUtil.isEmpty(emailMessage.getReplyTo()) ) {
+  emailMessage.setReplyTo(
+    ! SafetyUtil.isEmpty(group.getReplyTo()) ?
+      group.getReplyTo() :
+      getFrom().substring(0, getFrom().indexOf("@") + 1) + domain
+  );
+}
+
+if ( SafetyUtil.isEmpty(emailMessage.getDisplayName()) ) {
+  emailMessage.setDisplayName(
+    ! SafetyUtil.isEmpty(group.getDisplayName()) ? group.getDisplayName() : getDisplayName()
+  );
+}
+
+return emailMessage;
+      `
     }
   ]
 });


### PR DESCRIPTION
refs:
[4370](https://github.com/nanoPayinc/NANOPAY/issues/4370)
[4474](https://github.com/nanoPayinc/NANOPAY/issues/4474)

- [x] Refactor the EmailService interface. We need pass the user context into the email service so we can get the correct Domain URL from http request.

- [x] Make **emailFrom**, **emailReplyTo**, **emailDisplayName** fully configurable.
    i.  First, look for those value in the EmailMessage.
    ii.  If nothing found in the EmailMessage, look for the value in the group setting.
    iii. If nothing found in the group setting, use the default value. 

- [x] Make Subject of Email Template configurable
    i. If the subject doesn't provided when we creating the EmailMessage, use the subject in the template.
    ii. You can now use template arguments in both template subject and body.
