### PR TITLE
Add EnabledAwareDummy for tests

### DIFF
--- a/src/foam/nanos/auth/EnabledAware.js
+++ b/src/foam/nanos/auth/EnabledAware.js
@@ -27,3 +27,19 @@ foam.INTERFACE({
     }
   ]
 });
+
+foam.CLASS({
+  package: 'foam.nanos.auth',
+  name: 'EnabledAwareDummy',
+
+  properties: [
+    {
+      class: 'Long',
+      name: 'id'
+    },
+    {
+      class: 'Boolean',
+      name: 'enabled'
+    }
+  ]
+});

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -134,6 +134,7 @@ var classes = [
   'foam.nanos.app.Mode',
   'foam.nanos.bench.Benchmark',
   'foam.nanos.auth.EnabledAware',
+  'foam.nanos.auth.EnabledAwareDummy',
   'foam.nanos.auth.Group',
   'foam.nanos.auth.CreatedAware',
   'foam.nanos.auth.CreatedAwareDAO',


### PR DESCRIPTION
EnabledAwareDAOTest should not depend on User class to be a EnabledAware
type. Using EnabledAwareDummy in tests make EnabledAwareDAOTest isolated
from changes happening in classes that implement EnabledAware e.g., User.