### PR TITLE
Validate password method on auth service

### DIFF
--- a/src/foam/nanos/auth/AuthService.js
+++ b/src/foam/nanos/auth/AuthService.js
@@ -111,8 +111,7 @@ foam.INTERFACE({
     },
     {
       name: 'validatePassword',
-      javaReturns: 'boolean',
-      swiftReturns: 'Bool',
+      javaThrows: [ 'java.lang.RuntimeException' ],
       swiftThrows: true,
       args: [
         {

--- a/src/foam/nanos/auth/AuthService.js
+++ b/src/foam/nanos/auth/AuthService.js
@@ -110,6 +110,18 @@ foam.INTERFACE({
       ]
     },
     {
+      name: 'validatePassword',
+      javaReturns: 'boolean',
+      swiftReturns: 'Bool',
+      swiftThrows: true,
+      args: [
+        {
+          name: 'potentialPassword',
+          javaType: 'String',
+        }
+      ]
+    },
+    {
       name: 'checkUser',
       javaReturns: 'boolean',
       swiftReturns: 'Bool',

--- a/src/foam/nanos/auth/ChangePasswordView.js
+++ b/src/foam/nanos/auth/ChangePasswordView.js
@@ -139,13 +139,9 @@ foam.CLASS({
   `,
 
   messages: [
-    { name: 'noSpaces', message: 'Password cannot contain spaces' },
-    { name: 'noNumbers', message: 'Password must have one numeric character' },
-    { name: 'noSpecial', message: 'Password must not contain: !@#$%^&*()_+' },
     { name: 'emptyOriginal', message: 'Please enter your original password'},
     { name: 'emptyPassword', message: 'Please enter your new password' },
     { name: 'emptyConfirmation', message: 'Please re-enter your new password' },
-    { name: 'invalidLength', message: 'Password must be 7-32 characters long' },
     { name: 'passwordMismatch', message: 'Passwords do not match' },
     { name: 'passwordSuccess', message: 'Password successfully updated' }
   ],

--- a/src/foam/nanos/auth/ChangePasswordView.js
+++ b/src/foam/nanos/auth/ChangePasswordView.js
@@ -205,33 +205,13 @@ foam.CLASS({
           return;
         }
 
-        // validate new password
+        // check if new password entered
         if ( ! this.newPassword ) {
           this.add(this.NotificationMessage.create({ message: this.emptyPassword, type: 'error' }));
           return;
         }
 
-        if ( this.newPassword.includes(' ') ) {
-          this.add(this.NotificationMessage.create({ message: this.noSpaces, type: 'error' }));
-          return;
-        }
-
-        if ( this.newPassword.length < 7 || this.newPassword.length > 32 ) {
-          this.add(this.NotificationMessage.create({ message: this.invalidLength, type: 'error' }));
-          return;
-        }
-
-        if ( ! /\d/g.test(this.newPassword) ) {
-          this.add(self.NotificationMessage.create({ message: this.noNumbers, type: 'error' }));
-          return;
-        }
-
-        if ( /[^a-zA-Z0-9]/.test(this.newPassword) ) {
-          this.add(self.NotificationMessage.create({ message: this.noSpecial, type: 'error' }));
-          return;
-        }
-
-        // check if confirmation entered
+        // check if new password confirmation entered
         if ( ! this.confirmPassword ) {
           this.add(self.NotificationMessage.create({ message: this.emptyConfirmation, type: 'error' }));
           return;

--- a/src/foam/nanos/auth/UserAndGroupAuthService.java
+++ b/src/foam/nanos/auth/UserAndGroupAuthService.java
@@ -274,8 +274,8 @@ public class UserAndGroupAuthService
     return checkPermission(x, new AuthPermission(permission));
   }
 
-  public boolean validatePassword( String Password) {
-    return Password.isValid(Password);
+  public boolean validatePassword( String newPassword) {
+    return Password.isValid(newPassword);
   }
 
   public boolean checkUser(foam.core.X x, User user, String permission) {

--- a/src/foam/nanos/auth/UserAndGroupAuthService.java
+++ b/src/foam/nanos/auth/UserAndGroupAuthService.java
@@ -317,7 +317,7 @@ public class UserAndGroupAuthService
       throw new AuthenticationException("User group disabled");
     }
 
-    if (! validatePassword(newPassword)) {
+    if ( ! validatePassword(newPassword) ) {
       throw new AuthenticationException(Password.PASSWORD_ERROR_MESSAGE);
     }
 

--- a/src/foam/nanos/auth/UserAndGroupAuthService.java
+++ b/src/foam/nanos/auth/UserAndGroupAuthService.java
@@ -37,9 +37,6 @@ public class UserAndGroupAuthService
 
   public final static String CHECK_USER_PERMISSION = "service.auth.checkUser";
 
-  // pattern used to check if password has only alphanumeric characters
-  java.util.regex.Pattern alphanumeric = java.util.regex.Pattern.compile("[^a-zA-Z0-9]");
-
   public UserAndGroupAuthService(X x) {
     setX(x);
   }
@@ -277,6 +274,10 @@ public class UserAndGroupAuthService
     return checkPermission(x, new AuthPermission(permission));
   }
 
+  public boolean validatePassword( String Password) {
+    return Password.isValid(Password);
+  }
+
   public boolean checkUser(foam.core.X x, User user, String permission) {
     return checkUserPermission(x, user, new AuthPermission(permission));
   }
@@ -287,7 +288,7 @@ public class UserAndGroupAuthService
    */
   public User updatePassword(foam.core.X x, String oldPassword, String newPassword) throws AuthenticationException {
     if ( x == null || SafetyUtil.isEmpty(oldPassword) || SafetyUtil.isEmpty(newPassword) ) {
-      throw new RuntimeException("Invalid parameters");
+      throw new RuntimeException("Password fields cannot be blank");
     }
 
     Session session = x.get(Session.class);
@@ -316,21 +317,8 @@ public class UserAndGroupAuthService
       throw new AuthenticationException("User group disabled");
     }
 
-    int length = newPassword.length();
-    if ( length < 7 || length > 32 ) {
-      throw new RuntimeException("Password must be 7-32 characters long");
-    }
-
-    if ( newPassword.equals(newPassword.toLowerCase()) ) {
-      throw new RuntimeException("Password must have one capital letter");
-    }
-
-    if ( ! newPassword.matches(".*\\d+.*") ) {
-      throw new RuntimeException("Password must have one numeric character");
-    }
-
-    if ( alphanumeric.matcher(newPassword).matches() ) {
-      throw new RuntimeException("Password must not contain: !@#$%^&*()_+");
+    if (! validatePassword(newPassword)) {
+      throw new AuthenticationException(Password.PASSWORD_ERROR_MESSAGE);
     }
 
     // old password does not match

--- a/src/foam/nanos/auth/resetPassword/EmailView.js
+++ b/src/foam/nanos/auth/resetPassword/EmailView.js
@@ -22,7 +22,7 @@ foam.CLASS({
     'foam.u2.dialog.NotificationMessage'
   ],
 
-  css:`
+  css: `
     ^{
       width: 490px;
       margin: auto;
@@ -144,7 +144,7 @@ foam.CLASS({
   ],
 
   methods: [
-    function initE(){
+    function initE() {
     this.SUPER();
     var self = this;
 
@@ -154,7 +154,7 @@ foam.CLASS({
         .start().addClass('Forgot-Password').add('Forgot Password').end()
         .start().addClass('Message-Container')
         .start().addClass('Instructions-Text').add(this.Instructions).end()
-        .start().addClass('Email-Text').add("Email Address").end()
+        .start().addClass('Email-Text').add('Email Address').end()
         .start(this.EMAIL).addClass('full-width-input').end()
         .start(this.NEXT).addClass('Next-Button').end()
         .start('p').add('Remember your password?').end()
@@ -171,16 +171,16 @@ foam.CLASS({
   actions: [
     {
       name: 'next',
-      code: function (X) {
+      code: function(X) {
         var self = this;
         var user = this.User.create({ email: this.email });
-        this.resetPasswordToken.generateToken(null, user).then(function (result) {
+        this.resetPasswordToken.generateToken(null, user).then(function(result) {
           if ( ! result ) {
             throw new Error('Error generating reset token');
           }
-          self.stack.push(self.ResendView.create({ email: self.email }));;
+          self.stack.push(self.ResendView.create({ email: self.email }));
         })
-        .catch(function (err) {
+        .catch(function(err) {
           self.add(self.NotificationMessage.create({ message: err.message, type: 'error' }));
         });
       }

--- a/src/foam/nanos/auth/resetPassword/ResendView.js
+++ b/src/foam/nanos/auth/resetPassword/ResendView.js
@@ -92,7 +92,7 @@ foam.CLASS({
   ],
 
   messages: [
-    { name: 'Instructions', message: 'We\'ve sent the instructions to your email. Please check your inbox to continue.'}
+    { name: 'Instructions', message: "We've sent the instructions to your email. Please check your inbox to continue."}
   ],
 
   methods: [

--- a/src/foam/nanos/auth/resetPassword/ResendView.js
+++ b/src/foam/nanos/auth/resetPassword/ResendView.js
@@ -92,7 +92,7 @@ foam.CLASS({
   ],
 
   messages: [
-    { name: 'Instructions', message: "We've sent the instructions to your email. Please check your inbox to continue."}
+    { name: 'Instructions', message: `We've sent the instructions to your email. Please check your inbox to continue.` }
   ],
 
   methods: [

--- a/src/foam/nanos/auth/resetPassword/ResendView.js
+++ b/src/foam/nanos/auth/resetPassword/ResendView.js
@@ -92,11 +92,11 @@ foam.CLASS({
   ],
 
   messages: [
-    { name: 'Instructions', message: "We've sent the instructions to your email. Please check your inbox to continue."}
+    { name: 'Instructions', message: 'We\'ve sent the instructions to your email. Please check your inbox to continue.'}
   ],
 
   methods: [
-    function initE(){
+    function initE() {
       this.SUPER();
       var self = this;
 
@@ -112,8 +112,8 @@ foam.CLASS({
           .start('p').addClass('link')
             .add('Sign in.')
             .on('click', function() {self.stack.push({ class: 'foam.nanos.auth.SignInView' })})
-        .end()       
-      .end()
+        .end()
+      .end();
 
       this.add(self.NotificationMessage.create({ message: 'Password reset instructions sent to ' + self.email }));
     }
@@ -123,14 +123,14 @@ foam.CLASS({
     {
       name: 'resendEmail',
       label: 'Resend Email',
-      code: function (X) {
+      code: function(X) {
         var self = this;
 
         var user = this.User.create({ email: this.email });
-        this.resetPasswordToken.generateToken(null, user).then(function (result) {
+        this.resetPasswordToken.generateToken(null, user).then(function(result) {
           self.add(self.NotificationMessage.create({ message: 'Password reset instructions sent to ' + self.email }));
         })
-        .catch(function (err) {
+        .catch(function(err) {
           self.add(self.NotificationMessage.create({ message: err.message, type: 'error' }));
         });
       }

--- a/src/foam/nanos/auth/resetPassword/ResetPasswordTokenService.js
+++ b/src/foam/nanos/auth/resetPassword/ResetPasswordTokenService.js
@@ -115,7 +115,7 @@ if ( userResult == null ) {
   throw new RuntimeException("User not found");
 }
 
-if ( ! Password.isValid(newPassword) ) {
+if ( ! Password.isValid(x, newPassword) ) {
   throw new RuntimeException("Invalid password");
 }
 

--- a/src/foam/nanos/auth/resetPassword/ResetPasswordTokenService.js
+++ b/src/foam/nanos/auth/resetPassword/ResetPasswordTokenService.js
@@ -37,17 +37,6 @@ foam.CLASS({
     'java.util.UUID'
   ],
 
-  axioms: [
-    {
-      name: 'javaExtras',
-      buildJavaClass: function (cls) {
-        cls.extras.push(foam.java.Code.create({
-          data: 'java.util.regex.Pattern p = java.util.regex.Pattern.compile("[^a-zA-Z0-9]");'
-        }))
-      }
-    }
-  ],
-
   methods: [
     {
       name: 'generateTokenWithParameters',

--- a/src/foam/nanos/auth/resetPassword/ResetView.js
+++ b/src/foam/nanos/auth/resetPassword/ResetView.js
@@ -21,7 +21,7 @@ foam.CLASS({
     'foam.u2.dialog.NotificationMessage'
   ],
 
-  css:`
+  css: `
     ^{
       width: 490px;
       margin: auto;
@@ -135,11 +135,11 @@ foam.CLASS({
     {
       class: 'String',
       name: 'token',
-      factory: function () {
+      factory: function() {
         var search = /([^&=]+)=?([^&]*)/g;
         var query  = window.location.search.substring(1);
 
-        var decode = function (s) {
+        var decode = function(s) {
           return decodeURIComponent(s.replace(/\+/g, ' '));
         };
 
@@ -166,60 +166,41 @@ foam.CLASS({
   ],
 
   methods: [
-    function initE(){
+    function initE() {
     this.SUPER();
     var self = this;
 
     this
       .addClass(this.myClass())
       .start()
-        .start().addClass('Reset-Password').add("Reset Password").end()
+        .start().addClass('Reset-Password').add('Reset Password').end()
         .start().addClass('Message-Container')
-          .start().addClass('newPassword-Text').add("New Password").end()
+          .start().addClass('newPassword-Text').add('New Password').end()
           .add(this.NEW_PASSWORD)
-          .start().addClass('confirmPassword-Text').add("Confirm Password").end()
+          .start().addClass('confirmPassword-Text').add('Confirm Password').end()
           .add(this.CONFIRM_PASSWORD)
           .start('div')
             .start(this.CONFIRM).addClass('resetButton').end()
           .end()
         .end()
-        .start('p').add("Remember your password?").end()
+        .start('p').add('Remember your password?').end()
         .start('p').addClass('link')
           .add('Sign in.')
-          .on('click', function(){ window.location.href = '#'; self.stack.push({ class: 'foam.nanos.auth.SignInView' })})
+          .on('click', function() { window.location.href = '#'; self.stack.push({ class: 'foam.nanos.auth.SignInView' })})
       .end()
-    .end()
+    .end();
     }
   ],
 
   actions: [
     {
       name: 'confirm',
-      code: function (X, obj) {
+      code: function(X, obj) {
         var self = this;
+
         // check if new password entered
         if ( ! this.newPassword ) {
           this.add(this.NotificationMessage.create({ message: this.emptyPassword, type: 'error' }));
-          return;
-        }
-
-        if ( this.newPassword.includes(' ') ) {
-          this.add(this.NotificationMessage.create({ message: this.noSpaces, type: 'error' }));
-          return;
-        }
-
-        if ( this.newPassword.length < 7 || this.newPassword.length > 32 ) {
-          this.add(this.NotificationMessage.create({ message: this.invalidLength, type: 'error' }));
-          return;
-        }
-
-        if ( ! /\d/g.test(this.newPassword) ) {
-          this.add(self.NotificationMessage.create({ message: this.noNumbers, type: 'error' }));
-          return;
-        }
-
-        if ( /[^a-zA-Z0-9]/.test(this.newPassword) ) {
-          this.add(self.NotificationMessage.create({ message: this.noSpecial, type: 'error' }));
           return;
         }
 
@@ -239,9 +220,9 @@ foam.CLASS({
           desiredPassword: this.newPassword
         });
 
-        this.resetPasswordToken.processToken(null, user, this.token).then(function (result) {
+        this.resetPasswordToken.processToken(null, user, this.token).then(function(result) {
           self.stack.push({ class: 'foam.nanos.auth.resetPassword.SuccessView' });
-        }).catch(function (err) {
+        }).catch(function(err) {
           self.add(self.NotificationMessage.create({ message: err.message, type: 'error' }));
         });
       }

--- a/src/foam/nanos/auth/resetPassword/ResetView.js
+++ b/src/foam/nanos/auth/resetPassword/ResetView.js
@@ -122,12 +122,8 @@ foam.CLASS({
   `,
 
   messages: [
-    { name: 'noSpaces', message: 'Password cannot contain spaces' },
-    { name: 'noNumbers', message: 'Password must have one numeric character' },
-    { name: 'noSpecial', message: 'Password must not contain: !@#$%^&*()_+' },
     { name: 'emptyPassword', message: 'Please enter your new password' },
     { name: 'emptyConfirmation', message: 'Please re-enter your new password' },
-    { name: 'invalidLength', message: 'Password must be 7-32 characters long' },
     { name: 'passwordMismatch', message: 'Passwords do not match' }
   ],
 

--- a/src/foam/nanos/auth/resetPassword/SuccessView.js
+++ b/src/foam/nanos/auth/resetPassword/SuccessView.js
@@ -19,7 +19,7 @@ foam.CLASS({
     'foam.u2.dialog.NotificationMessage'
   ],
 
-  css:`
+  css: `
     ^{
       width: 490px;
       margin: auto;
@@ -82,25 +82,25 @@ foam.CLASS({
   `,
 
   messages: [
-    { name: 'Instructions', message: "Successfully reset password!"}
+    { name: 'Instructions', message: 'Successfully reset password!' }
   ],
 
   methods: [
-    function initE(){
+    function initE() {
       this.SUPER();
       var self = this;
 
       this
         .addClass(this.myClass())
         .start()
-          .start().addClass('Reset-Password').add("Reset Password").end()
+          .start().addClass('Reset-Password').add('Reset Password').end()
           .start().addClass('Message-Container')
             .start().addClass('success-Text').add(this.Instructions).end()
             .start().addClass('Back-Button')
-              .add("Back to Sign In")
-              .on('click', function(){
+              .add('Back to Sign In')
+              .on('click', function() {
                 window.location.href = '#';
-                self.stack.push({ class: 'foam.nanos.auth.SignInView' })
+                self.stack.push({ class: 'foam.nanos.auth.SignInView' });
               })
             .end()
           .end()

--- a/src/foam/util/Password.java
+++ b/src/foam/util/Password.java
@@ -16,8 +16,9 @@ import java.util.regex.Pattern;
 
 public class Password {
 
-  // Min 6 characters
-  private static Pattern PASSWORD_PATTERN = Pattern.compile("^.{6,}$");
+  // Password validation
+  private static Pattern PASSWORD_PATTERN = Pattern.compile("^.{6,}$"); // Minimum 6 characters
+  public static String PASSWORD_ERROR_MESSAGE = "Password must be at least 6 characters long";
 
   /**
    * Generates random salt given a size

--- a/src/foam/util/Password.java
+++ b/src/foam/util/Password.java
@@ -6,19 +6,16 @@
 
 package foam.util;
 
+import foam.nanos.auth.AuthService;
+
 import org.bouncycastle.crypto.PBEParametersGenerator;
 import org.bouncycastle.crypto.generators.PKCS5S2ParametersGenerator;
 import org.bouncycastle.crypto.params.KeyParameter;
 import org.bouncycastle.util.encoders.Base64;
 
 import java.security.SecureRandom;
-import java.util.regex.Pattern;
 
 public class Password {
-
-  // Password validation
-  private static Pattern PASSWORD_PATTERN = Pattern.compile("^.{6,}$"); // Minimum 6 characters
-  public static String PASSWORD_ERROR_MESSAGE = "Password must be at least 6 characters long";
 
   /**
    * Generates random salt given a size
@@ -101,7 +98,13 @@ public class Password {
    * @param password password to validate
    * @return true if valid, false otherwise
    */
-  public static boolean isValid(String password) {
-    return ! SafetyUtil.isEmpty(password) && PASSWORD_PATTERN.matcher(password).matches();
+  public static boolean isValid(foam.core.X x, String password) {
+    AuthService auth = (AuthService) x.get("auth");
+    try {
+      auth.validatePassword(password);
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
   }
 }

--- a/src/foam/util/PasswordTest.js
+++ b/src/foam/util/PasswordTest.js
@@ -9,6 +9,10 @@ foam.CLASS({
   name: 'PasswordTest',
   extends: 'foam.nanos.test.Test',
 
+  javaImports: [
+    'foam.core.X'
+  ],
+
   methods: [
     {
       name: 'runTest',
@@ -33,10 +37,10 @@ foam.CLASS({
         Password_Verify("F0amframew0rk", "ZgZ8/RVYJjg=:67iHRqR2TmD7JQNNDMRIek/vcNmJlwBOXBaENDJsa+8fOsyW6A6k6/jZLvalXI9suIngb0J/ruyrHAkCCUkQ6w==", true, "Password verification returns true with correct password, correct salt, and correct hashed password");
 
         // isValid tests
-        Password_IsValid(null, false, "isValid method returns false given null");
-        Password_IsValid("", false, "isValid method returns false given empty string");
-        Password_IsValid("foam", false, "isValid returns false given password shorter than 6 characters");
-        Password_IsValid("F0amframew0rk", true, "isValid returns true given password longer than 6 characters, with uppercase and with numbers");
+        Password_IsValid(x, null, false, "isValid method returns false given null");
+        Password_IsValid(x, "", false, "isValid method returns false given empty string");
+        Password_IsValid(x, "foam", false, "isValid returns false given password shorter than 6 characters");
+        Password_IsValid(x, "F0amframew0rk", true, "isValid returns true given password longer than 6 characters");
       `
     },
     {
@@ -82,12 +86,13 @@ foam.CLASS({
     {
       name: 'Password_IsValid',
       args: [
+        { javaType: 'foam.core.X',  name: 'x'    },
         { class: 'String',  name: 'input'    },
         { class: 'Boolean', name: 'expected' },
         { class: 'String',  name: 'message'  },
       ],
       javaCode: `
-        test(Password.isValid(input) == expected, message);
+        test(Password.isValid(x, input) == expected, message);
       `
     }
   ]


### PR DESCRIPTION
1. Adds a validatePassword password method to AuthService, which in turn calls Password.validatePassword
2. Adds a passwordErrorMessage to the Password model, which should be updated if/when password requirements change.
3. Removes frontEnd password validation, and validatePassword is called by updatePassword when there is an attempt to set a new password.
4. Makes validate password available through the auth service, creating a single source of truth for front end validation to rely and call upon.
5. Fixes styling issues in a number of files.

Next steps would be to go through the system and remove password validation on the front end, and call the validatePassword method on auth service instead.  