### PR TITLE
Fix issues with email templates

### DIFF
--- a/src/foam/box/SessionServerBox.java
+++ b/src/foam/box/SessionServerBox.java
@@ -92,6 +92,17 @@ public class SessionServerBox
           AppConfig appConfig = (AppConfig) x.get("appConfig");
           appConfig = (AppConfig) appConfig.fclone();
           String configUrl = ((Request) req).getRootURL().toString();
+
+          if ( appConfig.getForceHttps() ) {
+            if ( configUrl.startsWith("https://") ) {
+              // Don't need to do anything.
+            } else if ( configUrl.startsWith("http://") ) {
+              configUrl = "https" + configUrl.substring(4);
+            } else {
+              configUrl = "https://" + configUrl;
+            }
+          }
+
           appConfig.setUrl(configUrl);
           x = x.put("appConfig", appConfig);
           session.getContext().put("appConfig", appConfig);

--- a/src/foam/nanos/auth/Group.js
+++ b/src/foam/nanos/auth/Group.js
@@ -211,8 +211,6 @@ foam.CLASS({
         }
       ],
       javaCode: `
-DAO userDAO      = (DAO) x.get("localUserDAO");
-DAO groupDAO     = (DAO) x.get("groupDAO");
 AppConfig config = (AppConfig) ((AppConfig) x.get("appConfig")).fclone();
 
 String configUrl = config.getUrl();

--- a/src/foam/nanos/auth/email/EmailVerificationWebAgent.java
+++ b/src/foam/nanos/auth/email/EmailVerificationWebAgent.java
@@ -8,7 +8,6 @@ package foam.nanos.auth.email;
 
 import foam.core.X;
 import foam.dao.DAO;
-import foam.nanos.auth.Group;
 import foam.nanos.auth.User;
 import foam.nanos.http.WebAgent;
 import foam.nanos.notification.email.DAOResourceLoader;
@@ -65,19 +64,17 @@ public class EmailVerificationWebAgent
     } catch (Throwable t) {
       message = "Problem verifying your email.<br>" + t.getMessage();
     } finally {
-      Group group = (Group) x.get("group");
-
       if ( config_ == null ) {
         config_ = EnvironmentConfigurationBuilder
             .configuration()
             .resources()
             .resourceLoaders()
-            .add(new TypedResourceLoader("dao", new DAOResourceLoader(x, group.getId())))
+            .add(new TypedResourceLoader("dao", new DAOResourceLoader(x, (String) user.getGroup())))
             .and().and()
             .build();
       }
 
-      EmailTemplate emailTemplate = DAOResourceLoader.findTemplate(x, "verify-email-link", group.getId());
+      EmailTemplate emailTemplate = DAOResourceLoader.findTemplate(x, "verify-email-link", (String) user.getGroup());
       JtwigTemplate template = JtwigTemplate.inlineTemplate(emailTemplate.getBody(), config_);
       JtwigModel model = JtwigModel.newModel(Collections.<String, Object>singletonMap("msg", message));
       out.write(template.render(model));

--- a/src/foam/nanos/notification/email/DAOEmailService.js
+++ b/src/foam/nanos/notification/email/DAOEmailService.js
@@ -17,7 +17,6 @@ foam.CLASS({
   javaImports: [
     'foam.dao.DAO',
     'foam.dao.NullDAO',
-    'foam.nanos.auth.Group',
     'java.nio.charset.StandardCharsets',
     'org.jtwig.environment.EnvironmentConfiguration',
     'org.jtwig.environment.EnvironmentConfigurationBuilder',
@@ -98,9 +97,8 @@ return config_;`
     {
       name: 'sendEmailFromTemplate',
       javaCode: `
-Group group = (Group) x.get("group");
-String groupId = group != null ? group.getId() : null;
-EmailTemplate emailTemplate = DAOResourceLoader.findTemplate(getX(), name, groupId);
+String group = user != null ? (String) user.getGroup() : null;
+EmailTemplate emailTemplate = DAOResourceLoader.findTemplate(getX(), name, group);
 if ( emailMessage == null )
   return;
 
@@ -112,7 +110,7 @@ for ( String key : templateArgs.keySet() ) {
   }
 }
 
-EnvironmentConfiguration config = getConfig(groupId);
+EnvironmentConfiguration config = getConfig(group);
 JtwigModel model = JtwigModel.newModel(templateArgs);
 emailMessage = (EmailMessage) emailMessage.fclone();
 


### PR DESCRIPTION
In commit 8868279cc998c73e27b745263783c02c57c26191 I made changes to
access the group in the context rather than the user's group. I didn't
realize that these places in particular still should reference the group
on the user being passed in rather than the user in the context. The
change I made in that commit caused the wrong email template to be used
because it was now based on the group of the user doing the put, not the
user who's getting an email generated for them.

509e2e1 reverts those changes to exactly how they were before.

The changes to `SessionServerBox` make sure that the URL is set in the appConfig even when a user is signing up.