### PR TITLE
Output caught exceptions as 'FAILURE' so they are visible in test out…

### DIFF
--- a/src/foam/nanos/test/Test.js
+++ b/src/foam/nanos/test/Test.js
@@ -171,7 +171,7 @@ foam.CLASS({
           runTest(x);
         } catch (Throwable e) {
           setFailed(getFailed()+1);
-          ps.println();
+          ps.println("FAILURE: "+e.getMessage());
           e.printStackTrace(ps);
           e.printStackTrace();
         } finally {


### PR DESCRIPTION
…put.

Otherwise the test may report x failures, but none are visible in red in the output.