### PR TITLE
Set default max attempts for RetryBox to 0 for nanos DAOs

### DIFF
--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -321,16 +321,18 @@ return delegate;
       generateJava: false,
       factory: function() {
         // TODO: This should come from the server via a lookup from a NamedBox.
-        return this.SessionClientBox.create({
-          delegate: this.RetryBox.create({
+        var box = this.TimeoutBox.create({
+          delegate: this.remoteListenerSupport ?
+            this.WebSocketBox.create({ uri: this.serviceName }) :
+            this.HTTPBox.create({ url: this.serviceName })
+        })
+        if ( this.retryBoxMaxAttempts != 0 ) {
+          box = this.RetryBox.create({
             maxAttempts: this.retryBoxMaxAttempts,
-            delegate: this.TimeoutBox.create({
-              delegate: this.remoteListenerSupport ?
-                this.WebSocketBox.create({ uri: this.serviceName }) :
-                this.HTTPBox.create({ url: this.serviceName })
-            })
+            delegate: box,
           })
-        });
+        }
+        return this.SessionClientBox.create({ delegate: box });
       }
     },
     {

--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -313,16 +313,25 @@ return delegate;
     },
     {
       /** Destination address for server. */
+      name: 'retryBoxMaxAttempts',
+      generateJava: false,
+    },
+    {
+      /** Destination address for server. */
       name: 'serverBox',
       generateJava: false,
       factory: function() {
         // TODO: This should come from the server via a lookup from a NamedBox.
-        return this.SessionClientBox.create({ delegate: this.RetryBox.create({ delegate:
-          this.TimeoutBox.create({ delegate:
-          this.remoteListenerSupport ?
-              this.WebSocketBox.create({ uri: this.serviceName }) :
-              this.HTTPBox.create({ url: this.serviceName })
-        })})});
+        return this.SessionClientBox.create({
+          delegate: this.RetryBox.create({
+            maxAttempts: this.retryBoxMaxAttempts,
+            delegate: this.TimeoutBox.create({
+              delegate: this.remoteListenerSupport ?
+                this.WebSocketBox.create({ uri: this.serviceName }) :
+                this.HTTPBox.create({ url: this.serviceName })
+            })
+          })
+        });
       }
     },
     {

--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -312,7 +312,6 @@ return delegate;
       generateJava: false
     },
     {
-      /** Destination address for server. */
       name: 'retryBoxMaxAttempts',
       generateJava: false,
     },

--- a/src/foam/nanos/client/ClientBuilder.js
+++ b/src/foam/nanos/client/ClientBuilder.js
@@ -98,6 +98,7 @@ foam.CLASS({
                     if ( ! json.serviceName ) json.serviceName = 'service/' + spec.name;
                     if ( ! json.class       ) json.class       = 'foam.dao.EasyDAO'
                     if ( ! json.daoType     ) json.daoType     = 'CLIENT';
+                    if ( ! json.retryBoxMaxAttempts ) json.retryBoxMaxAttempts = 0;
                     return foam.json.parse(json, null, this);
                   }
                 });


### PR DESCRIPTION
This should be a temporary band-aid around a bug on nanos misleading the client into thinking it needs to retry transactions that actually completed successfully.