### PR TITLE
Add NSpec class to session context

### DIFF
--- a/src/foam/box/SessionServerBox.java
+++ b/src/foam/box/SessionServerBox.java
@@ -58,7 +58,8 @@ public class SessionServerBox
             new PrefixLogger(
                 new Object[] { user == null ? "" : user.getId() + " - " + user.label(), "[Service]", spec.getName() },
                 (Logger) session.getContext().get("logger")))
-          .put(HttpServletRequest.class, req);
+          .put(HttpServletRequest.class, req)
+          .put(NSpec.class, spec);
 
         session.touch();
 


### PR DESCRIPTION
Needed for: https://github.com/nanoPayinc/NANOPAY/pull/5930/commits/85a7a7e8ebd1a30b105b73d05d9bd3709fb577f2#diff-db975485d409dd9b601ee43def875fffR63.

This allows access to currently running DAO service. E.g., getting dao name when inside a decorator

```
String daoName = x.get(NSpec.class).getName();
```