### PR TITLE
Exclude relationship properties from search filter

### DIFF
--- a/src/foam/u2/search/FilterController.js
+++ b/src/foam/u2/search/FilterController.js
@@ -606,3 +606,33 @@ foam.CLASS({
     }
   ]
 });
+
+
+foam.CLASS({
+  package: 'foam.u2.search',
+  name: 'DAOPropertyRefinement',
+  refines: 'foam.dao.DAOProperty',
+
+  properties: [
+    {
+      class: 'foam.u2.ViewSpec',
+      name: 'searchView',
+      value: null
+    }
+  ]
+});
+
+
+foam.CLASS({
+  package: 'foam.u2.search',
+  name: 'ManyToManyRelationshipPropertyRefinement',
+  refines: 'foam.dao.ManyToManyRelationshipProperty',
+
+  properties: [
+    {
+      class: 'foam.u2.ViewSpec',
+      name: 'searchView',
+      value: null
+    }
+  ]
+});

--- a/src/foam/u2/view/ReciprocalSearch.js
+++ b/src/foam/u2/view/ReciprocalSearch.js
@@ -104,10 +104,7 @@ foam.CLASS({
         }
 
         return of.getAxiomsByClass(foam.core.Property)
-            .filter((prop) => prop.searchView
-              && ! prop.hidden
-              && ! foam.dao.OneToManyRelationshipProperty.isInstance(prop)
-              && ! foam.dao.ManyToManyRelationshipProperty.isInstance(prop))
+            .filter((prop) => prop.searchView && ! prop.hidden)
             .map(foam.core.Property.NAME.f);
       }
     },

--- a/src/foam/u2/view/ReciprocalSearch.js
+++ b/src/foam/u2/view/ReciprocalSearch.js
@@ -104,7 +104,10 @@ foam.CLASS({
         }
 
         return of.getAxiomsByClass(foam.core.Property)
-            .filter((prop) => prop.searchView && ! prop.hidden)
+            .filter((prop) => prop.searchView
+              && ! prop.hidden
+              && ! foam.dao.OneToManyRelationshipProperty.isInstance(prop)
+              && ! foam.dao.ManyToManyRelationshipProperty.isInstance(prop))
             .map(foam.core.Property.NAME.f);
       }
     },


### PR DESCRIPTION
The search filter uses GroupBy on properties however it doesn't make sense to GroupBy on a DAO property (aka. relationship).