### PR TITLE
HttpServer: Check nanos.webroot for ResourceBase, or compute from JAR.

### DIFF
--- a/nanos.in
+++ b/nanos.in
@@ -47,4 +47,4 @@ fi
 
 shift $(($OPTIND - 1))
 
-exec java $DEBUG_ARGS -cp @CLASSPATH@$EXTRA_CP foam.nanos.boot.Boot "$@"
+exec java $DEBUG_ARGS -Dnanos.webroot="$PWD" -cp @CLASSPATH@$EXTRA_CP foam.nanos.boot.Boot "$@"

--- a/src/foam/nanos/jetty/HttpServer.js
+++ b/src/foam/nanos/jetty/HttpServer.js
@@ -78,7 +78,13 @@ foam.CLASS({
         org.eclipse.jetty.servlet.ServletContextHandler handler =
           new org.eclipse.jetty.servlet.ServletContextHandler();
 
-        handler.setResourceBase(System.getProperty("user.dir"));
+        String root = System.getProperty("nanos.webroot");
+        if ( root == null ) {
+          root = this.getClass().getResource("/webroot/index.html").toExternalForm();
+          root = root.substring(0, root.lastIndexOf("/"));
+        }
+
+        handler.setResourceBase(root);
         handler.setWelcomeFiles(getWelcomeFiles());
 
         handler.setAttribute("X", getX());


### PR DESCRIPTION
If the SystemProperty nanos.webroot is set, we use that as the resource base for the web server.

Otherwise we try to look for /webroot/index.html inside the running JAR, or wherever the current ClassLoader thinks it should find resources.