### PR TITLE
Fix MultiPartIDs failing in merged journal entries.

### DIFF
--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -1764,8 +1764,7 @@ foam.CLASS({
   flags: ['java'],
 
   properties: [
-    // No point parsing it, multi part id is always transient.
-    ['javaJSONParser', 'new foam.lib.parse.Fail()'],
+    ['javaJSONParser', 'new foam.lib.json.FObjectParser()'],
     {
       name: 'javaGetter',
       factory: function() {


### PR DESCRIPTION
tl;dr: Can't replay journal updates with multipart ids because of journal diffing/merging.

Consider this example:

Journal starts with this put:
```
p({"class":"foam.nanos.auth.UserUserJunction","sourceId":101,"targetId":1000,"group":"admin"})
```
The `ID` of a `foam.nanos.auth.UserUserJunction` is a `foam.core.MultiPartID` on `sourceId` and `targetId`.

If I update this object, the journal entry looks like:
```
p({"class":"foam.nanos.auth.UserUserJunction","id":{"class":"foam.nanos.auth.UserUserJunctionId","sourceId":101,"targetId":1000},"status":1})
```
Which is the result of a call to `foam.lib.json.Outputter.stringifyDelta`.
This fails when replaying because the `javaJSONParser` of a `foam.core.MultiPartID` is `foam.lib.parse.Fail`. Changing it to `foam.lib.json.FObjectParser` fixes the issue but I'm not sure it's the right thing to do or if the `FileJournal` should be doing things differently.

What do y'all think?