### PR TITLE
Updated export modal css

### DIFF
--- a/src/foam/u2/ModalHeader.js
+++ b/src/foam/u2/ModalHeader.js
@@ -45,7 +45,7 @@ foam.CLASS({
       margin-top: 5px;
       cursor: pointer;
       position: relative;
-      top: 4px;
+      top: -3px;
       right: 20px;
       float: right;
     }
@@ -74,9 +74,8 @@ foam.CLASS({
   `,
 
   methods: [
-    function initE(){
+    function initE() {
     this.SUPER();
-    var self = this;
 
     this
       .addClass(this.myClass())
@@ -89,8 +88,9 @@ foam.CLASS({
     {
       name: 'closeModal',
       icon: 'images/ic-cancelwhite.svg',
-      code: function(X){
-        X.closeDialog()
+      label: 'Close',
+      code: function(X) {
+        X.closeDialog();
       }
     }
   ]


### PR DESCRIPTION
Close text was cut off on export modal.
Before:
![image](https://user-images.githubusercontent.com/44786222/51208899-e972d700-18dc-11e9-8899-dadc3c6be080.png)
After:
![image](https://user-images.githubusercontent.com/44786222/51208947-060f0f00-18dd-11e9-842c-a74d02bb2240.png)
