### PR TITLE
Fix ChoiceView not recognizing falsey values

### DIFF
--- a/src/foam/u2/view/ChoiceView.js
+++ b/src/foam/u2/view/ChoiceView.js
@@ -187,7 +187,7 @@ foam.CLASS({
     function initE() {
       // If no item is selected, and data has not been provided, select the 0th
       // entry.
-      if ( ! this.data && ! this.index ) {
+      if ( this.data == null && ! this.index ) {
         this.index = 0;
       }
 
@@ -249,7 +249,7 @@ foam.CLASS({
       code: function() {
         var d = this.data;
         if ( this.choices.length ) {
-          this.choice = ( d && this.findChoiceByData(d) ) || this.defaultValue;
+          this.choice = ( d != null && this.findChoiceByData(d) ) || this.defaultValue;
         }
       }
     },
@@ -259,7 +259,7 @@ foam.CLASS({
       code: function() {
         this.dao.select().then(function(s) {
           this.choices = s.array.map(this.objToChoice);
-          if ( ! this.data && this.index === -1 ) this.index = this.placeholder ? -1 : 0;
+          if ( this.data == null && this.index === -1 ) this.index = this.placeholder ? -1 : 0;
         }.bind(this));
       }
     }


### PR DESCRIPTION
Closes #1867 

This commit changes the conditions under which ChoiceView recognizes a 'valid' value for its `data` property.

Only `null` and `undefined` will be considered invalid if this commit is merged. All other values will be considered valid.

This change makes `0` a valid value. Currently `0` is an invalid value.