### PR TITLE
Refactor logout disabled user DAO

### DIFF
--- a/src/foam/nanos/auth/LogoutDisabledUserDAO.js
+++ b/src/foam/nanos/auth/LogoutDisabledUserDAO.js
@@ -20,11 +20,7 @@ foam.CLASS({
         User newUser = (User) obj;
         User oldUser = (User) getDelegate().find(newUser.getId());
 
-        if (
-          oldUser != null
-          && oldUser.getEnabled()
-          && !newUser.getEnabled()
-        ) {
+        if ( ! isDisabled(oldUser) && isDisabled(newUser) ) {
           sessionDAO_ = (DAO) x.get("localSessionDAO");
           auth_ = (AuthService) x.get("auth");
 
@@ -34,6 +30,14 @@ foam.CLASS({
 
         return super.put_(x, obj);
       `
+    },
+    {
+      name: 'isDisabled',
+      javaReturns: 'Boolean',
+      args: [
+        { of: 'User', name: 'user' }
+      ],
+      javaCode: `return ! user.getEnabled();`
     },
     {
       name: 'logoutAgent',

--- a/src/foam/nanos/auth/LogoutDisabledUserDAO.js
+++ b/src/foam/nanos/auth/LogoutDisabledUserDAO.js
@@ -20,7 +20,10 @@ foam.CLASS({
         User newUser = (User) obj;
         User oldUser = (User) getDelegate().find(newUser.getId());
 
-        if ( ! isDisabled(oldUser) && isDisabled(newUser) ) {
+        if ( oldUser != null
+          && ! isDisabled(oldUser)
+          && isDisabled(newUser)
+        ) {
           sessionDAO_ = (DAO) x.get("localSessionDAO");
           auth_ = (AuthService) x.get("auth");
 


### PR DESCRIPTION
Needed for: https://github.com/nanoPayinc/NANOPAY/pull/5354/commits/fcf26afeaa707cf5d30756622f8319622c571081

Refactor: extract isDisabled method

Decoupling the logic for checking if user is disabled allows descendant class to override and define its own definition of a disabled user to be logged out. For example, below DAO will randomly logout user with a probability of 0.1.

```javascript
foam.CLASS({
  name: 'DummyDAO',
  extends: 'foam.nanos.auth.LogoutDisabledUserDAO',

  methods: [
    {
      name: 'isDisabled',
      javaCode: `
        Random rnd = new Random();
        return rnd.nextInt(10) == 0;
      `
    }
  ]
});
```