### PR TITLE
Add editColumnsEnabled to ScrollTableView interface

### DIFF
--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -48,7 +48,15 @@
       class: 'Int',
       name: 'daoCount'
     },
-    'selection'
+    'selection',
+    {
+      class: 'Boolean',
+      name: 'editColumnsEnabled',
+      documentation: `
+        Set to true if users should be allowed to choose which columns to use.
+      `,
+      value: true
+    }
   ],
 
   methods: [
@@ -68,7 +76,8 @@
               data$: this.scrolledDAO$,
               columns: this.columns,
               contextMenuActions: this.contextMenuActions,
-              selection$: this.selection$
+              selection$: this.selection$,
+              editColumnsEnabled: this.editColumnsEnabled
             }).
             end().
           end().


### PR DESCRIPTION
TableView lets you set this property, but ScrollTableView didn't have this property, which meant you couldn't enable or disable it from a DAO controller.