### PR TITLE
DAO controller scrollbar improvements

### DIFF
--- a/src/foam/comics/DAOControllerView.js
+++ b/src/foam/comics/DAOControllerView.js
@@ -42,10 +42,13 @@ foam.CLASS({
     }
 
     ^top-row {
-      display: flex;
-      justify-content: space-between;
       align-items: flex-end;
       margin-bottom: 10px;
+    }
+
+    ^separate {
+      display: flex;
+      justify-content: space-between;
     }
 
     ^title-container > * {
@@ -71,23 +74,8 @@ foam.CLASS({
       margin-bottom: 8px;
     }
 
-    ^ .actions .net-nanopay-ui-ActionView {
-      margin: 0 10px 10px 0;
-    }
-
     ^ .actions button + button {
       margin-left: 8px;
-    }
-
-    ^ .net-nanopay-ui-ActionView {
-      width: 128px;
-      height: 40px;
-      background: #0098db;
-      color: white;
-      border-radius: 4px;
-      box-shadow: 0 1px 0 0 rgba(22, 29, 37, 0.05);
-      font-weight: 500;
-      font-size: 14px;
     }
   `,
 
@@ -151,6 +139,7 @@ foam.CLASS({
           .addClass(this.myClass())
           .start()
             .addClass(this.myClass('top-row'))
+            .addClass(this.myClass('separate'))
             .start()
               .addClass(this.myClass('title-container'))
               .start('h1')
@@ -185,26 +174,32 @@ foam.CLASS({
             .start()
               .style({ 'overflow-x': 'auto' })
               .start()
-                .addClass('actions')
-                .show(self.mode$.map((m) => m === foam.u2.DisplayMode.RW))
+                .addClass(this.myClass('separate'))
+                .callIf(this.data.searchMode === this.SearchMode.SIMPLE, function() {
+                  this
+                    .start()
+                      .add(self.cls.PREDICATE.clone().copyFrom({
+                        view: { class: 'foam.u2.view.SimpleSearch' }
+                      }))
+                    .end();
+                })
                 .start()
-                  .add(self.cls.getAxiomsByClass(foam.core.Action).filter((action) => {
-                    var rtn = true;
-                    if ( ! self.primaryAction ) {
-                      rtn = rtn && action.name !== 'create';
-                    }
-                    if ( self.data.searchMode !== self.SearchMode.FULL ) {
-                      rtn = rtn && action.name !== 'toggleFilters';
-                    }
-                    return rtn;
-                  }))
+                  .addClass('actions')
+                  .show(self.mode$.map((m) => m === foam.u2.DisplayMode.RW))
+                  .start()
+                    .add(self.cls.getAxiomsByClass(foam.core.Action).filter((action) => {
+                      var rtn = true;
+                      if ( ! self.primaryAction ) {
+                        rtn = rtn && action.name !== 'create';
+                      }
+                      if ( self.data.searchMode !== self.SearchMode.FULL ) {
+                        rtn = rtn && action.name !== 'toggleFilters';
+                      }
+                      return rtn;
+                    }))
+                  .end()
                 .end()
               .end()
-              .callIf(this.data.searchMode === this.SearchMode.SIMPLE, function() {
-                this.start().add(self.cls.PREDICATE.clone().copyFrom({
-                  view: { class: 'foam.u2.view.SimpleSearch' }
-                })).end();
-              })
               .start()
                 .style({ 'overflow-x': 'auto' })
                 .tag(this.summaryView, { data$: this.data.filteredDAO$ })

--- a/src/foam/graphics/ScrollCView.js
+++ b/src/foam/graphics/ScrollCView.js
@@ -147,14 +147,14 @@ foam.CLASS({
 
       c.strokeStyle = this.borderColor;
       c.lineWidth = 0.4;
-      c.strokeRect(0, 0, this.width-7, this.height);
+      c.strokeRect(0, 0, this.width, this.height);
 
       c.fillStyle = this.handleColor;
 
       c.fillRect(
         2,
         this.valueToY(this.value),
-        this.width - 11,
+        this.width - 4,
         this.handleSize);
     }
   ],

--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -110,13 +110,15 @@
             }, this.table_$).
             end().
           end().
-          start('td').style({ 'vertical-align': 'top' }).
+          start('td').
+            style({ 'vertical-align': 'top' }).
+            show(this.daoCount$.map((count) => count >= this.limit)).
             add(this.slot(function(limit) {
               return this.ScrollCView.create({
                 value$: this.skip$,
                 extent$: this.limit$,
                 height: this.rowHeight * limit + this.TABLE_HEAD_HEIGHT,
-                width: 18,
+                width: 12,
                 size$: this.daoCount$,
               });
             })).


### PR DESCRIPTION
## Changes

* Show secondary actions in line with the search box in simple search mode to match [the designs](https://app.zeplin.io/project/5bea24519befb87e8387dec8/screen/5bea256aa4a6973f4764d2aa)
* Hide the search bar in ScrollTableView when it's not necessary (ie: when there aren't enough table rows for a scroll bar to be necessary)
  * This fixes a visual issue where the right side of the table doesn't line up with the primary button on the right when there aren't enough rows to show the scroll bar because the scroll bar is still given space on the page even though it isn't being shown
* Fixed the width of the scroll bar itself since it wasn't making full use of the width it was given
  * This had a nice side effect of hiding some "fuzziness" of the scrollbar on the right side
* Removed some CSS that was breaking the layout and the disabled state colour for the actions in the DAO controller view

## Screenshots

Showing the secondary actions inline with the search bar as well as the right alignment fixed
<img width="984" alt="screen shot 2018-12-27 at 5 52 50 pm" src="https://user-images.githubusercontent.com/4259165/50496864-2ac04700-0a01-11e9-8151-732868eddad1.png">

Showing when a scrollbar is visible
<img width="995" alt="screen shot 2018-12-27 at 5 52 37 pm" src="https://user-images.githubusercontent.com/4259165/50496865-2ac04700-0a01-11e9-8a81-86b6b75c9c8a.png">
