### PR TITLE
CSV Outputter

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -193,6 +193,7 @@ FOAM_FILES([
   { name: "foam/dao/FilteredDAO" },
   { name: "foam/dao/DAOProperty" },
   { name: "foam/dao/SQLStatement" },
+  { name: "foam/dao/CSVSink" },
   { name: "foam/mlang/order/Comparator" },
 //  { name: "foam/mlang/order/ComparatorJava", flags: ['java'] },
   { name: "foam/mlang/mlang" },

--- a/src/foam/comics/DAOController.js
+++ b/src/foam/comics/DAOController.js
@@ -92,7 +92,7 @@ foam.CLASS({
       class: 'Boolean',
       name: 'exportCSVEnabled',
       documentation: 'True to enable export csv button',
-      value: false
+      value: true
     },
     {
       class: 'Boolean',

--- a/src/foam/comics/DAOController.js
+++ b/src/foam/comics/DAOController.js
@@ -91,8 +91,7 @@ foam.CLASS({
     {
       class: 'Boolean',
       name: 'exportCSVEnabled',
-      documentation: 'True to enable export csv button',
-      value: true
+      documentation: 'True to enable export csv button'
     },
     {
       class: 'Boolean',

--- a/src/foam/dao/CSVSink.js
+++ b/src/foam/dao/CSVSink.js
@@ -1,0 +1,13 @@
+foam.CLASS({
+  package: 'foam.dao',
+  name: 'CSVSink',
+  extends: 'foam.dao.AbstractSink',
+  properties: [
+    {
+      class: 'String',
+      name: 'csv',
+      view: 'foam.u2.tag.TextArea',
+      value: 'TODO'
+    }
+  ]
+});

--- a/src/foam/dao/CSVSink.js
+++ b/src/foam/dao/CSVSink.js
@@ -2,12 +2,171 @@ foam.CLASS({
   package: 'foam.dao',
   name: 'CSVSink',
   extends: 'foam.dao.AbstractSink',
+
+  documentation: ``,
+
+  requires: [
+    'foam.core.FObject',
+    'foam.dao.AbstractSink',
+    'foam.lib.json.OutputterMode',
+    'foam.util.SafetyUtil'
+  ],
+
   properties: [
     {
       class: 'String',
       name: 'csv',
-      view: 'foam.u2.tag.TextArea',
-      value: 'TODO'
+      view: 'foam.u2.tag.TextArea'
+    },
+    {
+      class: 'Class',
+      name: 'of',
+      visibility: 'HIDDEN'
+    },
+    {
+      name: 'props',
+      expression: function(of) {
+        return of.getAxiomsByClass(foam.core.Property)
+          .filter( (p) => ! p.transient || ! p.storageTransient );
+      },
+      visibility: 'HIDDEN'
+    },
+    {
+      class: 'Boolean',
+      name: 'isHeadersOutput',
+      visibility: 'HIDDEN'
+    },
+    {
+      class: 'Boolean',
+      name: 'isNewLine',
+      value: true,
+      visibility: 'HIDDEN'
+    }
+  ],
+
+  methods: [
+    function output(value) {
+      if ( ! this.isNewLine ) this.csv += ',';
+      this.isNewLine = false;
+      this.output_(value);
+    },
+    {
+      name: 'output_',
+      code:
+        foam.mmethod(
+          {
+            String: function(value) {
+              this.csv += `"${value.replace(/\"/g, '""')}"`;
+            },
+            Number: function(value) {
+              this.csv += value.toString();
+            },
+            Boolean: function(value) {
+              this.csv += value.toString();
+            },
+            Date: function(value) {
+              this.output_(value.toDateString());
+            },
+            FObject: function(value) {
+              this.output_(foam.json.Pretty.stringify(value));
+            },
+            Array: function(value) {
+              this.output_(foam.json.Pretty.stringify(value));
+            },
+            Undefined: function(value) {},
+            Null: function(value) {}
+          }, function(value) {
+            this.output_(value.toString());
+          })
+    },
+
+    function newLine_() {
+      this.csv += '\n';
+      this.isNewLine = true;
+    },
+
+    function put(obj) {
+      if ( ! this.of ) this.of = obj.cls_;
+
+      if ( ! this.isHeadersOutput ) {
+        this.props.forEach((element) => {
+          element.toCSVLabel(this, element);
+        });
+        this.newLine_();
+        this.isHeadersOutput = true;
+      }
+
+      this.props.forEach((element) => {
+        element.toCSV(obj, this, element);
+      });
+      this.newLine_();
+    },
+
+    function reset() {
+      ['csv', 'isNewLine', 'isHeadersOutput']
+        .forEach( (s) => this.clearProperty(s) );
+      return this;
+    }
+  ]
+});
+
+foam.CLASS({
+  package: 'foam.dao',
+  name: 'PropertyCSVRefinement',
+
+  refines: 'foam.core.Property',
+
+  properties: [
+    {
+      name: 'toCSV',
+      class: 'Function',
+      value: function(obj, outputter, prop) {
+        outputter.output(obj ? obj[prop.name] : null);
+      }
+    },
+    {
+      name: 'toCSVLabel',
+      class: 'Function',
+      value: function(outputter, prop) {
+        outputter.output(prop.name);
+      }
+    }
+  ]
+});
+
+foam.CLASS({
+  package: 'foam.dao',
+  name: 'FObjectPropertyCSVRefinement',
+
+  refines: 'foam.core.FObjectProperty',
+
+  properties: [
+    {
+      name: 'toCSV',
+      class: 'Function',
+      value: function(obj, outputter, prop) {
+        if ( ! prop.of ) return; // TODO JSON
+        prop.of.getAxiomsByClass(foam.core.Property)
+          .forEach((axiom) => {
+            axiom.toCSV(obj ? obj[prop.name] : null, outputter, axiom);
+          });
+      }
+    },
+    {
+      name: 'toCSVLabel',
+      class: 'Function',
+      value: function(outputter, prop) {
+        if ( ! prop.of ) return; // TODO JSON
+        var prefixedOutputter = {
+          output: function(value) {
+            outputter.output(`${prop.name}.${value}`);
+          }
+        };
+        prop.of.getAxiomsByClass(foam.core.Property)
+          .forEach((axiom) => {
+            axiom.toCSVLabel(prefixedOutputter, axiom);
+          });
+      }
     }
   ]
 });

--- a/src/foam/dao/CSVSink.js
+++ b/src/foam/dao/CSVSink.js
@@ -3,7 +3,7 @@ foam.CLASS({
   name: 'CSVSink',
   extends: 'foam.dao.AbstractSink',
 
-  documentation: `Sink runs the csv outputter, and contains the resulting string in this.csv`,
+  documentation: 'Sink runs the csv outputter, and contains the resulting string in this.csv',
 
   properties: [
     {

--- a/src/foam/dao/CSVSink.js
+++ b/src/foam/dao/CSVSink.js
@@ -20,7 +20,7 @@ foam.CLASS({
       name: 'props',
       expression: function(of) {
         return of.getAxiomsByClass(foam.core.Property)
-          .filter( (p) => ! p.transient || ! p.storageTransient );
+          .filter( (p) => ! p.networkTransient );
       },
       visibility: 'HIDDEN'
     },

--- a/src/foam/dao/CSVSink.js
+++ b/src/foam/dao/CSVSink.js
@@ -163,7 +163,7 @@ foam.CLASS({
         // mini decorator
         var prefixedOutputter = {
           output: function(value) {
-            outputter.output(`${prop.name}.${value}`);
+            outputter.output(prop.name + '.' + value);
           }
         };
         prop.of.getAxiomsByClass(foam.core.Property)

--- a/src/foam/nanos/export/CSVDriver.js
+++ b/src/foam/nanos/export/CSVDriver.js
@@ -31,6 +31,8 @@ foam.CLASS({
     function exportDAO(X, dao) {
       var sink = this.CSVSink.create();
       sink.reset();
+      // passing in our CSVSink runs our CSV outputter and
+      // s.csv is accessing our csv property string.
       return dao.select(sink).then( (s) => s.csv);
     }
   ]

--- a/src/foam/nanos/export/CSVDriver.js
+++ b/src/foam/nanos/export/CSVDriver.js
@@ -9,6 +9,10 @@ foam.CLASS({
   name: 'CSVDriver',
   implements: [ 'foam.nanos.export.ExportDriver' ],
 
+  requires: [
+    'foam.dao.CSVSink'
+  ],
+
   documentation: 'Class for exporting data from a DAO to CSV',
 
   properties: [
@@ -25,10 +29,9 @@ foam.CLASS({
       return this.outputter.toCSV(obj);
     },
     function exportDAO(X, dao) {
-      var self = this;
-      return dao.select().then(function (sink) {
-        return self.outputter.toCSV(sink.array);
-      });
+      var sink = this.CSVSink.create();
+      sink.reset();
+      return dao.select(sink).then( (s) => s.csv);
     }
   ]
 });

--- a/src/foam/test/CSVSinkDemo.js
+++ b/src/foam/test/CSVSinkDemo.js
@@ -1,0 +1,68 @@
+foam.CLASS({
+  package: 'foam.test',
+  name: 'CSVSinkDemo',
+  requires: [
+    'foam.dao.CSVSink',
+    'foam.dao.EasyDAO'
+  ],
+  properties: [
+    {
+      class: 'foam.dao.DAOProperty',
+      name: 'dao',
+      factory: function() {
+        return this.EasyDAO.create({
+          daoType: 'MDAO',
+          of: this.TestModel,
+          seqNo: true
+        });
+      }
+    },
+    {
+      class: 'FObjectProperty',
+      of: 'foam.dao.CSVSink',
+      name: 'sink',
+      factory: function() {
+        return this.CSVSink.create();
+      }
+    }
+  ],
+  classes: [
+    {
+      name: 'TestModel',
+      properties: [
+        {
+          class: 'Int',
+          name: 'id'
+        },
+        {
+          class: 'String',
+          name: 'str'
+        },
+        {
+          class: 'Boolean',
+          name: 'bool'
+        }
+      ]
+    }
+  ],
+  actions: [
+    {
+      name: 'toCsv',
+      code: function() {
+        this.sink.reset();
+        this.dao.select(this.sink);
+      }
+    },
+    {
+      name: 'fillDAO',
+      code: function() {
+        for ( var i = 0 ; i < 100 ; i++ ) {
+          this.dao.put(this.TestModel.create({
+            str: 'Random data ' + i,
+            bool: Math.random() < 0.5
+          }));
+        }
+      }
+    }
+  ]
+});

--- a/src/foam/test/CSVSinkDemo.js
+++ b/src/foam/test/CSVSinkDemo.js
@@ -1,10 +1,13 @@
 foam.CLASS({
   package: 'foam.test',
   name: 'CSVSinkDemo',
+
   requires: [
     'foam.dao.CSVSink',
-    'foam.dao.EasyDAO'
+    'foam.dao.EasyDAO',
+    'foam.nanos.auth.Phone'
   ],
+
   properties: [
     {
       class: 'foam.dao.DAOProperty',
@@ -22,10 +25,11 @@ foam.CLASS({
       of: 'foam.dao.CSVSink',
       name: 'sink',
       factory: function() {
-        return this.CSVSink.create();
+        return this.CSVSink.create({ of: this.TestModel });
       }
     }
   ],
+
   classes: [
     {
       name: 'TestModel',
@@ -41,10 +45,20 @@ foam.CLASS({
         {
           class: 'Boolean',
           name: 'bool'
+        },
+        {
+          class: 'Array',
+          name: 'arr'
+        },
+        {
+          class: 'FObjectProperty',
+          name: 'fop',
+          of: 'foam.nanos.auth.Phone'
         }
       ]
     }
   ],
+
   actions: [
     {
       name: 'toCsv',
@@ -59,7 +73,9 @@ foam.CLASS({
         for ( var i = 0 ; i < 100 ; i++ ) {
           this.dao.put(this.TestModel.create({
             str: 'Random data ' + i,
-            bool: Math.random() < 0.5
+            bool: Math.random() < 0.5,
+            arr: [Math.random()],
+            fop: this.Phone.create({ number: '111-111-1111' })
           }));
         }
       }

--- a/src/foam/u2/ExportModal.js
+++ b/src/foam/u2/ExportModal.js
@@ -93,9 +93,11 @@ foam.CLASS({
       exportDriver = foam.lookup(exportDriver.driverName).create();
 
       if ( this.exportData ) {
-        this.note = await exportDriver.exportDAO(this.__context__, this.exportData);
+        this.note = await exportDriver
+          .exportDAO(this.__context__, this.exportData);
       } else {
-        this.note = await exportDriver.exportFObject(this.__context__, this.exportObj);
+        this.note = await exportDriver
+          .exportFObject(this.__context__, this.exportObj);
       }
     },
 
@@ -103,22 +105,16 @@ foam.CLASS({
       var exportDriver = await this.exportDriverRegistryDAO.find(this.dataType);
       exportDriver = foam.lookup(exportDriver.driverName).create();
 
-      this.downloadCSVv(this.exportData, exportDriver);
-    }
-  ],
-
-  listeners: [
-    function downloadCSVv(data, exportDriver) {
       exportDriver.exportDAO(this.__context__, this.exportData)
-      .then(function(result) {
-        result = 'data:text/csv;charset=utf-8,' + result;
-        var encodedUri = encodeURI(result);
-        var link = document.createElement('a');
-        link.setAttribute('href', encodedUri);
-        link.setAttribute('download', 'data.csv');
-        document.body.appendChild(link);
-        link.click();
-      });
+        .then(function(result) {
+          result = 'data:text/csv;charset=utf-8,' + result;
+          var link = document.createElement('a');
+          link.setAttribute('href', encodeURI(result));
+          link.setAttribute('download', 'data.csv');
+          document.body.appendChild(link);
+          link.click();
+        });
     }
   ]
+
 });

--- a/src/foam/u2/ExportModal.js
+++ b/src/foam/u2/ExportModal.js
@@ -103,12 +103,12 @@ foam.CLASS({
       var exportDriver = await this.exportDriverRegistryDAO.find(this.dataType);
       exportDriver = foam.lookup(exportDriver.driverName).create();
 
-      this.downloadCSV(this.exportData, exportDriver);
+      this.downloadCSVv(this.exportData, exportDriver);
     }
   ],
 
   listeners: [
-    function downloadCSV(data, exportDriver) {
+    function downloadCSVv(data, exportDriver) {
       exportDriver.exportDAO(this.__context__, this.exportData)
       .then(function(result) {
         result = 'data:text/csv;charset=utf-8,' + result;


### PR DESCRIPTION
Main addition was a fix to the CSV Outputter.

But CSVSink.js (CSV Outputter) was redesigned, to extend AbstractSink and to define new property axioms toCSV() and toCSVLabel()

CSVSinkDemo.js is a demo for testing CSVSink with various property types. Will be needing this in the future for rebuilding CSV Parser.

Terminal cmd to run demo: ```python -m SimpleHTTPServer```
URL for testing: ```http://localhost:8000/foam2/?model=foam.test.CSVSinkDemo```

closing: 
https://github.com/nanoPayinc/NANOPAY/issues/5850
and 
CPF-196 #time 3d
CPF-196 #In Review done with @mcarcaso 


