### PR TITLE
Filter out permissioned property as arguments

### DIFF
--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -329,6 +329,32 @@ foam.INTERFACE({
       flags: ['js', 'java'],
       javaSupport: false,
       type: 'foam.mlang.predicate.Predicate',
+    },
+    {
+      name:'authorize',
+      flags: [ 'java' ],
+      type: 'Boolean',
+      args:[
+        {
+          name: 'x',
+          type: 'Context'
+        }
+      ]
+    },
+    {
+      name:'authorizeArg',
+      flags: [ 'java'],
+      type: 'Boolean',
+      args:[
+        {
+          name: 'x',
+          type: 'Context'
+        },
+        {
+          name: 'arg',
+          type: 'foam.mlang.Expr'
+        }
+      ]
     }
   ]
 });
@@ -390,6 +416,9 @@ foam.CLASS({
   name: 'AbstractPredicate',
   abstract: true,
   implements: [ 'foam.mlang.predicate.Predicate' ],
+  javaImports: [
+    'foam.nanos.auth.AuthService',
+  ],
 
   documentation: 'Abstract Predicate base-class.',
 
@@ -457,6 +486,27 @@ foam.CLASS({
       ],
       javaCode: '//noop',
       swiftCode: '//noop'
+    },
+    {
+      name: 'authorize',
+      javaCode:`
+  return true;
+  `
+    },
+    {
+      name:'authorizeArg',
+      javaCode:`
+  if ( arg instanceof foam.core.PropertyInfo ) {
+    foam.core.PropertyInfo prop =  (foam.core.PropertyInfo) arg;
+
+    if ( prop.getPermissionRequired() ) {
+      AuthService auth = (AuthService) x.get("auth");
+      return auth.check(x, prop.getClassInfo().getObjClass().getSimpleName() + ".rw." + prop.getName()) || auth.check(x, prop.getClassInfo().getObjClass().getSimpleName() + ".ro." + prop.getName());
+    }
+  }
+
+  return true;
+  `
     }
   ]
 });
@@ -570,6 +620,12 @@ foam.CLASS({
     {
       name: 'prepareStatement',
       javaCode: 'getArg1().prepareStatement(stmt);'
+    },
+    {
+      name: 'authorize',
+      javaCode:`
+  return authorizeArg(x, getArg1());
+  `
     }
   ]
 });
@@ -616,6 +672,12 @@ foam.CLASS({
       name: 'prepareStatement',
       javaCode: `getArg1().prepareStatement(stmt);
 getArg2().prepareStatement(stmt);`
+    },
+    {
+      name: 'authorize',
+      javaCode:`
+  return authorizeArg(x, getArg1()) && authorizeArg(x, getArg2());
+  `
     }
   ]
 });
@@ -665,6 +727,15 @@ foam.CLASS({
       javaCode:`for ( Predicate predicate : getArgs() ) {
   predicate.prepareStatement(stmt);
 }`
+    },
+    {
+      name: 'authorize',
+      javaCode:`
+  for ( Predicate predicate : getArgs() ) {
+    if ( ! predicate.authorize(x) ) return false;
+  }
+  return true;
+  `
     }
   ]
 });
@@ -1995,6 +2066,12 @@ return this;`
       name: 'prepareStatement',
       javaCode: 'getArg1().prepareStatement(stmt);'
     },
+    {
+      name: 'authorize',
+      javaCode:`
+  return getArg1().authorize(x);
+  `
+    }
 
 
     /*

--- a/src/foam/nanos/auth/PermissionedPropertyDAO.js
+++ b/src/foam/nanos/auth/PermissionedPropertyDAO.js
@@ -49,7 +49,7 @@ foam.CLASS({
       javaCode: `
       if ( x.get("auth") != null ) {
         if ( predicate != null && ! predicate.authorize(x) ) {
-          throw new AuthenticationException("You do not have access to the querying property / properties");
+          throw new AuthenticationException("Access denied: property protected");
         }
         foam.dao.Sink sink2 = ( sink != null ) ? new HidePropertiesSink(x, sink, this) : sink;
         super.select_(x, sink2, skip, limit, order, predicate);

--- a/src/foam/nanos/auth/PermissionedPropertyDAO.js
+++ b/src/foam/nanos/auth/PermissionedPropertyDAO.js
@@ -49,7 +49,7 @@ foam.CLASS({
       javaCode: `
       if ( x.get("auth") != null ) {
         if ( predicate != null && ! predicate.authorize(x) ) {
-          return super.select_(x, sink, skip, limit, order,  new foam.mlang.predicate.True());
+          throw new AuthenticationException("You do not have access to the querying property / properties");
         }
         foam.dao.Sink sink2 = ( sink != null ) ? new HidePropertiesSink(x, sink, this) : sink;
         super.select_(x, sink2, skip, limit, order, predicate);

--- a/src/foam/nanos/auth/PermissionedPropertyDAO.js
+++ b/src/foam/nanos/auth/PermissionedPropertyDAO.js
@@ -48,6 +48,9 @@ foam.CLASS({
       name: 'select_',
       javaCode: `
       if ( x.get("auth") != null ) {
+        if ( predicate != null && ! predicate.authorize(x) ) {
+          return super.select_(x, sink, skip, limit, order,  new foam.mlang.predicate.True());
+        }
         foam.dao.Sink sink2 = ( sink != null ) ? new HidePropertiesSink(x, sink, this) : sink;
         super.select_(x, sink2, skip, limit, order, predicate);
         return sink;


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/CPF-12
When permissioned properties as passed in as predicate arguments, and the user doesn't have the permission, then replace the predicate with TRUE.