### PR TITLE
Fix bug where properties were not being looked up properly

### DIFF
--- a/src/foam/nanos/auth/PermissionedPropertyDAO.js
+++ b/src/foam/nanos/auth/PermissionedPropertyDAO.js
@@ -174,10 +174,10 @@ foam.CLASS({
       javaCode: `
   AuthService auth = (AuthService) x.get("auth");
   String axiomName =  axiom.toString();
-  axiomName = axiomName.substring(axiomName.lastIndexOf(".") + 1).toLowerCase();
-  boolean hasPermission = auth.check(x, of + ".rw." + axiomName);
+  axiomName = axiomName.substring(axiomName.lastIndexOf(".") + 1);
+  boolean hasPermission = auth.check(x, of + ".rw." + axiomName.toLowerCase());
   if ( ! write ) {
-    hasPermission = hasPermission || auth.check(x, of + ".ro." + axiomName);
+    hasPermission = hasPermission || auth.check(x, of + ".ro." + axiomName.toLowerCase());
   }
 
   if ( ! hasPermission ) {


### PR DESCRIPTION
The lowercase property name should be used in the permission string, not in the `getProperty` lookup.

@Henry0422 

Marks https://github.com/nanoPayinc/NANOPAY/issues/5755 as ready for testing