### PR TITLE
Fix object cloning

### DIFF
--- a/src/foam/core/stdlib.js
+++ b/src/foam/core/stdlib.js
@@ -777,7 +777,7 @@ foam.LIB({
     function clone(o) {
       const newObj = {};
 
-      for ( let key in o ) {
+      for ( var key in o ) {
         if ( o.hasOwnProperty(key) ) {
           newObj[key] = foam.util.clone(o[key]);
         }

--- a/src/foam/core/stdlib.js
+++ b/src/foam/core/stdlib.js
@@ -774,7 +774,17 @@ foam.LIB({
       return typeof o === 'object' && ! Array.isArray(o) &&
           ! foam.core.FObject.isInstance(o) && ! foam.Null.isInstance(o);
     },
-    function clone(o) { return o; },
+    function clone(o) {
+      const newObj = {};
+
+      for ( let key in o ) {
+        if ( o.hasOwnProperty(key) ) {
+          newObj[key] = foam.util.clone(o[key]);
+        }
+      }
+
+      return newObj;
+    },
     function equals(a, b) { return a === b; },
     function compare(a, b) {
       if ( ! foam.Object.isInstance(b) ) return 1;


### PR DESCRIPTION
Closes #1780 

@Henry0422 and I ran into an issue where cloning a Menu and setting a property on the view on the handler of the menu (a property on a twice-nested object) was also setting the value on the original Menu that we cloned, meaning it wasn't a true clone. 

That lead us to look into it and found that the existing clone method for objects just returns the object to be cloned, which obviously doesn't clone it.

This PR adds an implementation that should work for true deep cloning at arbitrary levels of nesting since it gets called recursively for nested objects, but only with support for the types that stdlib recognizes.