### PR TITLE
Fix MDAO removeAll methtod

### DIFF
--- a/src/foam/dao/MDAO.java
+++ b/src/foam/dao/MDAO.java
@@ -5,11 +5,7 @@
  */
 package foam.dao;
 
-import foam.core.AbstractFObject;
-import foam.core.ClassInfo;
-import foam.core.FObject;
-import foam.core.PropertyInfo;
-import foam.core.X;
+import foam.core.*;
 import foam.dao.index.*;
 import foam.mlang.order.Comparator;
 import foam.mlang.predicate.Or;
@@ -165,7 +161,14 @@ public class MDAO
 
   public void removeAll_(X x, long skip, long limit, Comparator order, Predicate predicate) {
     synchronized ( lock_.writeLock() ) {
-      state_ = null;
+
+      this.where(predicate).select( new AbstractSink() {
+        @Override
+        public void put(Object obj, Detachable sub) {
+          MDAO.this.remove((FObject) obj);
+        }
+      });
+
     }
   }
 }

--- a/src/foam/dao/MDAO.java
+++ b/src/foam/dao/MDAO.java
@@ -162,12 +162,11 @@ public class MDAO
   public void removeAll_(X x, long skip, long limit, Comparator order, Predicate predicate) {
     synchronized ( lock_.writeLock() ) {
 
-      this.where(predicate).select( new AbstractSink() {
-        @Override
-        public void put(Object obj, Detachable sub) {
-          MDAO.this.remove((FObject) obj);
-        }
-      });
+      if ( predicate == null ) {
+        state_ = null;
+      } else {
+        super.removeAll_(x, skip, limit, order, predicate);
+      }
 
     }
   }


### PR DESCRIPTION
According to the documentation [See here](https://github.com/sirenChen/foam2/blob/master/doc/guides/Dao.md#removeall)

> `removeAll()` is very similar to `select()`, with the obvious exception that it
> removes all matching entries from the DAO instead of returning them.

But currently mdao.removeAll() will ignore the filtering and delete every entry.