### PR TITLE
Add a calendar date picker to the u2 view library.

### DIFF
--- a/src/foam/u2/view/date/AbstractDateView.js
+++ b/src/foam/u2/view/date/AbstractDateView.js
@@ -1,0 +1,139 @@
+foam.CLASS({
+  package: 'foam.u2.view.date',
+  name: 'AbstractDateView',
+  extends: 'foam.u2.Element',
+  properties: [
+    {
+      class: 'DateTime',
+      name: 'data',
+      value: new Date()
+    },
+    {
+      class: 'Int',
+      name: 'year',
+      expression: function(data) {
+        return data.getYear() + 1900;
+      },
+      postSet: function(_, n) {
+        var d = new Date(this.data);
+        d.setYear(n);
+        this.data = d;
+        this.year = undefined;
+      }
+    },
+    {
+      class: 'Int',
+      name: 'monthIndex',
+      expression: function(data) {
+        return data.getMonth();
+      },
+      postSet: function(_, n) {
+        var d = new Date(this.data);
+        d.setMonth(n);
+        this.data = d;
+        this.monthIndex = undefined;
+      }
+    },
+    {
+      class: 'Enum',
+      of: 'foam.u2.view.date.Month',
+      name: 'month',
+      expression: function(monthIndex) {
+        return this.Month.VALUES[monthIndex % this.Month.VALUES.length];
+      },
+      postSet: function(_, n) {
+        this.monthIndex = n.ordinal;
+        this.month = undefined;
+      }
+    },
+    {
+      class: 'Int',
+      name: 'day',
+      expression: function(data) {
+        return data.getDate();
+      },
+      postSet: function(_, n) {
+        var d = new Date(this.data);
+        d.setDate(n);
+        this.data = d;
+        this.day = undefined;
+      }
+    },
+    {
+      name: 'hour24',
+      expression: function(data) {
+        return data.getHours();
+      },
+      postSet: function(_, n) {
+        var d = new Date(this.data);
+        d.setHours(n);
+        this.data = d;
+        this.hour24 = undefined;
+      }
+    },
+    {
+      name: 'hour12',
+      expression: function(hour24) {
+        var h = (hour24 % 12) || 12;
+        return (h < 10 ? '0' : '') + h;
+      },
+      preSet: function(_, n) {
+        return parseInt(n) % 12;
+      },
+      postSet: function(_, n) {
+        this.hour24 = n + (this.period == 'pm' ? 12 : 0);
+        this.hour12 = undefined;
+      }
+    },
+    {
+      name: 'minute',
+      expression: function(data) {
+        var m = data.getMinutes();
+        return (m < 10 ? '0' : '') + m;
+      },
+      postSet: function(_, n) {
+        var d = new Date(this.data);
+        d.setMinutes(n);
+        this.data = d;
+        this.minute = undefined;
+      }
+    },
+    {
+      name: 'second',
+      expression: function(data) {
+        return data.getSeconds();
+      },
+      postSet: function(_, n) {
+        var d = new Date(this.data);
+        d.setSeconds(n);
+        this.data = d;
+        this.second = undefined;
+      }
+    },
+    {
+      name: 'period',
+      view: {
+        class: 'foam.u2.view.ChoiceView',
+        choices: ['am', 'pm']
+      },
+      expression: function(hour24) {
+        return hour24 >= 12 ? 'pm' : 'am';
+      },
+      postSet: function(_, n) {
+        this.hour24 = this.hour24 +
+          (n == 'am' ? -12 : 12);
+        this.period = undefined;
+      }
+    }
+  ],
+  actions: [
+    {
+      name: 'noon',
+      code: function() {
+        this.hour24 = 12;
+        this.minute = 0;
+        this.second = 0;
+      }
+    }
+  ]
+});

