### PR TITLE
Add explicit service permissions check to SessionServerBox 

### DIFF
--- a/src/foam/box/SessionServerBox.java
+++ b/src/foam/box/SessionServerBox.java
@@ -86,8 +86,13 @@ public class SessionServerBox
 
           if ( authenticate_ && ! auth.check(session.getContext(), "service." + spec.getName()) ) {
             logger.debug("missing permission", group != null ? group.getId() : "NO GROUP" , "service." + spec.getName());
-            // msg.replyWithException(new NoPermissionException("No permission"));
-            // return;
+            /**
+             * for security purposes we uncommented the following two lines
+             * we needed to remove basicUser and SME wildcard permissions to service.*
+             * and enforce explicit service permissions
+             */
+            msg.replyWithException(new NoPermissionException("No permission"));
+            return;
           }
 
           // padding this cause if group is null this can cause an NPE


### PR DESCRIPTION
As outlined in ticket [CPF-694](https://nanopay.atlassian.net/browse/CPF-694), after having removed the service.* permissions wildcard from both basicUser and SME, we need to enforce strict service permissions for security purposes.

Previously in SessionServerBox.java, on lines 89 and 90, we were ignoring the specific service checks.
<img width="1113" alt="sessionServerBoxCommentedOut" src="https://user-images.githubusercontent.com/26717171/55018784-efb2bd00-4fc9-11e9-8d57-77f2339193c2.png">

I have uncommented the above two lines and left a comment block describing why we needed to do so for any future reader.