### PR TITLE
Fix bug related to toast notifications

### DIFF
--- a/src/foam/nanos/controller/ApplicationController.js
+++ b/src/foam/nanos/controller/ApplicationController.js
@@ -42,7 +42,6 @@ foam.CLASS({
     'foam.nanos.u2.navigation.FooterView',
     'foam.u2.stack.Stack',
     'foam.u2.stack.StackView',
-    'foam.u2.dialog.NotificationMessage',
     'foam.nanos.session.SessionTimer',
     'foam.u2.dialog.Popup'
   ],
@@ -321,7 +320,11 @@ foam.CLASS({
 
     // This method is for toast notification message
     function notify(message, type) {
-      this.add(this.NotificationMessage.create({ message, type }));
+      this.tag({
+        class: 'foam.u2.dialog.NotificationMessage',
+        message: message,
+        type: type
+      });
     }
   ],
 


### PR DESCRIPTION
We have a controller that extends `ApplicationController`, and in it we register an alternative view in place of `NotificationMessage`. That means that all child views should use the replacement view instead of `NotificationMessage` when trying to create one.

However, we primarily call the `notify` method to notify the user of something rather than add a `NotificationMessage` manually. And since the `notify` method is defined on `ApplicationController`, which `require`s 'foam.u2.dialog.NotificationMessage', the old view is being shown. I'm assuming this is because the require happens before our controller registers the view replacement.

This commit fixes the issue by creating the notification in a different way, specifically one in which the class will be looked up in the context _after_  the replacement has been registered.