### PR TITLE
Java Enum generation changes

### DIFF
--- a/src/foam/java/Enum.js
+++ b/src/foam/java/Enum.js
@@ -27,109 +27,15 @@ foam.CLASS({
       value: true
     },
     {
-      name: 'labelsOutput',
-      expression: function() {
-        var out = 'return new String[] { ';
-
-        for ( var i = 0, value ; value = this.values[i] ; i++ ) {
-          out += this.labelForValue(value);
-          if ( i < this.values.length - 1 ) out += ', ';
-        }
-
-        out += ' };';
-
-        return out;
-      }
-    },
-    {
-      name: 'forOrdinal',
-      expression: function() {
-        var out = 'switch (ordinal) {\n';
-
-        for ( var i = 0, value ; value = this.values[i] ; i++ ) {
-          out += '  case ' + value.ordinal + ': return ' + this.name + '.' + value.name + ';\n';
-        }
-
-        out += '}\nreturn null;';
-
-        return out;
-      }
-    },
-    {
-      name: 'forLabel',
-      expression: function() {
-        var out = 'switch (label) {\n';
-
-        for ( var i = 0, value ; value = this.values[i] ; i++ ) {
-          out += '  case ' + '"' + value.label + '"' +
-                  ': return ' + this.name + '.' + value.name + ';\n';
-        }
-
-        out += '}\nreturn null;';
-
-        return out;
-      }
-    },
-    {
-      name: 'methods',
-      factory: function() {
-        return [
-          {
-            name: this.name,
-            args: [
-              {
-                name: 'ordinal',
-                type: 'int'
-              },
-              {
-                name: 'label',
-                type: 'String'
-              },
-            ],
-            body: 'setOrdinal(ordinal);\nsetLabel(label);\nsetName(name());'
-          },
-          {
-            name: 'forOrdinal',
-            type: this.name,
-            visibility: 'public',
-            static: true,
-            args: [ { name: 'ordinal', type: 'int' } ],
-            body: this.forOrdinal
-          },
-          {
-            name: 'forLabel',
-            type: this.name,
-            visibility: 'public',
-            static: true,
-            args: [ { name: 'label', type: 'String' } ],
-            body: this.forLabel
-          },
-          {
-            name: 'labels',
-            type: 'String[]',
-            visibility: 'public',
-            static: true,
-            body: this.labelsOutput
-          }
-        ]
-      }
+      class: 'String',
+      name: 'declarations'
     }
   ],
 
   methods: [
-    function labelForValue(value) {
-      return '"' + value.label + '"';
-    },
     function writeDeclarations(o) {
       o.indent();
-
-      // Outputs declared enums
-      for ( var i = 0 ; i < this.values.length ; i++ ) {
-        var value = this.values[i];
-        o.out(value.name, '(', value.ordinal, ',', this.labelForValue(value),')');
-        o.out(( i == this.values.length - 1 ) ? ';\n\n' : ', ');
-      }
-
+      o.out(this.declarations, ';\n\n');
       this.out = o;
     }
   ]


### PR DESCRIPTION
- Move the logic for putting the methods together from Enum.js to refinements.js because this seems like the more standard place for the model -> java logic and this keeps the foam.java.Enum more "dumb". (plus a `values` property was being set that isn't actually a thing so I'm a little surprised this worked to begin with :p)
- Generate all of the properties for enums which now includes documentation and can include any custom properties added to an enum.