### PR TITLE
Fix scrollbar size to be proportional to data

### DIFF
--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -127,7 +127,7 @@
       expression: function(daoCount, limit, rowHeight) {
         this.lastScrollTop_ = 0;
         this.skip = 0;
-        return rowHeight * daoCount + this.TABLE_HEAD_HEIGHT + 'px';
+        return rowHeight * (daoCount - limit) + this.TABLE_HEAD_HEIGHT + 'px';
       }
     },
     {


### PR DESCRIPTION
Fixes what we just talked about in person. I wasn't accounting for the visible rows when calculating the height of the container.