### PR TITLE
Authorization bug fixes

### DIFF
--- a/src/foam/dao/AuthorizationSink.java
+++ b/src/foam/dao/AuthorizationSink.java
@@ -16,29 +16,29 @@ public class AuthorizationSink
   extends ProxySink
 {
   public Authorizer authorizer_;
+  public Boolean checkDelete_;
 
   public AuthorizationSink(X x, Authorizer authorizer, Sink delegate) {
+    this(x, authorizer, delegate, false);
+  }
+
+  public AuthorizationSink(X x, Authorizer authorizer, Sink delegate, Boolean checkDelete) {
     super(x, delegate);
     authorizer_ = authorizer;
+    checkDelete_ = checkDelete;
   }
 
   @Override
   public void put(Object obj, Detachable sub) {
     try {
-      authorizer_.authorizeOnRead(getX(), (FObject) obj);
+      if ( checkDelete_ ) {
+        authorizer_.authorizeOnDelete(getX(), (FObject) obj);
+      } else {
+        authorizer_.authorizeOnRead(getX(), (FObject) obj);
+      }
       super.put(obj, sub);
     } catch ( AuthorizationException e ) {
-      // Do not put to sink if not authorized to read this object.
-    }
-  }
-
-  @Override
-  public void remove(Object obj, Detachable sub) {
-    try {
-      authorizer_.authorizeOnDelete(getX(), (FObject) obj);
-      super.remove(obj, sub);
-    } catch ( AuthorizationException e ) {
-      // Do not remove from sink if not authorized to delete this object.
+      // Do not put to sink if not authorized.
     }
   }
 }

--- a/src/foam/nanos/auth/AuthorizationDAO.java
+++ b/src/foam/nanos/auth/AuthorizationDAO.java
@@ -47,7 +47,10 @@ public class AuthorizationDAO extends ProxyDAO {
 
   @Override
   public FObject remove_(X x, FObject obj) {
-    authorizer_.authorizeOnDelete(x, obj);
+    Object id = obj.getProperty("id");
+    FObject oldObj = getDelegate().inX(x).find(id);
+    if ( id == null || oldObj == null ) return null;
+    authorizer_.authorizeOnDelete(x, oldObj);
     return super.remove_(x, obj);
   }
 

--- a/src/foam/nanos/auth/AuthorizationDAO.java
+++ b/src/foam/nanos/auth/AuthorizationDAO.java
@@ -59,7 +59,7 @@ public class AuthorizationDAO extends ProxyDAO {
     FObject obj = super.find_(x, id);
     if ( id == null || obj == null ) return null;
     authorizer_.authorizeOnRead(x, obj);
-    return super.find_(x, id);
+    return obj;
   }
 
   @Override

--- a/src/foam/nanos/auth/AuthorizationDAO.java
+++ b/src/foam/nanos/auth/AuthorizationDAO.java
@@ -70,7 +70,7 @@ public class AuthorizationDAO extends ProxyDAO {
 
   @Override
   public void removeAll_(X x, long skip, long limit, Comparator order, Predicate predicate) {
-    Sink authorizationSink = new AuthorizationSink(x, authorizer_, new RemoveSink(x, this));
-    this.select_(x, authorizationSink, skip, limit, order, predicate);
+    Sink sink = new AuthorizationSink(x, authorizer_, new RemoveSink(x, getDelegate()), true);
+    getDelegate().select_(x, sink, skip, limit, order, predicate);
   }
 }


### PR DESCRIPTION
Closes #1767 

* When removing, check existing object instead of given one
  * This is to avoid people manipulating an object's properties before
removing it in such a way that they could pass the authorization check
with the modified properties but wouldn't have been able to pass it had
they not modified those properties.
* Minor optimization: Avoid unnecessary second lookup in `find_` method
* Fix bug where read authorization check was being called for deletes
  * It used to call `authorizeOnRead` because calling `this.select_` with
the AuthorizationSink would call `authorizeOnRead` in the `put` method
of the sink. Then the RemoveSink would call `remove_` which would call
`authorizeOnDelete`, which is the call we want.
  * Now it doesn't call `authorizeOnRead`, just `authorizeOnDelete` like it
should.
  * It's important that we call `select_` on the delegate instead of `this`
because otherwise we'd still be hitting the AuthorizationSink which
calls the `authorizeOnRead` method.
  * It's an optimization to pass the delegate to the RemoveSink instead of
`this` because that way we avoid unnecessarily calling
`authorizeOnDelete` a second time when the RemoveSink calls the
`remove_` method on the DAO given to it.