### PR TITLE
Don't show configure button if not served

### DIFF
--- a/src/foam/nanos/boot/NSpec.js
+++ b/src/foam/nanos/boot/NSpec.js
@@ -198,8 +198,8 @@ foam.CLASS({
       // for now, but should get the config object from the NSpec itself
       // to be extensible.
       name: 'configure',
-      isAvailable: function(boxClass) {
-        return ! boxClass;
+      isAvailable: function(boxClass, serve) {
+        return serve && ! boxClass;
 //        return foam.dao.DAO.isInstance(this.__context__[this.name]);
       },
       code: function() {


### PR DESCRIPTION
Please correct me if I'm wrong, but it seems like it it doesn't make sense to show the "configure" button in the DAO controller for DAO's that aren't served because you can't access them on the client anyway.