### PR TITLE
Add agent id to session

### DIFF
--- a/src/foam/nanos/auth/AgentUserAuthService.java
+++ b/src/foam/nanos/auth/AgentUserAuthService.java
@@ -82,7 +82,7 @@ public class AgentUserAuthService
     // Set user and agent objects into the session context and place into sessionDAO.
     Session session = x.get(Session.class);
     session.setUserId(user.getId());
-    session.setUserId(agent.getId());
+    session.setAgentId(agent.getId());
     session.setContext(session.getContext().put("user", user));
     session.setContext(session.getContext().put("agent", agent));
     return user;

--- a/src/foam/nanos/auth/AgentUserAuthService.java
+++ b/src/foam/nanos/auth/AgentUserAuthService.java
@@ -82,6 +82,7 @@ public class AgentUserAuthService
     // Set user and agent objects into the session context and place into sessionDAO.
     Session session = x.get(Session.class);
     session.setUserId(user.getId());
+    session.setUserId(agent.getId());
     session.setContext(session.getContext().put("user", user));
     session.setContext(session.getContext().put("agent", agent));
     return user;

--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -29,6 +29,17 @@ foam.CLASS({
       }
     },
     {
+      class: 'Long',
+      name: 'agentId',
+      tableCellFormatter: function(value, obj) {
+        if ( ! value ) return;
+        this.add(value);
+        this.__context__.userDAO.find(value).then(function(user) {
+          this.add(' ', user.label());
+        }.bind(this));
+      }
+    },
+    {
       class: 'DateTime',
       name: 'created',
       factory: function() { return new Date(); },


### PR DESCRIPTION
Without the agent id, there's no way to tell the difference between two
sessions where user A and user B are both acting as user C because only
the id of user C is saved on the session. This makes it impossible to
query the sessions where a particular user is an agent.

Originally I thought we could just set the userId to the agent's id, but
that would break a large number of places that expect the userId on the
session to be set to what it's currently set to.

Required for https://nanopay.atlassian.net/browse/CPF-188