### PR TITLE
Improve error message for unauthorized property access via mlangs

### DIFF
--- a/src/foam/core/AbstractPropertyInfo.java
+++ b/src/foam/core/AbstractPropertyInfo.java
@@ -8,6 +8,8 @@ package foam.core;
 
 import foam.dao.pg.IndexedPreparedStatement;
 import foam.lib.xml.Outputter;
+import foam.nanos.auth.AuthService;
+import foam.nanos.auth.AuthorizationException;
 import foam.nanos.logger.Logger;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -148,6 +150,25 @@ public abstract class AbstractPropertyInfo
   @Override
   public boolean containsDeletablePII(){
     return false;
+  }
+
+  @Override
+  public void authorize(X x) {
+    if ( this.getPermissionRequired() ) {
+      AuthService auth = (AuthService) x.get("auth");
+      String simpleName = this.getClassInfo().getObjClass().getSimpleName();
+      String permission =
+        simpleName.toLowerCase() +
+        ".%s." +
+        this.getName().toLowerCase();
+
+      if (
+        ! auth.check(x, String.format(permission, "rw")) &&
+        ! auth.check(x, String.format(permission, "ro"))
+      ) {
+        throw new AuthorizationException(String.format("Access denied. User lacks permission to access property '%s' on model '%s'.", this.getName(), simpleName));
+      };
+    }
   }
 
   @Override

--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -149,6 +149,17 @@ foam.INTERFACE({
     {
       name: 'partialEval',
       type: 'foam.mlang.Expr'
+    },
+    {
+      name: 'authorize',
+      flags: [ 'java' ],
+      type: 'Void',
+      args: [
+        {
+          name: 'x',
+          type: 'Context'
+        }
+      ]
     }
   ]
 });
@@ -292,21 +303,6 @@ foam.INTERFACE({
           type: 'Context'
         }
       ]
-    },
-    {
-      name: 'authorizeArg',
-      flags: [ 'java' ],
-      type: 'Void',
-      args:[
-        {
-          name: 'x',
-          type: 'Context'
-        },
-        {
-          name: 'arg',
-          type: 'foam.mlang.Expr'
-        }
-      ]
     }
   ]
 });
@@ -442,30 +438,6 @@ foam.CLASS({
     {
       name: 'authorize',
       javaCode: `//noop`
-    },
-    {
-      name: 'authorizeArg',
-      javaCode: `
-  if ( arg instanceof foam.core.PropertyInfo ) {
-    foam.core.PropertyInfo prop =  (foam.core.PropertyInfo) arg;
-
-    if ( prop.getPermissionRequired() ) {
-      AuthService auth = (AuthService) x.get("auth");
-      String simpleName = prop.getClassInfo().getObjClass().getSimpleName();
-      String permission =
-        simpleName.toLowerCase() +
-        ".%s." +
-        prop.getName().toLowerCase();
-
-      if (
-        ! auth.check(x, String.format(permission, "rw")) &&
-        ! auth.check(x, String.format(permission, "ro"))
-      ) {
-        throw new foam.nanos.auth.AuthorizationException(String.format("Access denied. User lacks permission to access property '%s' on model '%s'.", prop.getName(), simpleName));
-      };
-    }
-  }
-  `
     }
   ]
 });
@@ -500,6 +472,11 @@ foam.CLASS({
         }
       ],
       javaCode: ' '
+    },
+    {
+      name: 'authorize',
+      type: 'Void',
+      javaCode: `//noop`
     }
   ]
 });
@@ -583,7 +560,7 @@ foam.CLASS({
     {
       name: 'authorize',
       javaCode: `
-        authorizeArg(x, getArg1());
+        getArg1().authorize(x);
       `
     }
   ]
@@ -734,8 +711,8 @@ getArg2().prepareStatement(stmt);`
     {
       name: 'authorize',
       javaCode: `
-        authorizeArg(x, getArg1());
-        authorizeArg(x, getArg2());
+        getArg1().authorize(x);
+        getArg2().authorize(x);
       `
     }
   ]

--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -283,7 +283,7 @@ foam.INTERFACE({
       type: 'foam.mlang.predicate.Predicate',
     },
     {
-      name:'authorize',
+      name: 'authorize',
       flags: [ 'java' ],
       type: 'Void',
       args: [
@@ -294,8 +294,8 @@ foam.INTERFACE({
       ]
     },
     {
-      name:'authorizeArg',
-      flags: [ 'java'],
+      name: 'authorizeArg',
+      flags: [ 'java' ],
       type: 'Void',
       args:[
         {
@@ -444,8 +444,8 @@ foam.CLASS({
       javaCode: `//noop`
     },
     {
-      name:'authorizeArg',
-      javaCode:`
+      name: 'authorizeArg',
+      javaCode: `
   if ( arg instanceof foam.core.PropertyInfo ) {
     foam.core.PropertyInfo prop =  (foam.core.PropertyInfo) arg;
 

--- a/src/foam/nanos/auth/PermissionedPropertyDAO.js
+++ b/src/foam/nanos/auth/PermissionedPropertyDAO.js
@@ -48,9 +48,7 @@ foam.CLASS({
       name: 'select_',
       javaCode: `
       if ( x.get("auth") != null ) {
-        if ( predicate != null && ! predicate.authorize(x) ) {
-          throw new AuthenticationException("Access denied: property protected");
-        }
+        if ( predicate != null ) predicate.authorize(x);
         foam.dao.Sink sink2 = ( sink != null ) ? new HidePropertiesSink(x, sink, this) : sink;
         super.select_(x, sink2, skip, limit, order, predicate);
         return sink;


### PR DESCRIPTION
## Changes

* Changed the interface from returning a boolean to return type void and throwing an exception if need be. This way, deeply nested mlangs can throw specific and useful errors and the call site doesn't need to try and figure out what caused the call to `authorize` to return false to create an error message.
* Changed the exception thrown from an `AuthenticationException` to an `AuthorizationException`. I did this because `AuthenticationException`s will cause the web client to show the sign in screen.
* Changed the error message to include the specific model and property that caused the exception to be thrown, making it easier to debug.
* Remove `authorizeArg` method from interface
* Add an authorize method to Expr interface, which PropertyInfo implements
* Move logic previously in `authorizeArg` to `authorize` on PropertyInfo