### PR TITLE
Set ScrollTableView table min-width to 968px

### DIFF
--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -29,13 +29,17 @@
     ^scrollbarContainer {
       overflow: scroll;
       display: grid;
-      grid-template-columns: auto auto;
+      grid-template-columns: 1px minmax(968px, 1fr);
     }
 
     ^ th {
       position: -webkit-sticky;
       position: sticky;
       top: 0;
+    }
+
+    ^ table {
+      min-width: 100%;
     }
   `,
 
@@ -222,7 +226,6 @@
           addClass(this.myClass('scrollbarContainer')).
           on('scroll', this.onScroll).
           start().
-            show(this.daoCount$.map((count) => count >= this.limit)).
             addClass(this.myClass('scrollbar')).
             style({ height: this.scrollHeight$ }).
           end().


### PR DESCRIPTION
Part of a fix for https://nanopay.atlassian.net/browse/CPF-733. Also fixes empty tables in the portal being 0-width, causing the buttons to scrunch up together.