### PR TITLE
Email message view update closing cpf-352

### DIFF
--- a/src/foam/nanos/notification/email/EmailMessage.js
+++ b/src/foam/nanos/notification/email/EmailMessage.js
@@ -49,7 +49,12 @@ foam.CLASS({
     },
     {
       class: 'String',
-      name: 'body'
+      name: 'body',
+      view: {
+        class: 'foam.u2.view.DualView',
+        viewa: { class: 'foam.u2.HTMLView' },
+        viewb: { class: 'foam.u2.tag.TextArea', rows: 30, cols: 130 }
+      }
     },
     {
       class: 'String',

--- a/src/foam/nanos/notification/email/EmailMessage.js
+++ b/src/foam/nanos/notification/email/EmailMessage.js
@@ -51,9 +51,11 @@ foam.CLASS({
       class: 'String',
       name: 'body',
       view: {
-        class: 'foam.u2.view.DualView',
-        viewa: { class: 'foam.u2.HTMLView' },
-        viewb: { class: 'foam.u2.tag.TextArea', rows: 30, cols: 130 }
+        class: 'foam.u2.MultiView',
+        views: [
+          { class: 'foam.u2.HTMLView' },
+          { class: 'foam.u2.tag.TextArea', rows: 30, cols: 130 }
+        ]
       }
     },
     {


### PR DESCRIPTION
Requirement avoid email spamming by being able to view email at:
http://localhost:8080/ --> services --> emailMessageDAO --> configure --> dbClick entry

there is one more thing we need before asking dev team to stop turning on smtp: https://nanopay.atlassian.net/browse/CPF-360

cpf-352 #comment reliant on https://github.com/foam-framework/foam2/pull/1937
cpf-352 #In Review

![image](https://user-images.githubusercontent.com/10802216/53431003-a7e64900-39bd-11e9-969b-e58b565ef1b5.png)



Image in above is broken for a reason that is not related to this PR. Will fix