### PR TITLE
Forgot password email redirect to wrong URL

### DIFF
--- a/src/foam/nanos/auth/resetPassword/ResetPasswordTokenService.js
+++ b/src/foam/nanos/auth/resetPassword/ResetPasswordTokenService.js
@@ -52,7 +52,7 @@ foam.CLASS({
     {
       name: 'generateTokenWithParameters',
       javaCode:
-`AppConfig appConfig = (AppConfig) getAppConfig();
+`AppConfig appConfig = (AppConfig) x.get("appConfig");
 DAO userDAO = (DAO) getLocalUserDAO();
 DAO tokenDAO = (DAO) getTokenDAO();
 String url = appConfig.getUrl()


### PR DESCRIPTION
refs: [bug 4531](https://github.com/nanoPayinc/NANOPAY/issues/4531)
We have to get the appConfig from the user context