### PR TITLE
Use passed context to create session context

### DIFF
--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -55,7 +55,8 @@ foam.CLASS({
       class: 'Object',
       name: 'context',
       javaType: 'foam.core.X',
-      javaFactory: 'return foam.core.EmptyX.instance().put(Session.class, this);',
+      // Put a null user to prevent sytem user from leaking into subcontexts
+      javaFactory: 'return getX().put("user", null).put(Session.class, this);',
       hidden: true,
       transient: true
     }


### PR DESCRIPTION
Also explicitly sets user to null, redundant since we expect root to be passed, but just another way to ensure system user does not leak into any sessions 