### PR TITLE
XMl outputter format changes and bug fixes

### DIFF
--- a/src/foam/core/XML.js
+++ b/src/foam/core/XML.js
@@ -277,7 +277,7 @@ foam.CLASS({
             this.end('</' +  this.propertyName(p) + '>');
           }
         }
-      })
+      }, function(v, p) { this.outputPrimitive(v, p); })
     },
 
     function outputPrimitive(v, p){
@@ -356,10 +356,14 @@ foam.CLASS({
           }
         },
         Array: function(o, opt_cls) {
+
           this.start('<objects>\n');
           var cls = this.getCls(opt_cls);
+
           for ( var i = 0 ; i < o.length ; i++ ) {
+            this.start('<object>\n');
             this.output(o[i], cls);
+            this.start('\n</object>');
             if ( i < o.length-1 ) this.out('\n').nl().indent();
           }
           this.end('\n</objects>');

--- a/src/foam/core/stdlib.js
+++ b/src/foam/core/stdlib.js
@@ -940,9 +940,7 @@ foam.LIB({
               'and no deafult method provided');
         }
 
-        if ( type[uid] || opt_defaultMethod ) {
           return ( type[uid] || opt_defaultMethod ).apply(this, arguments);
-        }
       };
       // The native toString on the function that's returned will never work on
       // its own because the args and vars declared above it won't exist so

--- a/src/foam/lib/xml/Outputter.java
+++ b/src/foam/lib/xml/Outputter.java
@@ -93,8 +93,11 @@ public class Outputter
     } else if ( isArray(value) ) {
       if ( value.getClass().equals(byte[][].class) )
         outputByteArray((byte[][]) value);
-      else
+      else {
+        writer_.append("<objects>");
         outputArray((Object[]) value);
+        writer_.append("</objects>");
+      }
     }
   }
 
@@ -109,9 +112,9 @@ public class Outputter
   }
 
   protected void outputFObject(FObject obj) {
-    writer_.append("<").append(obj.getClass().getSimpleName()).append(">");
+    writer_.append("<object>");
     outputProperties_(obj);
-    writer_.append("</").append(obj.getClass().getSimpleName()).append(">");
+    writer_.append("</object>");
   }
 
   protected void outputNumber(Number value) {

--- a/src/foam/nanos/dig/DigWebAgent.java
+++ b/src/foam/nanos/dig/DigWebAgent.java
@@ -156,6 +156,9 @@ public class DigWebAgent
           XMLSupport      xmlSupport = new XMLSupport();
           XMLInputFactory factory    = XMLInputFactory.newInstance();
 
+          resp.setContentType("Content-Type: application/xml;");
+          foam.lib.xml.Outputter outputterXml = new foam.lib.xml.Outputter(OutputterMode.NETWORK);
+
           if ( SafetyUtil.isEmpty(data) ) {
             DigErrorMessage error = new EmptyDataException.Builder(x)
               .build();
@@ -182,9 +185,10 @@ public class DigWebAgent
           while ( i.hasNext() ) {
             obj = (FObject)i.next();
             obj = dao.put(obj);
+            outputterXml.output(obj);
           }
 
-          //returnMessage = "<objects>" + success + "</objects>";
+          out.println(outputterXml);
         } else if ( Format.CSV == format ) {
           if ( SafetyUtil.isEmpty(data) && SafetyUtil.isEmpty(fileAddress) ) {
             DigErrorMessage error = new EmptyDataException.Builder(x)
@@ -195,6 +199,7 @@ public class DigWebAgent
 
           CSVSupport csvSupport = new CSVSupport();
           csvSupport.setX(x);
+          foam.lib.csv.Outputter outputterCsv = new foam.lib.csv.Outputter(OutputterMode.NETWORK);
 
           ArraySink arraySink = new ArraySink();
 
@@ -229,9 +234,15 @@ public class DigWebAgent
             return;
           }
 
+          if ( list.size() > 0 )
+            outputterCsv.output(list.toArray());
+
           for ( int i = 0 ; i < list.size() ; i++ ) {
             dao.put((FObject) list.get(i));
+            outputterCsv.put((FObject) list.get(i), null);
           }
+
+          out.println(outputterCsv);
         } else if ( Format.HTML == format ) {
           DigErrorMessage error = new UnsupportException.Builder(x)
                                         .setMessage("Unsupported Format: " + format)
@@ -301,7 +312,6 @@ public class DigWebAgent
             return;
           }
         }
-        out.println(returnMessage);
       } else if ( Command.select == command ) {
         PropertyInfo idProp = (PropertyInfo) cInfo.getAxiomByName("id");
         ArraySink sink = (ArraySink) ( ! SafetyUtil.isEmpty(id) ?
@@ -335,12 +345,12 @@ public class DigWebAgent
             foam.lib.xml.Outputter outputterXml = new foam.lib.xml.Outputter(OutputterMode.NETWORK);
             outputterXml.output(sink.getArray().toArray());
 
-            resp.setContentType("application/xml");
+            resp.setContentType("Content-Type: application/xml;");
+
             if ( emailSet ) {
               output(x, "<textarea style=\"width:700;height:400;\" rows=10 cols=120>" + outputterXml.toString() + "</textarea>");
             } else {
-              String simpleName = cInfo.getObjClass().getSimpleName().toString();
-              out.println("<" + simpleName + "s>"+ outputterXml.toString() + "</" + simpleName + "s>");
+              out.println(outputterXml.toString());
             }
           } else if ( Format.CSV == format ) {
             foam.lib.csv.Outputter outputterCsv = new foam.lib.csv.Outputter(OutputterMode.NETWORK);


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/CPF-201

1. XMl outputter format changes on java & js, so now printed out like this format:
 <objcets><object></object><object></object></objects>

<img width="336" alt="screen shot 2019-02-19 at 11 44 14 am" src="https://user-images.githubusercontent.com/33228583/53043087-b2e92880-3455-11e9-920e-b6eee8256138.png">


2. failing Export xml fixed

3. when Dig data put, after it's gone successfully with CSV, XML, it returns input data as Json does.