### PR TITLE
Export the invoice as csv

### DIFF
--- a/src/foam/nanos/fs/File.js
+++ b/src/foam/nanos/fs/File.js
@@ -34,7 +34,10 @@ foam.CLASS({
     {
       class: 'Blob',
       name: 'data',
-      documentation: 'File data'
+      documentation: 'File data',
+      adapt: function(oldObj, newObj) {
+        return newObj;
+      }
     },
     {
       class: 'String',

--- a/src/foam/nanos/fs/File.js
+++ b/src/foam/nanos/fs/File.js
@@ -35,6 +35,13 @@ foam.CLASS({
       class: 'Blob',
       name: 'data',
       documentation: 'File data',
+      /**
+       * See: https://github.com/nanoPayinc/NANOPAY/issues/4068
+       * When we export this as the CSV, we are trying to create a new object if this property is undefined.
+       * But because this 'Blob' is an interface, we can not instantiate it.
+       *
+       * Provide an adapt function will fix that issue.
+       */
       adapt: function(oldObj, newObj) {
         return newObj;
       }


### PR DESCRIPTION
refs : 
[5562](https://github.com/nanoPayinc/NANOPAY/issues/5562) - issue 6
[4068](https://github.com/nanoPayinc/NANOPAY/issues/4068)

We are getting an error when we exporting the invoice as the csv.
![interface](https://user-images.githubusercontent.com/11410259/51191912-67ba8380-18b3-11e9-830c-5c2a0ba60371.jpg)

This is because when we export the data as csv, we are trying to create a new object if the property is undefined. see [if ( o[p.name] == undefined ) o[p.name] = p.of.id;](https://github.com/foam-framework/foam2/blob/master/src/foam/lib/csv/CSV.js#L89).

But the issue is we can not instantiate this Blob datatype because it's an interface.

The easiest way to fix this is provide an adapt function to this property.