### PR TITLE
Make scrolling speed proportional to input

### DIFF
--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -87,10 +87,9 @@
       `
     },
     {
-      type: 'Int',
+      class: 'Int',
       name: 'accumulator',
-      value: 0,
-      documentation: `Used internally to mimic native scrolling speed.`,
+      documentation: 'Used internally to mimic native scrolling speed.',
       adapt: function(_, v) {
         return v % this.rowHeight;
       }

--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -85,6 +85,15 @@
       documentation: `
         A reference to the table element we use in the fitInScreen calculations.
       `
+    },
+    {
+      type: 'Int',
+      name: 'accumulator',
+      value: 0,
+      documentation: `Used internally to mimic native scrolling speed.`,
+      adapt: function(_, v) {
+        return v % this.rowHeight;
+      }
     }
   ],
 
@@ -141,11 +150,10 @@
       name: 'onWheel',
       code: function(e) {
         var negative = e.deltaY < 0;
-        // Convert to rows, rounding up. (Therefore minumum 1.)
-        var rows = Math.ceil(Math.abs(e.deltaY) / 40);
-        var oldSkip = this.skip;
+        var rows = Math.floor(Math.abs(this.accumulator + e.deltaY) / this.rowHeight);
+        this.accumulator += e.deltaY;
         this.skip = Math.max(0, this.skip + (negative ? -rows : rows));
-        if ( e.deltaY !== 0 && oldSkip != this.skip ) e.preventDefault();
+        if ( e.deltaY !== 0 ) e.preventDefault();
       }
     },
     {


### PR DESCRIPTION
Before this change, every single wheel event would scroll by at least 1 row. That made it difficult to scroll small amounts since even tiny gestures on a trackpad would cause several rows to be skipped.

This PR changes that behaviour so that it keeps track of the deltas from the events and only changes the rows when the delta is greater than or equal to the height of 1 row. This makes it much easier to control how fast you want to scroll.