### PR TITLE
Replace Authenticator generated Account name from AppConfig.name to S…

### DIFF
--- a/src/foam/nanos/auth/twofactor/GoogleTOTPAuthService.js
+++ b/src/foam/nanos/auth/twofactor/GoogleTOTPAuthService.js
@@ -70,7 +70,7 @@ foam.CLASS({
         try {
           AppConfig config = (AppConfig) x.get("appConfig");
           SMTPEmailService service = (SMTPEmailService) x.get("smtpEmailService");
-          String name = service == null ? "nanopay Corporation" : service.getDisplayName();
+          String name = service == null ? "FOAM" : service.getDisplayName();
           String path = String.format("/%s:%s", name, user.getEmail());
           String query = String.format("secret=%s&issuer=%s&algorithm=%s", key, name, getAlgorithm());
           URI uri = new URI("otpauth", "totp", path, query, null);

--- a/src/foam/nanos/auth/twofactor/GoogleTOTPAuthService.js
+++ b/src/foam/nanos/auth/twofactor/GoogleTOTPAuthService.js
@@ -14,6 +14,7 @@ foam.CLASS({
     'foam.dao.DAO',
     'foam.nanos.app.AppConfig',
     'foam.nanos.auth.User',
+    'foam.nanos.notification.email.SMTPEmailService',
     'foam.nanos.session.Session',
     'foam.util.SafetyUtil',
     'io.nayuki.qrcodegen.QrCode',
@@ -68,8 +69,10 @@ foam.CLASS({
 
         try {
           AppConfig config = (AppConfig) x.get("appConfig");
-          String path = String.format("/%s:%s", config.getName(), user.getEmail());
-          String query = String.format("secret=%s&issuer=%s&algorithm=%s", key, config.getName(), getAlgorithm());
+          SMTPEmailService service = (SMTPEmailService) x.get("smtpEmailService");
+          String name = service == null ? "nanopay Corporation" : service.getDisplayName();
+          String path = String.format("/%s:%s", name, user.getEmail());
+          String query = String.format("secret=%s&issuer=%s&algorithm=%s", key, name, getAlgorithm());
           URI uri = new URI("otpauth", "totp", path, query, null);
           return "data:image/svg+xml;charset=UTF-8," + QrCode.encodeText(uri.toASCIIString(), QrCode.Ecc.MEDIUM).toSvgString(0);
         } catch ( Throwable t ) {


### PR DESCRIPTION
…MTPEmailService.displayName

Issue: [5286](https://github.com/nanoPayinc/NANOPAY/issues/5286)

The AppConfig.name is not suitable for this use as it is one: development, branch_anme, test, staging, demo, prod
While the SMTPEmailService.displayName is 'nanopay Corporation' (default), and 'Ablii' for ablii groups and when logged in under the ablii url.

NP-5286 #time 30m