### PR TITLE
Add ability to format chart labels

### DIFF
--- a/src/foam/dashboard/view/Bar.js
+++ b/src/foam/dashboard/view/Bar.js
@@ -24,8 +24,8 @@ foam.CLASS({
   ],
   methods: [
     function initCView(x) {
-      this.SUPER(x);
       this.data$ = this.visualization$.dot('data');
+      this.SUPER(x);
     }
   ]
 });

--- a/src/foam/dashboard/view/Line.js
+++ b/src/foam/dashboard/view/Line.js
@@ -24,8 +24,8 @@ foam.CLASS({
   ],
   methods: [
     function initCView(x) {
-      this.SUPER(x);
       this.data$ = this.visualization$.dot('data');
+      this.SUPER(x);
     }
   ]
 });

--- a/src/foam/dashboard/view/Pie.js
+++ b/src/foam/dashboard/view/Pie.js
@@ -24,8 +24,8 @@ foam.CLASS({
   ],
   methods: [
     function initCView(x) {
-      this.SUPER(x);
       this.data$ = this.visualization$.dot('data');
+      this.SUPER(x);
     }
   ]
 });

--- a/src/foam/u2/view/TableCellFormatter.js
+++ b/src/foam/u2/view/TableCellFormatter.js
@@ -121,12 +121,22 @@ foam.CLASS({
 
   properties: [
     {
+      documentation: `
+        A method that can be called to format a value for display purposes.
+        // TODO: Only works for $. How would this work for other currencies?
+      `,
+      name: 'displayFormatter',
+      value: function(value) {
+        return '$' + (value/100).toFixed(2).replace(/(\d)(?=(\d{3})+\.)/g, '$1,')
+      },
+    },
+    {
       class: 'foam.u2.view.TableCellFormatter',
       name: 'tableCellFormatter',
-      value: function(value) {
+      value: function(value, _, prop) {
         this.start()
           .style({'text-align': 'left', 'padding-right': '20px'})
-          .add('$' + (value/100).toFixed(2).replace(/(\d)(?=(\d{3})+\.)/g, '$1,'))
+          .add(prop.displayFormatter(value))
         .end();
       }
     }

--- a/src/foam/u2/view/TableCellFormatter.js
+++ b/src/foam/u2/view/TableCellFormatter.js
@@ -121,22 +121,12 @@ foam.CLASS({
 
   properties: [
     {
-      documentation: `
-        A method that can be called to format a value for display purposes.
-        // TODO: Only works for $. How would this work for other currencies?
-      `,
-      name: 'displayFormatter',
-      value: function(value) {
-        return '$' + (value/100).toFixed(2).replace(/(\d)(?=(\d{3})+\.)/g, '$1,')
-      },
-    },
-    {
       class: 'foam.u2.view.TableCellFormatter',
       name: 'tableCellFormatter',
-      value: function(value, _, prop) {
+      value: function(value) {
         this.start()
           .style({'text-align': 'left', 'padding-right': '20px'})
-          .add(prop.displayFormatter(value))
+          .add('$' + (value/100).toFixed(2).replace(/(\d)(?=(\d{3})+\.)/g, '$1,'))
         .end();
       }
     }

--- a/src/org/chartjs/AbstractChartCView.js
+++ b/src/org/chartjs/AbstractChartCView.js
@@ -9,16 +9,6 @@ foam.CLASS({
 });
 
 foam.CLASS({
-  refines: 'foam.core.Currency',
-  properties: [
-    {
-      name: 'chartJsFormatter',
-      value: function(v) { return this.displayFormatter(v) },
-    },
-  ]
-});
-
-foam.CLASS({
   refines: 'foam.mlang.sink.Sum',
   properties: [
     {

--- a/src/org/chartjs/AbstractChartCView.js
+++ b/src/org/chartjs/AbstractChartCView.js
@@ -1,4 +1,52 @@
 foam.CLASS({
+  refines: 'foam.core.Property',
+  properties: [
+    {
+      name: 'chartJsFormatter',
+      value: function(v) { return v },
+    },
+  ]
+});
+
+foam.CLASS({
+  refines: 'foam.core.Currency',
+  properties: [
+    {
+      name: 'chartJsFormatter',
+      value: function(v) { return this.displayFormatter(v) },
+    },
+  ]
+});
+
+foam.CLASS({
+  refines: 'foam.mlang.sink.Sum',
+  properties: [
+    {
+      name: 'chartJsFormatter',
+      value: function(v) { return this.arg1.chartJsFormatter(v) },
+    },
+  ]
+});
+
+foam.CLASS({
+  refines: 'foam.core.Date',
+  properties: [
+    {
+      name: 'chartJsFormatter',
+      value: function(d) {
+        if ( ! foam.Date.isInstance(d) ) { d = new Date(d) }
+        var month = d.getMonth() + 1
+        if ( month < 10 ) month = '0' + month
+        var day = d.getDate()
+        if ( day < 10 ) day = '0' + day
+        var year = d.getFullYear()
+        return `${year}-${month}-${day}`;
+      }
+    }
+  ]
+});
+
+foam.CLASS({
   package: 'org.chartjs',
   name: 'AbstractChartCView',
   extends: 'foam.graphics.CView',
@@ -15,6 +63,48 @@ foam.CLASS({
     'colors',
     'data',
     {
+      name: 'xFormatter',
+      expression: function(propertyFormatters_) {
+        return propertyFormatters_[propertyFormatters_.length - 2]
+      },
+    },
+    {
+      name: 'yFormatter',
+      expression: function(propertyFormatters_) {
+        return propertyFormatters_[propertyFormatters_.length - 1]
+      },
+    },
+    {
+      name: 'tooltipLabelFormatter',
+      value: function(tooltipItem, data) {
+        var yLabel = data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index]
+        if ( foam.Object.isInstance(yLabel) ) yLabel = yLabel.y
+        return data.datasets[tooltipItem.datasetIndex].label +
+          ': ' + this.yFormatter(yLabel)
+      }
+    },
+    {
+      name: 'tooltipTitleFormatter',
+      value: function(tooltipItem, data) {
+        return tooltipItem[0].xLabel;
+      }
+    },
+    {
+      name: 'propertyFormatters_',
+      expression: function(data) {
+        var getData = function(data) {
+          if ( this.GroupBy.isInstance(data) || this.Plot.isInstance(data) ) {
+            return getData(data.arg1).concat(getData(data.arg2));
+          } else if ( data.chartJsFormatter ) {
+            return [data.chartJsFormatter.bind(data)]
+          } else {
+            return [function(v) { return v }];
+          }
+        }.bind(this);
+        return getData(data)
+      },
+    },
+    {
       name: 'config',
       factory: function() {
         return {
@@ -22,7 +112,29 @@ foam.CLASS({
           datasets: [{}],
           options: {
             responsive: false,
-            maintainAspectRatio: false
+            maintainAspectRatio: false,
+            tooltips: {
+              callbacks: {
+                title: this.tooltipTitleFormatter.bind(this),
+                label: this.tooltipLabelFormatter.bind(this),
+              }
+            },
+            scales: {
+              yAxes: [
+                {
+                  ticks: {
+                    callback: this.yFormatter.bind(this),
+                  },
+                }
+              ],
+              xAxes: [
+                {
+                  ticks: {
+                    callback: this.xFormatter.bind(this),
+                  },
+                }
+              ]
+            }
           }
         };
       }

--- a/src/org/chartjs/Pie.js
+++ b/src/org/chartjs/Pie.js
@@ -8,7 +8,7 @@ foam.CLASS({
       name: 'tooltipLabelFormatter',
       value: function(tooltipItem, data) {
         return data.labels[tooltipItem.index] +
-          ': ' + data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index]
+          ': ' + this.yFormatter(data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index]);
       }
     },
     {

--- a/src/org/chartjs/Pie.js
+++ b/src/org/chartjs/Pie.js
@@ -5,32 +5,24 @@ foam.CLASS({
   properties: [
     [ 'chartType', 'pie' ],
     {
-      name: 'config',
-      factory: function() {
-        return {
-          type: this.chartType,
-          datasets: [{}],
-          options: {
-            responsive: false,
-            maintainAspectRatio: false,
-            tooltips: {
-              callbacks: {
-                title: function(tooltipItem, data) {
-                  tooltipItem = tooltipItem[0];
-                  return data.datasets[tooltipItem.datasetIndex].label;
-                },
-                label: function(tooltipItem, data) {
-                  return data.labels[tooltipItem.index] +
-                    ': ' + data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index]
-                },
-              }
-            }
-          }
-        }
+      name: 'tooltipLabelFormatter',
+      value: function(tooltipItem, data) {
+        return data.labels[tooltipItem.index] +
+          ': ' + data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index]
+      }
+    },
+    {
+      name: 'tooltipTitleFormatter',
+      value: function(tooltipItem, data) {
+        tooltipItem = tooltipItem[0];
+        return data.datasets[tooltipItem.datasetIndex].label;
       }
     },
   ],
   methods: [
+    function configChart_(chart) {
+      delete chart.options.scales;
+    },
     function genChartData_(data) {
       var chartData = this.toChartData(data);
       chartData.datasets.forEach(function(d, i) {

--- a/src/org/chartjs/demos/Stock.js
+++ b/src/org/chartjs/demos/Stock.js
@@ -161,9 +161,21 @@ foam.CLASS({
       properties: [
         { name: 'id' },
         { class: 'String', name: 'symbol' },
-        { class: 'String', name: 'person' },
+        {
+          class: 'String',
+          name: 'person',
+          chartJsFormatter: function(v) {
+            return v + '!'
+          },
+        },
         { class: 'Currency', name: 'pricePerShare' },
-        { class: 'Int', name: 'shares' },
+        {
+          class: 'Int',
+          name: 'shares',
+          chartJsFormatter: function(v) {
+            return v + ' shares'
+          },
+        },
       ]
     },
   ],


### PR DESCRIPTION
Not too sure about the change to src/foam/u2/view/TableCellFormatter.js and wouldn't mind a fresh set of eyes on the formatting bit.

chartjs makes you format using a callback and so I'm setting the callback based on the sink given to the chart. propertyFormatters_ is constructed by digging into the sink and figuring out which expressions should be used for each value being displayed. These will typically wind down to a property's chartJsFormatter which is something being newly refined on properties. So a user can customize this stuff in one of two ways: setting the chartJsFormatter on the property that's being used in the sink, or by specifying xFormatter/yFormatter on the chart view itself.