### PR TITLE
Adjust ScrollTableView height on window resize

### DIFF
--- a/src/foam/comics/DAOControllerView.js
+++ b/src/foam/comics/DAOControllerView.js
@@ -111,7 +111,8 @@ foam.CLASS({
       name: 'summaryView',
       factory: function() {
         return this.data.summaryView || this.importedSummaryView || {
-          class: 'foam.u2.view.ScrollTableView'
+          class: 'foam.u2.view.ScrollTableView',
+          fitInScreen: true
         };
       }
     },

--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -124,7 +124,13 @@
         end().
       end();
 
-      if ( this.fitInScreen ) this.onload.sub(this.updateTableHeight);
+      if ( this.fitInScreen ) {
+        this.onload.sub(this.updateTableHeight);
+        window.addEventListener('resize', this.updateTableHeight);
+        this.onDetach(() => {
+          window.removeEventListener('resize', this.updateTableHeight);
+        });
+      }
     }
   ],
 

--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -69,7 +69,7 @@
       class: 'Int',
       name: 'rowHeight',
       documentation: 'The height of one row of the table in px.',
-      value: 40
+      value: 48
     },
     {
       class: 'Boolean',


### PR DESCRIPTION
Closes #1736

* Adjust ScrollTableView height on window resize
* Set `fitInScreen` to true in the DAO controller view
* Update default table height from 40px to 48px
  * This requires a CSS change in the NANOPAY repo to work