### PR TITLE
Fixing Deleted aware tests

### DIFF
--- a/src/foam/nanos/auth/DeletedAwareDAO.java
+++ b/src/foam/nanos/auth/DeletedAwareDAO.java
@@ -76,10 +76,12 @@ public class DeletedAwareDAO extends ProxyDAO {
   public FObject remove_(X x, FObject obj) {
 
     if ( obj instanceof DeletedAware ) {
-      ((DeletedAware) obj).setDeleted(true);
-      obj = getDelegate().put_(x, obj);
+      DeletedAware clone = (DeletedAware) obj.fclone();
+      clone.setDeleted(true);
+      obj = getDelegate().put_(x, (FObject) clone);
+    } else {
+      obj = getDelegate().remove_(x, obj); // can remove a non deleted Aware Obj
     }
-
     return obj;
   }
 

--- a/src/foam/nanos/auth/DeletedAwareDAOTest.js
+++ b/src/foam/nanos/auth/DeletedAwareDAOTest.js
@@ -44,9 +44,7 @@ foam.CLASS({
       ],
       javaCode: `
         DAO delegate = new MDAO(DeletedAwareDummy.getOwnClassInfo());
-        DAO dao = (DAO) new DeletedAwareDAO.Builder(x)
-          .setDelegate(delegate)
-          .build();
+        DAO dao = (DAO) new DeletedAwareDAO(x, delegate);
 
         FObject object = new DeletedAwareDummy.Builder(x)
           .setId(1)
@@ -55,7 +53,8 @@ foam.CLASS({
         object = dao.put(object);
 
         dao.remove(object);
-        object = dao.find(object.getProperty("id"));
+
+        object = dao.inX(x).find(object.getProperty("id"));
 
         test(object != null, "DeletedAwareDAO does not remove DeletedAware object from DAO.");
         test(
@@ -71,9 +70,7 @@ foam.CLASS({
       ],
       javaCode: `
         DAO delegate = new MDAO(Country.getOwnClassInfo());
-        DAO dao = (DAO) new DeletedAwareDAO.Builder(x)
-          .setDelegate(delegate)
-          .build();
+        DAO dao = (DAO) new DeletedAwareDAO(x, delegate);
 
         FObject object = new Country.Builder(x)
           .setCode("CA")
@@ -93,9 +90,7 @@ foam.CLASS({
       ],
       javaCode: `
         DAO delegate = new MDAO(DeletedAwareDummy.getOwnClassInfo());
-        DAO dao = (DAO) new DeletedAwareDAO.Builder(x)
-          .setDelegate(delegate)
-          .build();
+        DAO dao = (DAO) new DeletedAwareDAO(x, delegate);
 
         dao.put(
           new DeletedAwareDummy.Builder(x)
@@ -121,9 +116,7 @@ foam.CLASS({
       ],
       javaCode: `
         DAO delegate = new MDAO(DeletedAwareDummy.getOwnClassInfo());
-        DAO dao = (DAO) new DeletedAwareDAO.Builder(x)
-          .setDelegate(delegate)
-          .build();
+        DAO dao = (DAO) new DeletedAwareDAO(x, delegate);
 
         FObject object = new DeletedAwareDummy.Builder(x)
           .setId(1)
@@ -144,9 +137,7 @@ foam.CLASS({
       ],
       javaCode: `
         DAO delegate = new MDAO(DeletedAwareDummy.getOwnClassInfo());
-        DAO dao = (DAO) new DeletedAwareDAO.Builder(x)
-          .setDelegate(delegate)
-          .build();
+        DAO dao = (DAO) new DeletedAwareDAO(x, delegate);
 
         FObject object = new DeletedAwareDummy.Builder(x)
           .setId(1)

--- a/src/foam/nanos/auth/PermissionedPropertyDAO.js
+++ b/src/foam/nanos/auth/PermissionedPropertyDAO.js
@@ -16,7 +16,7 @@ foam.CLASS({
 
   documentation: `A DAO decorator that prevents users from updating / reading
       properties for which they do not have the update / read permission.
-      
+
       To require update / read permission on a property, set the permissionRequired
       to be true, and add the corresponding permissions,
       i.e. model.ro.prop / model.rw.prop to  the groups who are granted permissions
@@ -34,8 +34,8 @@ foam.CLASS({
     {
       name: 'find_',
       javaCode: `
-  FObject oldObj = getDelegate().find(id);
-  
+  FObject oldObj = getDelegate().find_(x, id);
+
   if ( oldObj != null ) {
     return hideProperties(x, oldObj);
   }
@@ -95,7 +95,7 @@ foam.CLASS({
     }
     propertyMap_.put(of, properties);
   }
-    
+
   return obj;
       `,
     },
@@ -137,7 +137,7 @@ foam.CLASS({
     }
     propertyMap_.put(of, properties);
   }
-    
+
   return obj;
       `,
     },
@@ -207,7 +207,7 @@ foam.CLASS({
     },
   ],
 });
-  
+
 foam.CLASS({
   package: 'foam.nanos.auth',
   name: 'HidePropertiesSink',


### PR DESCRIPTION
fixing deletedAware tests 
and fixing a bug in PermissionedPropertyDAO.js, where `find` instead of `find_` is being called on the delegate. This causes the delegates to get the system context and not the user context.