### PR TITLE
Replace test for session context with userId

### DIFF
--- a/src/foam/nanos/http/AuthWebAgent.java
+++ b/src/foam/nanos/http/AuthWebAgent.java
@@ -201,7 +201,7 @@ public class AuthWebAgent
     AuthService auth    = (AuthService) x.get("auth");
     Session     session = authenticate(x);
 
-    if ( session != null && session.getContext() != null ) {
+    if ( session != null && session.getUserId() != 0 ) {
       if ( auth.check(session.getContext(), permission_) ) {
         getDelegate().execute(x.put(Session.class, session).put("user", session.getContext().get("user")));
       } else {


### PR DESCRIPTION
Recent changes set the context on the session generated during the authentication process.
Previoulsy the test for a null context was a flag to generate the login.  Now test for zero userId, as the user will not be set until after a successful login.