### PR TITLE
Fix ScrollTableView onWheel

### DIFF
--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -135,8 +135,9 @@
         var negative = e.deltaY < 0;
         // Convert to rows, rounding up. (Therefore minumum 1.)
         var rows = Math.ceil(Math.abs(e.deltaY) / 40);
+        var oldSkip = this.skip;
         this.skip = Math.max(0, this.skip + (negative ? -rows : rows));
-        if ( e.deltaY !== 0 ) e.preventDefault();
+        if ( e.deltaY !== 0 && oldSkip != this.skip ) e.preventDefault();
       }
     },
     {


### PR DESCRIPTION
Address: https://github.com/nanoPayinc/NANOPAY/issues/5370

We can use skip change as an indicator for data change in ScrollTableView and if skip change is not detected we don't prevent default mouse wheel event.