### PR TITLE
Password token service validations

### DIFF
--- a/src/foam/nanos/auth/resetPassword/ResetPasswordTokenService.js
+++ b/src/foam/nanos/auth/resetPassword/ResetPasswordTokenService.js
@@ -103,23 +103,6 @@ return true;`
 
 String newPassword = user.getDesiredPassword();
 
-int length = newPassword.length();
-if ( length < 7 || length > 32 ) {
-  throw new RuntimeException("Password must be 7-32 characters long");
-}
-
-if ( newPassword.equals(newPassword.toLowerCase()) ) {
-  throw new RuntimeException("Password must have one capital letter");
-}
-
-if ( ! newPassword.matches(".*\\\\d+.*") ) {
-  throw new RuntimeException("Password must have one numeric character");
-}
-
-if ( p.matcher(newPassword).matches() ) {
-  throw new RuntimeException("Password must not contain: !@#$%^&*()_+");
-}
-
 DAO userDAO = (DAO) getLocalUserDAO();
 DAO tokenDAO = (DAO) getTokenDAO();
 Calendar calendar = Calendar.getInstance();

--- a/src/foam/util/Password.java
+++ b/src/foam/util/Password.java
@@ -16,8 +16,8 @@ import java.util.regex.Pattern;
 
 public class Password {
 
-  // Min 8 characters, at least one uppercase, one lowercase, one number
-  private static Pattern PASSWORD_PATTERN = Pattern.compile("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[a-zA-Z\\d]{8,}$");
+  // Min 6 characters
+  private static Pattern PASSWORD_PATTERN = Pattern.compile("^.{6,}$");
 
   /**
    * Generates random salt given a size


### PR DESCRIPTION
This PR -

1. Removes password validation from ResetPasswordTokenService
2. Changes validation on util/password to a min of 6 chars from - 8 characters, at least one uppercase, one lowercase, one number

This is a temporary solution to the problem of password validation happening in many places throughout the system.A PR will follow, to add a method to AuthService, called ValidatePassword, which will become singular method called to validate a potential password. Ref issue - #1755