### PR TITLE
Fix the password word reset not working

### DIFF
--- a/src/foam/nanos/auth/resetPassword/ResetPasswordTokenService.js
+++ b/src/foam/nanos/auth/resetPassword/ResetPasswordTokenService.js
@@ -132,10 +132,8 @@ if ( ! Password.isValid(newPassword) ) {
 
 // update user's password
 userResult = (User) userResult.fclone();
-userResult.setPasswordLastModified(Calendar.getInstance().getTime());
-userResult.setPreviousPassword(userResult.getPassword());
-userResult.setPassword(Password.hash(newPassword));
-userResult.setPasswordExpiry(null);
+userResult.setDesiredPassword(newPassword);
+user.setPasswordExpiry(null);
 userDAO.put(userResult);
 
 // set token processed to true


### PR DESCRIPTION
refs [5498](https://github.com/nanoPayinc/NANOPAY/issues/5498)

- [x] fix: email - password reset not working

The real password reset and hashing happens [here](https://github.com/foam-framework/foam2/blob/master/src/foam/nanos/auth/UserPasswordHashingDAO.java#L31)