### PR TITLE
Fix bug where popup background covers popup in Safari

### DIFF
--- a/src/foam/u2/dialog/Popup.js
+++ b/src/foam/u2/dialog/Popup.js
@@ -60,6 +60,12 @@ foam.CLASS({
     }
     ^inner {
       z-index: 3;
+      /* The following transforms fix an overflow issue in certain browsers. */
+      -o-transform: translate3D(0,0,0);
+      -ms-transform: translate3D(0,0,0);
+      -moz-transform: translate3D(0,0,0);
+      -webkit-transform: translate3D(0,0,0);
+      transform: translate3D(0,0,0);
     }
  `,
 


### PR DESCRIPTION
In Safari, the popup overlay for a certain modal doesn't work in Ablii, see here:
![](https://user-images.githubusercontent.com/23502640/50696224-dd4d6680-100c-11e9-9b52-bd26af2ea297.png)

The background is covering the rest of the modal, meaning it can't be interacted with.

I looked up the issue and found a fix that works from [this Stack Overflow thread](https://stackoverflow.com/a/40896165/2512768), although I couldn't actually tell you why it fixes the problem unfortunately.

Necessary for https://github.com/nanoPayinc/NANOPAY/issues/5551