### PR TITLE
Fix bug when acting as another user

### DIFF
--- a/src/foam/nanos/auth/UserAndGroupAuthService.java
+++ b/src/foam/nanos/auth/UserAndGroupAuthService.java
@@ -227,8 +227,14 @@ public class UserAndGroupAuthService
       return false;
     }
 
+    // NOTE: It's important that we use the User from the context here instead
+    // of looking it up in a DAO because if the user is actually an entity that
+    // an agent is acting as, then the user we get from the DAO won't have the
+    // correct group, which is be the group set on the junction between the
+    // agent and the entity.
+    User user = (User) x.get("user");
+
     // check if user exists and is enabled
-    User user = (User) userDAO_.find(session.getUserId());
     if ( user == null || ! user.getEnabled() ) {
       return false;
     }

--- a/src/foam/nanos/auth/UserAndGroupAuthService.java
+++ b/src/foam/nanos/auth/UserAndGroupAuthService.java
@@ -230,8 +230,8 @@ public class UserAndGroupAuthService
     // NOTE: It's important that we use the User from the context here instead
     // of looking it up in a DAO because if the user is actually an entity that
     // an agent is acting as, then the user we get from the DAO won't have the
-    // correct group, which is be the group set on the junction between the
-    // agent and the entity.
+    // correct group, which is the group set on the junction between the agent
+    // and the entity.
     User user = (User) x.get("user");
 
     // check if user exists and is enabled


### PR DESCRIPTION
When acting as another user, the user in the context is updated such
that the group is set to the group on the junction between the agent and
the entity. In the checkPermission method in the auth service, we were
looking up the user in the DAO and checking the group of the looked up
user, but that lead to the wrong group being checked. When an agent is
acting as an entity, we want to use the group that was set for the
agent's relationship with the entity, not the agent's usual group.