### PR TITLE
[nanos] Removed validateObj on PostalCode

### DIFF
--- a/src/foam/nanos/auth/Address.js
+++ b/src/foam/nanos/auth/Address.js
@@ -102,12 +102,6 @@ foam.CLASS({
       name: 'postalCode',
       documentation: 'Postal code pertaining to address.',
       required: true,
-      validateObj: function(postalCode) {
-        var postalCodeRegex = /^[ABCEGHJ-NPRSTVXY]\d[ABCEGHJ-NPRSTV-Z][ -]?\d[ABCEGHJ-NPRSTV-Z]\d$/i;
-        if ( ! postalCodeRegex.test(postalCode) ) {
-          return 'Invalid postal code.';
-        }
-      },
       preSet: function(oldValue, newValue) {
         return newValue.toUpperCase();
       },


### PR DESCRIPTION
Removes the postal code validation assumption.
[This addresses #5878 in NANOPAY](https://github.com/nanoPayinc/NANOPAY/issues/5878)