### PR TITLE
Add search to RichChoiceView

### DIFF
--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -36,6 +36,10 @@ foam.CLASS({
       }
   `,
 
+  implements: [
+    'foam.mlang.Expressions'
+  ],
+
   exports: [
     'of'
   ],
@@ -88,6 +92,15 @@ foam.CLASS({
 
     ^custom-selection-view {
       flex-grow: 1;
+    }
+
+    ^ .search input {
+      width: 100%;
+      border: none;
+    }
+
+    ^ .search input:focus {
+      border: none;
     }
   `,
 
@@ -156,6 +169,25 @@ foam.CLASS({
         The full object from the DAO. This property is only used internally, you
         do not need to set it as a consumer of this view.
       `
+    },
+    {
+      class: 'Boolean',
+      name: 'search',
+      documentation: 'Set to true to enable searching.'
+    },
+    {
+      class: 'String',
+      name: 'filter_',
+      documentation: 'The text that the user typed in to search by.',
+      postSet: function(oldValue, newValue) {
+        this.sections = this.sections.map((section) => {
+          return Object.assign({}, section, {
+            filtered: newValue
+              ? section.dao.where(this.KEYWORD(newValue))
+              : section.dao
+          });
+        });
+      }
     }
   ],
 
@@ -202,26 +234,41 @@ foam.CLASS({
         .start()
           .addClass(this.myClass('container'))
           .show(self.isOpen_$)
-          .forEach(this.sections, function(section) {
-            var dao = section.dao;
-            this
+          .add(self.search$.map((searchEnabled) => {
+            if ( ! searchEnabled ) return null;
+            return this.E()
               .start()
-                .addClass(self.myClass('heading'))
-                .add(section.heading)
-              .end()
-              .start()
-                .select(dao, function(obj) {
-                  return this.E()
-                    .start(self.rowView, { data: obj })
-                      .on('click', () => {
-                        self.fullObject_ = obj;
-                        self.data = obj;
-                        self.isOpen_ = false;
-                      })
-                    .end();
-                })
+                .startContext({ data: self })
+                  .addClass('search')
+                  .add(self.FILTER_.clone().copyFrom({ view: {
+                    class: 'foam.u2.view.TextField',
+                    placeholder: 'Search...',
+                    onKey: true
+                  } }))
+                .endContext()
               .end();
-          })
+          }))
+          .add(this.slot(function(sections) {
+            return this.E().forEach(sections, function(section) {
+              this
+                .start()
+                  .addClass(self.myClass('heading'))
+                  .add(section.heading)
+                .end()
+                .start()
+                  .select(section.filtered || section.dao, function(obj) {
+                    return this.E()
+                      .start(self.rowView, { data: obj })
+                        .on('click', () => {
+                          self.fullObject_ = obj;
+                          self.data = obj;
+                          self.isOpen_ = false;
+                        })
+                      .end();
+                  })
+                .end();
+            });
+          }))
         .end();
     }
   ],


### PR DESCRIPTION
It can be enabled by setting the `search` property to true.

It filters the sections in the dropdown body as you type. The search input is part of the body of the dropdown.

### No text in search field
<img width="472" alt="screen shot 2018-12-04 at 12 50 34 pm" src="https://user-images.githubusercontent.com/4259165/49462111-426e2c00-f7c3-11e8-8f08-4b46ec933c9c.png">

### Some text in search field
<img width="473" alt="screen shot 2018-12-04 at 12 50 46 pm" src="https://user-images.githubusercontent.com/4259165/49462110-426e2c00-f7c3-11e8-8c4d-68d40b297d0b.png">
