### PR TITLE
sendTo - on emailTemplate

### DIFF
--- a/src/foam/nanos/notification/email/DAOEmailService.js
+++ b/src/foam/nanos/notification/email/DAOEmailService.js
@@ -127,7 +127,7 @@ if (foam.util.SafetyUtil.isEmpty(emailMessage.getSubject())) {
 // and sendTo is provided in the template, use the sendTo from template
 String sendTo = emailTemplate.getSendTo();
 if ( foam.util.SafetyUtil.isEmpty(emailMessage.getTo()) &&
-! foam.util.SafetyUtil.isEmpty(emailTemplate.getsendTo()) ) {
+  ! foam.util.SafetyUtil.isEmpty(emailTemplate.getsendTo()) ) {
   emailMessage.setTo(new String[] {sendTo});
 }
 

--- a/src/foam/nanos/notification/email/DAOEmailService.js
+++ b/src/foam/nanos/notification/email/DAOEmailService.js
@@ -123,10 +123,16 @@ if (foam.util.SafetyUtil.isEmpty(emailMessage.getSubject())) {
   emailMessage.setSubject(templateSubject.render(model));
 }
 
+// If emailTemplate has a send To address use that.
+String sendTo = emailTemplate.getSendTo();
+if (sendTo != null && !foam.util.SafetyUtil.isEmpty(sendTo)) {
+  emailMessage.setTo(new String[] {sendTo});
+}
+
 // If the displayName doesn't set in the message
 // and the displayName provided in the template, use the displayName from template
 if ( foam.util.SafetyUtil.isEmpty(emailMessage.getDisplayName()) &&
-     ! foam.util.SafetyUtil.isEmpty(emailTemplate.getDisplayName()) ) {
+  ! foam.util.SafetyUtil.isEmpty(emailTemplate.getDisplayName()) ) {
   JtwigTemplate templateDisplayName = JtwigTemplate.inlineTemplate(emailTemplate.getDisplayName(), config);
   emailMessage.setDisplayName(templateDisplayName.render(model));
 }

--- a/src/foam/nanos/notification/email/DAOEmailService.js
+++ b/src/foam/nanos/notification/email/DAOEmailService.js
@@ -123,9 +123,11 @@ if (foam.util.SafetyUtil.isEmpty(emailMessage.getSubject())) {
   emailMessage.setSubject(templateSubject.render(model));
 }
 
-// If emailTemplate has a send To address use that.
+// If sendTo isn't set in the message
+// and sendTo is provided in the template, use the sendTo from template
 String sendTo = emailTemplate.getSendTo();
-if (sendTo != null && !foam.util.SafetyUtil.isEmpty(sendTo)) {
+if ( foam.util.SafetyUtil.isEmpty(emailMessage.getTo()) &&
+! foam.util.SafetyUtil.isEmpty(emailTemplate.getsendTo()) ) {
   emailMessage.setTo(new String[] {sendTo});
 }
 

--- a/src/foam/nanos/notification/email/EmailTemplate.js
+++ b/src/foam/nanos/notification/email/EmailTemplate.js
@@ -58,6 +58,11 @@ bodyAsByteArrayIsSet_ = false;`
     {
       class: 'String',
       name: 'displayName'
+    },
+    {
+      class: 'String',
+      name: 'sendTo',
+      documentation: `This property will set who the email is being sent too.`
     }
   ]
 });


### PR DESCRIPTION
adding property and functionality for setting sendTo on email templates

Requirement Came From:

Needing to send an email to a specific address. The work around was to hard code the emailMessage and the address, and use the emailService.sendEmail(x,EmailMessage).

However this is not a dynamic or scalable solution.

So instead by adding the sendTo property in the emailTemplate we can now specify the default address to send an email to, use the existing emailService.sendEmailFromTemplate(...) and have one location where email information exists (templates).