--- a/src/foam/u2/view/date/CalendarDatePicker.js
+++ b/src/foam/u2/view/date/CalendarDatePicker.js
@@ -1,0 +1,149 @@
+foam.CLASS({
+  package: 'foam.u2.view.date',
+  name: 'CalendarDatePicker',
+  extends: 'foam.u2.Element',
+  requires: [
+    'foam.u2.view.date.Weekday'
+  ],
+  properties: [
+    {
+      class: 'Date',
+      name: 'data',
+      value: new Date()
+    },
+    {
+      name: 'nodeName',
+      value: 'table'
+    }
+  ],
+  axioms: [
+    foam.u2.CSS.create({
+      code: function() {/*
+        ^selected_day_cell, ^calendar_table td^selected_day_cell:hover {
+          background-color: green;
+        }
+        ^prev_month_cell, ^next_month_cell {
+          color: lightgray;
+        }
+        ^calendar_table td {
+          text-align: center;
+        }
+        ^calendar_table th {
+          cursor: default;
+        }
+        ^calendar_table td {
+          cursor: pointer;
+        }
+        ^calendar_table td:hover {
+          background-color: gray;
+        }
+      */}
+    })
+  ],
+  methods: [
+    function daysInMonth(month, year) {
+      var d = new Date();
+      d.setYear(year);
+      d.setMonth(month+1);
+      d.setDate(0);
+      return d.getDate();
+    },
+    function startingWeekday(month, year) {
+      var d = new Date();
+      d.setYear(year);
+      d.setMonth(month);
+      d.setDate(1);
+      return d.getDay();
+    },
+    function weeksOfMonth(month, year) {
+      var weeks = [[]];
+      var curWeekday = this.startingWeekday(month, year);
+      var curDay = 1;
+      var daysInMonth = this.daysInMonth(month, year);
+      while ( curDay <= daysInMonth ) {
+        weeks[weeks.length-1][curWeekday] = curDay;
+        curDay++;
+        curWeekday = (curWeekday+1) % this.Weekday.VALUES.length;
+        if ( curWeekday == 0 && curDay <= daysInMonth ) weeks.push([]);
+      }
+      return weeks;
+    },
+    function initE() {
+      var self = this;
+      this.startContext({data: this}).
+        addClass(this.myClass('calendar_table')).
+        add(this.slot(function(data) {
+          var month = data.getMonth();
+          var year = data.getYear() + 1900;
+
+          var prevMonthLastWeek = self.weeksOfMonth(month-1, year).pop()
+            .map(function(day) {
+              return self.E('td').
+                add(day).
+                on('click', function() {
+                  var d = new Date(data);
+                  d.setDate(1);
+                  d.setMonth(d.getMonth()-1);
+                  d.setDate(day);
+                  self.data = d;
+                }).
+                addClass(self.myClass('prev_month_cell'));
+            });
+
+          var curMonthWeeks = self.weeksOfMonth(month, year)
+            .map(function(week) {
+              return week.map(function(day) {
+                return self.E('td').
+                  add(day).
+                  on('click', function() {
+                    var d = new Date(data);
+                    d.setDate(day);
+                    self.data = d;
+                  }).
+                  addClass(day == self.data.getDate() ? self.myClass('selected_day_cell') : '').
+                  addClass(self.myClass('cur_month_cell'));
+              });
+            });
+
+          var nextMonthFirstWeek = self.weeksOfMonth(month+1, year).shift()
+            .map(function(day) {
+              return self.E('td').
+                add(day).
+                on('click', function() {
+                  var d = new Date(data);
+                  d.setDate(1);
+                  d.setMonth(d.getMonth()+1);
+                  d.setDate(day);
+                  self.data = d;
+                }).
+                addClass(self.myClass('next_month_cell'));
+            }).filter(function(d) { return d; });
+
+          if ( prevMonthLastWeek.length < 7 ) {
+            prevMonthLastWeek = prevMonthLastWeek.concat(curMonthWeeks.shift());
+          }
+          if ( nextMonthFirstWeek.length < 7 ) {
+            nextMonthFirstWeek = curMonthWeeks.pop().concat(nextMonthFirstWeek);
+          }
+
+          var weeks = [].concat([prevMonthLastWeek], curMonthWeeks, [nextMonthFirstWeek]);
+
+          return this.E('tbody').
+              start('tr').
+                forEach(self.Weekday.VALUES, function(wd) {
+                  this.start('th').add(wd.name).end();
+                }).
+              end().
+              forEach(weeks, function(w) {
+                this.
+                  start('tr').
+                    forEach(w, function(wd) {
+                      this.add(wd);
+                    }).
+                  end();
+              });
+        })).
+      endContext();
+    }
+  ]
+});

