### PR TITLE
DO_NOT_MERGE  Remove password validation reset password token

### DIFF
--- a/src/foam/nanos/auth/resetPassword/EmailView.js
+++ b/src/foam/nanos/auth/resetPassword/EmailView.js
@@ -22,7 +22,7 @@ foam.CLASS({
     'foam.u2.dialog.NotificationMessage'
   ],
 
-  css:`
+  css: `
     ^{
       width: 490px;
       margin: auto;
@@ -144,7 +144,7 @@ foam.CLASS({
   ],
 
   methods: [
-    function initE(){
+    function initE() {
     this.SUPER();
     var self = this;
 
@@ -154,7 +154,7 @@ foam.CLASS({
         .start().addClass('Forgot-Password').add('Forgot Password').end()
         .start().addClass('Message-Container')
         .start().addClass('Instructions-Text').add(this.Instructions).end()
-        .start().addClass('Email-Text').add("Email Address").end()
+        .start().addClass('Email-Text').add('Email Address').end()
         .start(this.EMAIL).addClass('full-width-input').end()
         .start(this.NEXT).addClass('Next-Button').end()
         .start('p').add('Remember your password?').end()
@@ -171,16 +171,16 @@ foam.CLASS({
   actions: [
     {
       name: 'next',
-      code: function (X) {
+      code: function(X) {
         var self = this;
         var user = this.User.create({ email: this.email });
-        this.resetPasswordToken.generateToken(null, user).then(function (result) {
+        this.resetPasswordToken.generateToken(null, user).then( function(result) {
           if ( ! result ) {
             throw new Error('Error generating reset token');
           }
-          self.stack.push(self.ResendView.create({ email: self.email }));;
+          self.stack.push(self.ResendView.create({ email: self.email }));
         })
-        .catch(function (err) {
+        .catch( function(err) {
           self.add(self.NotificationMessage.create({ message: err.message, type: 'error' }));
         });
       }

--- a/src/foam/nanos/auth/resetPassword/ResendView.js
+++ b/src/foam/nanos/auth/resetPassword/ResendView.js
@@ -22,7 +22,7 @@ foam.CLASS({
     'foam.u2.dialog.NotificationMessage'
   ],
 
-  css:`
+  css: `
     ^{
       width: 490px;
       margin: auto;
@@ -92,11 +92,11 @@ foam.CLASS({
   ],
 
   messages: [
-    { name: 'Instructions', message: "We've sent the instructions to your email. Please check your inbox to continue."}
+    { name: 'Instructions', message: 'We\'ve sent the instructions to your email. Please check your inbox to continue.'}
   ],
 
   methods: [
-    function initE(){
+    function initE() {
       this.SUPER();
       var self = this;
 
@@ -112,8 +112,8 @@ foam.CLASS({
           .start('p').addClass('link')
             .add('Sign in.')
             .on('click', function() {self.stack.push({ class: 'foam.nanos.auth.SignInView' })})
-        .end()       
-      .end()
+        .end()
+      .end();
 
       this.add(self.NotificationMessage.create({ message: 'Password reset instructions sent to ' + self.email }));
     }
@@ -123,14 +123,14 @@ foam.CLASS({
     {
       name: 'resendEmail',
       label: 'Resend Email',
-      code: function (X) {
+      code: function(X) {
         var self = this;
 
         var user = this.User.create({ email: this.email });
-        this.resetPasswordToken.generateToken(null, user).then(function (result) {
+        this.resetPasswordToken.generateToken(null, user).then( function(result) {
           self.add(self.NotificationMessage.create({ message: 'Password reset instructions sent to ' + self.email }));
         })
-        .catch(function (err) {
+        .catch( function(err) {
           self.add(self.NotificationMessage.create({ message: err.message, type: 'error' }));
         });
       }

--- a/src/foam/nanos/auth/resetPassword/ResetPasswordTokenService.js
+++ b/src/foam/nanos/auth/resetPassword/ResetPasswordTokenService.js
@@ -103,23 +103,6 @@ return true;`
 
 String newPassword = user.getDesiredPassword();
 
-int length = newPassword.length();
-if ( length < 7 || length > 32 ) {
-  throw new RuntimeException("Password must be 7-32 characters long");
-}
-
-if ( newPassword.equals(newPassword.toLowerCase()) ) {
-  throw new RuntimeException("Password must have one capital letter");
-}
-
-if ( ! newPassword.matches(".*\\\\d+.*") ) {
-  throw new RuntimeException("Password must have one numeric character");
-}
-
-if ( p.matcher(newPassword).matches() ) {
-  throw new RuntimeException("Password must not contain: !@#$%^&*()_+");
-}
-
 DAO userDAO = (DAO) getLocalUserDAO();
 DAO tokenDAO = (DAO) getTokenDAO();
 Calendar calendar = Calendar.getInstance();

--- a/src/foam/nanos/auth/resetPassword/ResetPasswordTokenService.js
+++ b/src/foam/nanos/auth/resetPassword/ResetPasswordTokenService.js
@@ -40,10 +40,10 @@ foam.CLASS({
   axioms: [
     {
       name: 'javaExtras',
-      buildJavaClass: function (cls) {
+      buildJavaClass: function(cls) {
         cls.extras.push(foam.java.Code.create({
           data: 'java.util.regex.Pattern p = java.util.regex.Pattern.compile("[^a-zA-Z0-9]");'
-        }))
+        }));
       }
     }
   ],

--- a/src/foam/nanos/auth/resetPassword/ResetView.js
+++ b/src/foam/nanos/auth/resetPassword/ResetView.js
@@ -21,7 +21,7 @@ foam.CLASS({
     'foam.u2.dialog.NotificationMessage'
   ],
 
-  css:`
+  css: `
     ^{
       width: 490px;
       margin: auto;
@@ -135,11 +135,11 @@ foam.CLASS({
     {
       class: 'String',
       name: 'token',
-      factory: function () {
+      factory: function() {
         var search = /([^&=]+)=?([^&]*)/g;
         var query  = window.location.search.substring(1);
 
-        var decode = function (s) {
+        var decode = function(s) {
           return decodeURIComponent(s.replace(/\+/g, ' '));
         };
 
@@ -166,27 +166,27 @@ foam.CLASS({
   ],
 
   methods: [
-    function initE(){
+    function initE() {
     this.SUPER();
     var self = this;
 
     this
       .addClass(this.myClass())
       .start()
-        .start().addClass('Reset-Password').add("Reset Password").end()
+        .start().addClass('Reset-Password').add('Reset Password').end()
         .start().addClass('Message-Container')
-          .start().addClass('newPassword-Text').add("New Password").end()
+          .start().addClass('newPassword-Text').add('New Password').end()
           .add(this.NEW_PASSWORD)
-          .start().addClass('confirmPassword-Text').add("Confirm Password").end()
+          .start().addClass('confirmPassword-Text').add('Confirm Password').end()
           .add(this.CONFIRM_PASSWORD)
           .start('div')
             .start(this.CONFIRM).addClass('resetButton').end()
           .end()
         .end()
-        .start('p').add("Remember your password?").end()
+        .start('p').add('Remember your password?').end()
         .start('p').addClass('link')
           .add('Sign in.')
-          .on('click', function(){ window.location.href = '#'; self.stack.push({ class: 'foam.nanos.auth.SignInView' })})
+          .on('click', function() { window.location.href = '#'; self.stack.push({ class: 'foam.nanos.auth.SignInView' })})
       .end()
     .end()
     }
@@ -195,7 +195,7 @@ foam.CLASS({
   actions: [
     {
       name: 'confirm',
-      code: function (X, obj) {
+      code: function(X, obj) {
         var self = this;
         // check if new password entered
         if ( ! this.newPassword ) {
@@ -239,9 +239,9 @@ foam.CLASS({
           desiredPassword: this.newPassword
         });
 
-        this.resetPasswordToken.processToken(null, user, this.token).then(function (result) {
+        this.resetPasswordToken.processToken(null, user, this.token).then( function(result) {
           self.stack.push({ class: 'foam.nanos.auth.resetPassword.SuccessView' });
-        }).catch(function (err) {
+        }).catch( function(err) {
           self.add(self.NotificationMessage.create({ message: err.message, type: 'error' }));
         });
       }

--- a/src/foam/nanos/auth/resetPassword/SuccessView.js
+++ b/src/foam/nanos/auth/resetPassword/SuccessView.js
@@ -82,23 +82,23 @@ foam.CLASS({
   `,
 
   messages: [
-    { name: 'Instructions', message: "Successfully reset password!"}
+    { name: 'Instructions', message: 'Successfully reset password!'}
   ],
 
   methods: [
-    function initE(){
+    function initE() {
       this.SUPER();
       var self = this;
 
       this
         .addClass(this.myClass())
         .start()
-          .start().addClass('Reset-Password').add("Reset Password").end()
+          .start().addClass('Reset-Password').add('Reset Password').end()
           .start().addClass('Message-Container')
             .start().addClass('success-Text').add(this.Instructions).end()
             .start().addClass('Back-Button')
-              .add("Back to Sign In")
-              .on('click', function(){
+              .add('Back to Sign In')
+              .on('click', function() {
                 window.location.href = '#';
                 self.stack.push({ class: 'foam.nanos.auth.SignInView' })
               })

--- a/src/foam/util/Password.java
+++ b/src/foam/util/Password.java
@@ -16,8 +16,8 @@ import java.util.regex.Pattern;
 
 public class Password {
 
-  // Min 8 characters, at least one uppercase, one lowercase, one number
-  private static Pattern PASSWORD_PATTERN = Pattern.compile("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[a-zA-Z\\d]{8,}$");
+  // Min 6 characters
+  private static Pattern PASSWORD_PATTERN = Pattern.compile("^.{6,}$");
 
   /**
    * Generates random salt given a size


### PR DESCRIPTION
This PR - 

1) Makes styling changes that don't affect functionality
2) Removes password validation from ResetPasswordTokenService
3) Changes validation on util/password to a min of 6 chars from - 8 characters, at least one uppercase, one lowercase, one number

This is a temporary solution to the problem of password validation happening in many places throughout the system. 
A PR will follow, to add a method to AuthService, called ValidatePassword, which will become singular method called to validate a potential password. Ref issue - https://github.com/foam-framework/foam2/issues/1755