### PR TITLE
ScrollTableView native scrolling support

### DIFF
--- a/src/foam/comics/DAOControllerView.js
+++ b/src/foam/comics/DAOControllerView.js
@@ -102,8 +102,7 @@ foam.CLASS({
       name: 'summaryView',
       factory: function() {
         return this.data.summaryView || this.importedSummaryView || {
-          class: 'foam.u2.view.ScrollTableView',
-          fitInScreen: true
+          class: 'foam.u2.view.ScrollTableView'
         };
       }
     },

--- a/src/foam/nanos/controller/AppStyles.js
+++ b/src/foam/nanos/controller/AppStyles.js
@@ -37,7 +37,6 @@ foam.CLASS({
       font-weight: 900;
       line-height: 1.5;
       letter-spacing: 0.4px;
-      background: transparent;
     }
     .foam-u2-view-TableView-row > th > td {
       font-size: 12px;

--- a/src/foam/nanos/controller/ApplicationController.js
+++ b/src/foam/nanos/controller/ApplicationController.js
@@ -75,7 +75,7 @@ foam.CLASS({
   ],
 
   constants: {
-    MACROS: [ 'primaryColor', 'secondaryColor', 'tableColor', 'tableHoverColor', 'accentColor', 'secondaryHoverColor', 'secondaryDisabledColor', 'groupCSS' ]
+    MACROS: [ 'primaryColor', 'secondaryColor', 'tableColor', 'tableHoverColor', 'accentColor', 'secondaryHoverColor', 'secondaryDisabledColor', 'groupCSS', 'backgroundColor' ]
   },
 
   css: `
@@ -169,6 +169,7 @@ foam.CLASS({
     'tableColor',
     'tableHoverColor',
     'accentColor',
+    'backgroundColor',
     'groupCSS',
     'topNavigation_',
     'footerView_'

--- a/src/foam/u2/md/OverlayDropdown.js
+++ b/src/foam/u2/md/OverlayDropdown.js
@@ -19,7 +19,7 @@ foam.CLASS({
 
   css: `
     ^overlay {
-      position: fixed;
+      position: absolute;
       z-index: 1009;
     }
 
@@ -35,7 +35,7 @@ foam.CLASS({
       padding-bottom: -20px;
       margin-bottom: -20px;
       z-index: 1010;
-      transform: translate(-60%, 33px);
+      transform: translate(-100%, 12px);
     }
 
     ^open {
@@ -76,6 +76,14 @@ foam.CLASS({
     {
       name: 'addToSelf_',
       value: false
+    },
+    {
+      type: 'Int',
+      name: 'x'
+    },
+    {
+      type: 'Int',
+      name: 'y'
     }
   ],
 
@@ -91,7 +99,9 @@ foam.CLASS({
       return this;
     },
 
-    function open() {
+    function open(x, y) {
+      this.x = x;
+      this.y = y;
       this.opened = true;
     },
 
@@ -110,6 +120,7 @@ foam.CLASS({
 
       this.start('dropdown-overlay')
         .addClass(this.myClass('overlay'))
+        .show(this.opened$)
         .addClass(this.slot(function(opened) {
           return opened
             ? view.myClass('zeroOverlay')
@@ -119,9 +130,11 @@ foam.CLASS({
       .end();
 
       this.dropdownE_.addClass(this.myClass())
-        .addClass(this.slot(function(opened) {
-          return opened ? this.myClass('open') : '';
-        }, this.opened$))
+        .show(this.opened$)
+        .style({
+          top: this.y$,
+          left: this.x$
+        })
         .on('mouseleave', this.onMouseLeave)
         .on('click', this.onClick);
 

--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -4,21 +4,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// TODO:
-//   [x] Fix overlays.
-//   [x] Make the table header sticky.
-//   [x] Fix jump in scrollbar when tables are added/removed.
-//   [x] See if I can get it so that the DOM elements aren't removed and
-//       re-added when filtering. It would be nicer to just change the
-//       underlying DAO so you don't see the flicker.
-//   [x] Make sure all column widths are consistent.
-//   [x] Handle when a user scrolls more than an entire page in one event.
-//   [x] Make sure table height isn't broken.
-//   [x] Make sure filtering didn't break.
-//   [x] Make sure sorting didn't break.
-//   [x] Fix bug where table header is gone if you scroll back up after it was
-//       removed when previously scrolling down far enough for it to be removed.
-
  foam.CLASS({
   package: 'foam.u2.view',
   name: 'ScrollTableView',
@@ -71,7 +56,6 @@
       class: 'Int',
       name: 'limit',
       value: 18,
-      // TODO make this a funciton of the height.
     },
     {
       class: 'Int',

--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -376,7 +376,7 @@
       name: 'updateTableHeight',
       code: function() {
         // Find the distance from the top of the table to the top of the screen.
-        var distanceFromTop = this.table_.el().getBoundingClientRect().y;
+        var distanceFromTop = this.scrollbarContainer_.el().getBoundingClientRect().y;
 
         // Calculate the remaining space we have to make use of.
         var remainingSpace = window.innerHeight - distanceFromTop;

--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -7,10 +7,24 @@
 // TODO:
 //   [ ] Make sure all column widths are consistent. Only way to do this is to
 //       have one table and add rows, not have many tables.
+//         * <table>'s can have multiple <tbody>'s, so that's one option. The
+//           hard part about doing this is that we need each of the <tbody>'s
+//           to have a different DAO/data source. We could try to support
+//           multiple DAOs in a single table.
+//         * We could also sidestep the issue by using `table-layout: fixed` so
+//           the tables are indistinguishable from each other. This feels like
+//           too much of a constraint though.
 //   [ ] Fix overlays.
 //   [x] Handle when a user scrolls more than an entire page in one event.
 //   [x] Make sure table height isn't broken.
 //   [ ] Fix jump in scrollbar when tables are added/removed.
+//         * `position: absolute` would solve this perfectly if it weren't for
+//           the fact that the conainer wouldn't use the table to calculate its
+//           width anymore so it breaks the layout.
+//             * Note that using `table-layout: fixed` would solve this too.
+//         * Note that the jumping only happens when scrolling down, which is
+//           surprising. I'm not sure why that's the case, I'd expect it happen
+//           while scrolling either way.
 //   [x] Make sure filtering didn't break.
 //   [x] Make sure sorting didn't break.
 //   [ ] Make the table header sticky.

--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -6,15 +6,8 @@
 
 // TODO:
 //   [ ] Fix overlays.
-//   [ ] Fix jump in scrollbar when tables are added/removed.
-//         * `position: absolute` would solve this perfectly if it weren't for
-//           the fact that the conainer wouldn't use the table to calculate its
-//           width anymore so it breaks the layout.
-//             * Note that using `table-layout: fixed` would solve this.
-//         * Note that the jumping only happens when scrolling down, which is
-//           surprising. I'm not sure why that's the case, I'd expect it happen
-//           while scrolling either way.
 //   [ ] Make the table header sticky.
+//   [x] Fix jump in scrollbar when tables are added/removed.
 //   [x] See if I can get it so that the DOM elements aren't removed and
 //       re-added when filtering. It would be nicer to just change the
 //       underlying DAO so you don't see the flicker.
@@ -44,6 +37,8 @@
 
     ^scrollbar {
       box-sizing: border-box;
+      width: 1px;
+      background: rgba(0, 0, 0, 0);
     }
 
     ^scrollbarContainer {
@@ -207,7 +202,6 @@
     'topBufferTable_',
     'visibleTable_',
     'bottomBufferTable_',
-    'tablesContainer_',
     {
       type: 'Int',
       name: 'tablesRemoved_',
@@ -242,7 +236,7 @@
             addClass(this.myClass('scrollbar')).
             style({ height: this.scrollHeight$ }).
           end().
-          start('div', undefined, this.tablesContainer_$).
+          start().
             start('div', undefined, this.spacer_$).
               style({ height: this.spacerHeight_$ }).
             end().

--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -15,8 +15,6 @@
 //           the tables are indistinguishable from each other. This feels like
 //           too much of a constraint though.
 //   [ ] Fix overlays.
-//   [x] Handle when a user scrolls more than an entire page in one event.
-//   [x] Make sure table height isn't broken.
 //   [ ] Fix jump in scrollbar when tables are added/removed.
 //         * `position: absolute` would solve this perfectly if it weren't for
 //           the fact that the conainer wouldn't use the table to calculate its
@@ -25,9 +23,11 @@
 //         * Note that the jumping only happens when scrolling down, which is
 //           surprising. I'm not sure why that's the case, I'd expect it happen
 //           while scrolling either way.
+//   [ ] Make the table header sticky.
+//   [x] Handle when a user scrolls more than an entire page in one event.
+//   [x] Make sure table height isn't broken.
 //   [x] Make sure filtering didn't break.
 //   [x] Make sure sorting didn't break.
-//   [ ] Make the table header sticky.
 //   [x] Fix bug where table header is gone if you scroll back up after it was
 //       removed when previously scrolling down far enough for it to be removed.
 

--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -4,6 +4,19 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
+// TODO:
+//   [ ] Make sure all tables are the same width. Only way to do this is to have
+//       one table and add rows, not have many tables.
+//   [ ] Fix overlays.
+//   [ ] Handle when a user scrolls more than an entire page in one event.
+//   [ ] Make sure fitInScreen isn't broken.
+//   [ ] Fix jump in scrollbar when tables are added/removed.
+//   [ ] Make sure filtering didn't break.
+//   [ ] Make sure sorting didn't break.
+//   [ ] Make the table header sticky.
+//   [ ] Fix bug where table header is gone if you scroll back up after it was
+//       removed when previously scrolling down far enough for it to be removed.
+
  foam.CLASS({
   package: 'foam.u2.view',
   name: 'ScrollTableView',
@@ -26,14 +39,15 @@
 
     ^scrollbarContainer {
       overflow: scroll;
+      display: grid;
+      grid-template-columns: auto auto;
     }
 
+    /*
     ^table {
-      /* The following line is required for Safari. */
-      position: -webkit-sticky;
-      position: sticky;
-      top: 0;
+      border-bottom: 3px solid red !important;
     }
+    */
   `,
 
   constants: [
@@ -58,13 +72,6 @@
     {
       class: 'Int',
       name: 'skip',
-    },
-    {
-      class: 'foam.dao.DAOProperty',
-      name: 'scrolledDAO',
-      expression: function(data, limit, skip) {
-        return data && data.limit(limit).skip(skip);
-      },
     },
     'columns',
     {
@@ -127,13 +134,73 @@
       expression: function(daoCount, limit, rowHeight) {
         this.lastScrollTop_ = 0;
         this.skip = 0;
-        return rowHeight * daoCount + this.TABLE_HEAD_HEIGHT + 'px';
+        return rowHeight * daoCount /* + this.TABLE_HEAD_HEIGHT */ + 'px';
       }
     },
     {
       type: 'Int',
       name: 'lastScrollTop_',
       value: 0
+    },
+    {
+      type: 'Int',
+      name: 'pageSize',
+      value: 40,
+      documentation: 'The number of items in each "page". There are three pages.'
+    },
+    {
+      class: 'foam.dao.DAOProperty',
+      name: 'page1DAO',
+      expression: function(data, pageSize) {
+        return data && data.limit(pageSize);
+      }
+    },
+    {
+      class: 'foam.dao.DAOProperty',
+      name: 'page2DAO',
+      expression: function(data, pageSize) {
+        return data && data.skip(pageSize).limit(pageSize);
+      }
+    },
+    {
+      class: 'foam.dao.DAOProperty',
+      name: 'page3DAO',
+      expression: function(data, pageSize) {
+        return data && data.skip(pageSize * 2).limit(pageSize);
+      }
+    },
+    {
+      type: 'Int',
+      name: 'currentLowerBound',
+      value: 0
+    },
+    {
+      type: 'Int',
+      name: 'currentUpperBound',
+      expression: function(pageSize) {
+        return pageSize * 3;
+      }
+    },
+    {
+      name: 'spacer_',
+      documentation: `
+        A named reference to an element so we can update its height
+        periodically. Used to put empty space between the top of the container
+        and the tables so we create the illusion of the table always being
+        visible.
+      `
+    },
+    'topBufferTable_',
+    'visibleTable_',
+    'bottomBufferTable_',
+    'tablesContainer_',
+    {
+      type: 'Int',
+      name: 'tablesRemoved_',
+      value: 0,
+      documentation: `
+        The number of tables that have been removed due to scrolling down.
+      `
     }
   ],
 
@@ -149,27 +216,60 @@
         start('div', undefined, this.scrollbarContainer_$).
           addClass(this.myClass('scrollbarContainer')).
           on('scroll', this.onScroll).
-          start(this.TableView, {
-            data$: this.scrolledDAO$,
-            columns: this.columns,
-            contextMenuActions: this.contextMenuActions,
-            selection$: this.selection$,
-            editColumnsEnabled: this.editColumnsEnabled
-          }, this.table_$).
-            addClass(this.myClass('table')).
-          end().
           start().
             show(this.daoCount$.map((count) => count >= this.limit)).
             addClass(this.myClass('scrollbar')).
             style({ height: this.scrollHeight$ }).
           end().
+          start('div', undefined, this.tablesContainer_$).
+            tag('div', undefined, this.spacer_$).
+            start(this.TableView, {
+              data$: this.page1DAO$,
+              columns: this.columns,
+              contextMenuActions: this.contextMenuActions,
+              selection$: this.selection$,
+              editColumnsEnabled: this.editColumnsEnabled
+            }, this.topBufferTable_$).
+              addClass(this.myClass('table')).
+            end().
+            start(this.TableView, {
+              data$: this.page2DAO$,
+              columns: this.columns,
+              contextMenuActions: this.contextMenuActions,
+              selection$: this.selection$,
+              editColumnsEnabled: this.editColumnsEnabled,
+              showHeader: false
+            }, this.visibleTable_$).
+              addClass(this.myClass('table')).
+            end().
+            start(this.TableView, {
+              data$: this.page3DAO$,
+              columns: this.columns,
+              contextMenuActions: this.contextMenuActions,
+              selection$: this.selection$,
+              editColumnsEnabled: this.editColumnsEnabled,
+              showHeader: false
+            }, this.bottomBufferTable_$).
+              addClass(this.myClass('table')).
+            end().
+          end().
         end();
 
       if ( this.fitInScreen ) {
-        this.onDetach(this.onload.sub(this.updateTableHeight));
-        window.addEventListener('resize', this.updateTableHeight);
-        this.onDetach(() => {
-          window.removeEventListener('resize', this.updateTableHeight);
+        // this.onDetach(this.onload.sub(this.updateTableHeight));
+        // window.addEventListener('resize', this.updateTableHeight);
+        // this.onDetach(() => {
+        //   window.removeEventListener('resize', this.updateTableHeight);
+        // });
+
+        this.onload.sub(() => {
+          // Find the distance from the top of the table to the top of the screen.
+          var distanceFromTop = this.topBufferTable_.el().getBoundingClientRect().y;
+
+          // Calculate the remaining space we have to make use of.
+          var remainingSpace = window.innerHeight - distanceFromTop;
+
+          this.scrollbarContainer_.style({ height: `${remainingSpace}px` });
         });
       }
 
@@ -185,9 +285,88 @@
         var negative = deltaY < 0;
         var rows = Math.floor(Math.abs(this.accumulator + deltaY) / this.rowHeight);
         this.accumulator += deltaY;
-        var newSkip = Math.max(0, this.skip + (negative ? -rows : rows));
-        if ( this.skip <= this.daoCount - this.limit ) this.skip = newSkip;
+        var oldSkip = this.skip;
+        this.skip = Math.min(this.daoCount - this.limit, Math.max(0, this.skip + (negative ? -rows : rows)));
         this.lastScrollTop_ = e.target.scrollTop;
+
+        console.log('Lower bound: ' + (this.currentLowerBound + this.pageSize));
+        console.log('Upper bound: ' + (this.currentUpperBound - this.pageSize - Math.floor(this.limit / 2)));
+        console.log(`${oldSkip} -> ${this.skip}`);
+
+        // Check if we scrolled over a page boundary. If we did, remove one of
+        // the tables, add another, and update the dummy element's height to
+        // make sure the tables are pushed down far enough.
+        if (
+          oldSkip   <= this.currentUpperBound - this.pageSize - Math.floor(this.limit / 2) &&
+          this.skip >  this.currentUpperBound - this.pageSize - Math.floor(this.limit / 2)
+        ) {
+          // The user scrolled down past a page boundary.
+
+          // Update the bounds.
+          if ( this.currentUpperBound > this.daoCount ) return;
+
+          this.currentUpperBound += this.pageSize;
+          this.currentLowerBound += this.pageSize;
+
+          // Remove the top buffer table.
+          this.topBufferTable_.remove();
+          this.tablesRemoved_ += 1;
+
+          // Update the table references.
+          this.topBufferTable_ = this.visibleTable_;
+          this.visibleTable_   = this.bottomBufferTable_;
+
+          // Update the spacer element height.
+          this.spacer_.style({ height: `${this.tablesRemoved_ * this.pageSize * this.rowHeight}px` });
+
+          // Add a new bottom buffer table.
+          this.tablesContainer_.start(this.TableView, {
+            data$: this.data$.map((dao) => dao.skip(this.currentUpperBound - this.pageSize).limit(this.pageSize)),
+            columns: this.columns,
+            contextMenuActions: this.contextMenuActions,
+            selection$: this.selection$,
+            editColumnsEnabled: this.editColumnsEnabled,
+            showHeader: false
+          }, this.bottomBufferTable_$).
+            addClass(this.myClass('table')).
+          end();
+        } else if (
+          oldSkip   >  this.currentLowerBound + this.pageSize &&
+          this.skip <= this.currentLowerBound + this.pageSize
+        ) {
+          // The user scrolled up past a page boundary.
+
+          // Update the bounds.
+          if ( this.currentLowerBound <= 0 ) return;
+
+          this.currentLowerBound -= this.pageSize;
+          this.currentUpperBound -= this.pageSize;
+
+          // Remove the bottom buffer table.
+          this.bottomBufferTable_.remove();
+          this.tablesRemoved_ -= 1;
+
+          // Update the table references.
+          this.bottomBufferTable_ = this.visibleTable_;
+          this.visibleTable_      = this.topBufferTable_;
+
+          // Update the spacer element height.
+          this.spacer_.style({ height: `${this.tablesRemoved_ * this.pageSize * this.rowHeight}px` });
+
+          // Add a new top buffer table.
+          var table = this.E().start(this.TableView, {
+            data$: this.data$.map((dao) => dao.skip(this.currentLowerBound).limit(this.pageSize)),
+            columns: this.columns,
+            contextMenuActions: this.contextMenuActions,
+            selection$: this.selection$,
+            editColumnsEnabled: this.editColumnsEnabled,
+            showHeader: this.currentLowerBound === 0
+          }, this.topBufferTable_$).
+            addClass(this.myClass('table')).
+          end();
+
+          this.tablesContainer_.insertAfter(table, this.spacer_);
+        }
       }
     },
     {
@@ -201,22 +380,22 @@
         });
       }
     },
-    {
-      name: 'updateTableHeight',
-      code: function() {
-        // Find the distance from the top of the table to the top of the screen.
-        var distanceFromTop = this.table_.el().getBoundingClientRect().y;
+    // {
+    //   name: 'updateTableHeight',
+    //   code: function() {
+    //     // Find the distance from the top of the table to the top of the screen.
+    //     var distanceFromTop = this.table_.el().getBoundingClientRect().y;
 
-        // Calculate the remaining space we have to make use of.
-        var remainingSpace = window.innerHeight - distanceFromTop;
+    //     // Calculate the remaining space we have to make use of.
+    //     var remainingSpace = window.innerHeight - distanceFromTop;
 
-        // Set the limit such that we make maximum use of the space without
-        // overflowing.
-        this.limit = Math.max(1, Math.floor((remainingSpace - this.TABLE_HEAD_HEIGHT) / this.rowHeight));
+    //     // Set the limit such that we make maximum use of the space without
+    //     // overflowing.
+    //     this.limit = Math.max(1, Math.floor((remainingSpace - this.TABLE_HEAD_HEIGHT) / this.rowHeight));
 
-        this.updateScrollbarContainerHeight();
-      }
-    },
+    //     this.updateScrollbarContainerHeight();
+    //   }
+    // },
     {
       name: 'updateScrollbarContainerHeight',
       code: function() {

--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -185,9 +185,8 @@
         var negative = deltaY < 0;
         var rows = Math.floor(Math.abs(this.accumulator + deltaY) / this.rowHeight);
         this.accumulator += deltaY;
-        var oldSkip = this.skip;
-        this.skip = Math.max(0, this.skip + (negative ? -rows : rows));
-        if ( this.skip > this.daoCount - this.limit ) this.skip = oldSkip;
+        var newSkip = Math.max(0, this.skip + (negative ? -rows : rows));
+        if ( this.skip <= this.daoCount - this.limit ) this.skip = newSkip;
         this.lastScrollTop_ = e.target.scrollTop;
       }
     },

--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -6,7 +6,7 @@
 
 // TODO:
 //   [ ] Fix overlays.
-//   [ ] Make the table header sticky.
+//   [x] Make the table header sticky.
 //   [x] Fix jump in scrollbar when tables are added/removed.
 //   [x] See if I can get it so that the DOM elements aren't removed and
 //       re-added when filtering. It would be nicer to just change the
@@ -45,6 +45,12 @@
       overflow: scroll;
       display: grid;
       grid-template-columns: auto auto;
+    }
+
+    ^ th {
+      position: -webkit-sticky;
+      position: sticky;
+      top: 0;
     }
   `,
 

--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -5,7 +5,7 @@
  */
 
 // TODO:
-//   [ ] Fix overlays.
+//   [x] Fix overlays.
 //   [x] Make the table header sticky.
 //   [x] Fix jump in scrollbar when tables are added/removed.
 //   [x] See if I can get it so that the DOM elements aren't removed and

--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -51,12 +51,6 @@
       display: grid;
       grid-template-columns: auto auto;
     }
-
-    /*
-    ^table {
-      border-bottom: 3px solid red !important;
-    }
-    */
   `,
 
   constants: [
@@ -110,7 +104,7 @@
     {
       name: 'table_',
       documentation: `
-        A reference to the table element we use in the fitInScreen calculations.
+        A reference to the table element we use in various calculations.
       `
     },
     {

--- a/src/foam/u2/view/TableView.js
+++ b/src/foam/u2/view/TableView.js
@@ -23,6 +23,7 @@ foam.CLASS({
       line-height: 1;
       letter-spacing: 0.4px;
       color: #2b2b2b;
+      background: %BACKGROUNDCOLOR%;
     }
 
     ^ th > img {
@@ -42,10 +43,6 @@ foam.CLASS({
     ^row:hover {
       background: #eee;
       cursor: pointer;
-    }
-
-    ^ tbody {
-      box-shadow: 0 2px 2px 0 #dae1e9;
     }
 
     ^ tbody > tr {

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -141,7 +141,13 @@ foam.CLASS({
     },
     'hoverSelection',
     'dropdownOrigin',
-    'overlayOrigin'
+    'overlayOrigin',
+    {
+      type: 'Boolean',
+      name: 'showHeader',
+      value: true,
+      documentation: 'Set to false to not render the header.'
+    }
   ],
 
   methods: [
@@ -184,6 +190,7 @@ foam.CLASS({
         addClass(this.myClass(this.of.id.replace(/\./g, '-'))).
         setNodeName('table').
         start('thead').
+          show(this.showHeader$).
           add(this.slot(function(columns_) {
             return this.E('tr').
               forEach(columns_, function(column) {

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -27,6 +27,7 @@ foam.CLASS({
   ],
 
   imports: [
+    'ctrl',
     'dblclick?',
     'editRecord?',
     'selection? as importSelection'
@@ -165,19 +166,10 @@ foam.CLASS({
       var view = this;
       var columnSelectionE;
 
-      this.
-        start('div', null, this.overlayOrigin$).
-          style({
-            float: 'right',
-            // Make sure the dropdown to edit the table columns is in the
-            // correct position.
-            transform: 'translate(-67px, 2px)'
-          }).
-          callIf(view.editColumnsEnabled, function() {
-            columnSelectionE = view.createColumnSelection();
-            this.add(columnSelectionE);
-          }).
-        end();
+      if ( this.editColumnsEnabled ) {
+        columnSelectionE = this.createColumnSelection();
+        this.ctrl.add(columnSelectionE);
+      }
 
       this.
         addClass(this.myClass()).
@@ -211,7 +203,7 @@ foam.CLASS({
                   callIf(view.editColumnsEnabled, function() {
                     this.addClass(view.myClass('th-editColumns')).
                     on('click', function(e) {
-                      columnSelectionE.open();
+                      columnSelectionE.open(e.clientX, e.clientY);
                     }).
                     add(' ', view.vertMenuIcon).
                     addClass(view.myClass('vertDots')).
@@ -301,7 +293,7 @@ foam.CLASS({
                             }).
                           end();
                       });
-                      this.add(overlay);
+                      view.ctrl.add(overlay);
                     }).
                     style({ 'text-align': 'right' }).
                     start('span').
@@ -310,7 +302,7 @@ foam.CLASS({
                       enableClass('disabled', actions.length === 0).
                       callIf(actions.length > 0, function() {
                         this.on('click', function(evt) {
-                          overlay.open();
+                          overlay.open(evt.clientX, evt.clientY);
                         });
                       }).
                       add(view.vertMenuIcon).


### PR DESCRIPTION
Refactors `ScrollTableView` to support real native vertical scrolling.

## Changes

* Made the ScrollTableView use real scrolling instead of just replacing the data in the table.
  * This was the main point of the PR and all of the other changes are caused by this.
  * See the image below for the structure of the DOM elements to accomplish this.
  * There is always one `<table>` with three `<tbody>`'s in it. As the user scrolls we add and remove `<tbody>` elements. Each of them has their own DAO with a different skip value. The bulk of the code in this PR is just tracking these `<tbody>`'s and what data to feel them.
* Added a background colour CSS macro so the sticky table header could set it's background colour.
  * It used to be transparent which was fine when the rows didn't move, but now that the rows move, they would be visible behind the table header.
* Removed `fitInScreen :: Boolean` as an optional flag on `ScrollTableView`
  * This flag used to make sure the table height didn't extend off of the bottom of the screen. Now it's always on. Not sure if this is quite what we want. We probably want it as an option still that can be overwritten.
* Changed the way `OverlayDropdown` is positioned. Now it's position is based on the coordinates of the mouse click event instead of the coordinates of it's DOM element.
  * The issue was that since the DOM element was inside the `<td>` element in the table and one of the containers containing the table needs to have `overflow: hidden`, the overlay would be cut off if it were near the bottom of the table. So since we can't put it directly in the table anymore, I chose to add it to the controller and then use the mouse coordinates to position it since we can't use the DOM anymore.

![IMG_20190322_154914600](https://user-images.githubusercontent.com/4259165/54849314-41053880-4cba-11e9-8e16-ee862bc3d761.jpg)