--- a/src/foam/u2/view/date/DateTimePicker.js
+++ b/src/foam/u2/view/date/DateTimePicker.js
@@ -1,0 +1,131 @@
+foam.CLASS({
+  package: 'foam.u2.view.date',
+  name: 'DateTimePicker',
+  extends: 'foam.u2.view.date.AbstractDateView',
+  requires: [
+    'foam.u2.view.date.CalendarDatePicker',
+    'foam.u2.view.date.Month',
+    'foam.u2.view.ChoiceView'
+  ],
+  axioms: [
+    foam.u2.CSS.create({
+      code: function() {/*
+        ^date_time_picker input,
+        ^date_time_picker select {
+          font-size: inherit;
+        }
+
+        ^next_btn, ^prev_btn {
+          display: inline-block;
+          width: 31px;
+          height: 31px;
+          line-height: 31px;
+          background-color: lightgray;
+          margin: 1px;
+          text-align: center;
+          cursor: pointer;
+          user-select: none;
+        }
+      */}
+    })
+  ],
+  methods: [
+    function initE() {
+      var zeroLeadingNumArray = function(start, end) {
+        var a = [];
+        for ( var i = start; i <= end; i++ ) {
+          a.push((i < 10 ? '0' : '') + i);
+        }
+        return a;
+      };
+
+      var self = this;
+      this.startContext({data: this}).
+        addClass(this.myClass('date_time_picker')).
+        style({
+          'display': 'inline-flex',
+          'flex-direction': 'column'
+        }).
+        start('span').
+          style({
+            'display': 'flex',
+            'align-items': 'center'
+          }).
+          start('span').
+            addClass(this.myClass('prev_btn')).
+            entity('#8249').
+            on('click', function() { self.year--; }).
+          end().
+          start(this.YEAR).
+            style({
+              'flex-grow': 1,
+              'text-align': 'center'
+            }).
+          end().
+          start('span').
+            addClass(this.myClass('next_btn')).
+            entity('#8250').
+            on('click', function() { self.year++; }).
+          end().
+        end().
+        start('div').
+          style({
+            'display': 'flex',
+            'align-items': 'center'
+          }).
+          start('span').
+            addClass(this.myClass('prev_btn')).
+            entity('#8249').
+            on('click', function() { self.monthIndex--; }).
+          end().
+          start(this.MONTH, {size: 3}).
+            style({
+              'flex-grow': 1,
+              'display': 'flex',
+              'flex-direction': 'column',
+              'text-align-last': 'center'
+            }).
+          end().
+          start('span').
+            addClass(this.myClass('next_btn')).
+            entity('#8250').
+            on('click', function() { self.monthIndex++; }).
+          end().
+        end().
+        start(this.CalendarDatePicker, {data$: this.data$}).
+          style({
+            'flex-shrink': '1'
+          }).
+        end().
+        start('div').
+          style({
+            'display': 'flex',
+            'justify-content': 'center',
+            'font-size': 'medium'
+          }).
+          tag(this.NOON, { data: this }).
+          start(this.ChoiceView, {
+            choices: zeroLeadingNumArray(1, 12),
+            data$: this.hour12$
+          }).
+            attrs({size: 2, maxlength: 2}).
+          end().
+          start().
+            add(':').
+            style({
+              'padding': '0 4px',
+              'font-weight': 'bold'
+            }).
+          end().
+          start(this.ChoiceView, {
+            choices: zeroLeadingNumArray(0, 59),
+            data$: this.minute$
+          }).
+            attrs({size: 2, maxlength: 2}).
+          end().
+          add(this.PERIOD).
+        end().
+      endContext();
+    }
+  ]
+});

--- a/src/foam/u2/view/date/Month.js
+++ b/src/foam/u2/view/date/Month.js
@@ -1,0 +1,18 @@
+foam.ENUM({
+  package: 'foam.u2.view.date',
+  name: 'Month',
+  values: [
+    { name: 'JAN', label: 'January' },
+    { name: 'FEB', label: 'February' },
+    { name: 'MAR', label: 'March' },
+    { name: 'APR', label: 'April' },
+    { name: 'MAY', label: 'May' },
+    { name: 'JUN', label: 'June' },
+    { name: 'JUL', label: 'July' },
+    { name: 'AUG', label: 'August' },
+    { name: 'SEP', label: 'September' },
+    { name: 'OCT', label: 'October' },
+    { name: 'NOV', label: 'November' },
+    { name: 'DEC', label: 'December' }
+  ]
+});

--- a/src/foam/u2/view/date/Weekday.js
+++ b/src/foam/u2/view/date/Weekday.js
@@ -1,0 +1,13 @@
+foam.ENUM({
+  package: 'foam.u2.view.date',
+  name: 'Weekday',
+  values: [
+    { name: 'SUN', label: 'Sunday' },
+    { name: 'MON', label: 'Monday' },
+    { name: 'TUE', label: 'Tuesday' },
+    { name: 'WED', label: 'Wednesday' },
+    { name: 'THU', label: 'Thursday' },
+    { name: 'FRI', label: 'Friday' },
+    { name: 'SAT', label: 'Saturday' }
+  ]
+});


### PR DESCRIPTION
It's not super pretty but I prefer this over most date pickers I've used before:

![image](https://user-images.githubusercontent.com/8106568/55186281-8919d480-516c-11e9-9d84-c25dfcc07818.png)

Demo link if you run `python -m SimpleHTTPServer` from cmd line:
`http://localhost:8000/index.html?model=foam.u2.view.date.DateTimePicker`