### PR TITLE
Enforce fixed-width table columns

### DIFF
--- a/src/foam/nanos/boot/NSpec.js
+++ b/src/foam/nanos/boot/NSpec.js
@@ -39,7 +39,7 @@ foam.CLASS({
     {
       class: 'Boolean',
       name: 'lazy',
-      tableWidth: 60,
+      tableWidth: 65,
       value: true,
       tableCellFormatter: function(value, obj, property) {
         this
@@ -54,7 +54,7 @@ foam.CLASS({
     {
       class: 'Boolean',
       name: 'serve',
-      tableWidth: 50,
+      tableWidth: 72,
       tableCellFormatter: function(value, obj, property) {
         this
           .start()

--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -29,7 +29,7 @@
     ^scrollbarContainer {
       overflow: scroll;
       display: grid;
-      grid-template-columns: 1px minmax(968px, 1fr);
+      grid-template-columns: 1px 1fr;
     }
 
     ^ th {
@@ -39,7 +39,15 @@
     }
 
     ^ table {
-      min-width: 100%;
+      table-layout: fixed;
+      width: 1024px;
+    }
+
+    ^ td,
+    ^ th {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
     }
   `,
 

--- a/src/foam/u2/view/TableView.js
+++ b/src/foam/u2/view/TableView.js
@@ -24,6 +24,7 @@ foam.CLASS({
       letter-spacing: 0.4px;
       color: #2b2b2b;
       background: %BACKGROUNDCOLOR%;
+      box-sizing: border-box;
     }
 
     ^ th > img {

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -265,6 +265,9 @@ foam.CLASS({
                       callOn(column.tableCellFormatter, 'format', [
                         column.f ? column.f(obj) : null, obj, column
                       ]).
+                      callIf(column.f, function() {
+                        this.attr('title', column.f(obj));
+                      }).
                     end();
                 }).
                 call(function() {

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -209,6 +209,7 @@ foam.CLASS({
                     addClass(view.myClass('vertDots')).
                     addClass(view.myClass('noselect'));
                   }).
+                  style({ width: 40 }).
                   tag('div', null, view.dropdownOrigin$).
                 end();
               });


### PR DESCRIPTION
Make use of `table-layout: fixed` to make sure columns are always a fixed width and don't jump around as you scroll. There are a number of trade-offs in doing it this way and we'll need to set some `tableColumns`' and `tableWidth`'s on our models and properties to make some of the tables more usable, but hopefully we feel it's a net gain. 

See https://drafts.csswg.org/css2/tables.html#fixed-table-layout for an explanation on how it works.

The tl;dr is

> In the fixed table layout algorithm, the width of each column is determined as follows:
> 1. A column element with a value other than 'auto' for the 'width' property sets the width for that column.
> 2. Otherwise, a cell in the first row with a value other than 'auto' for the 'width' property determines the width for that column. If the cell spans more than one column, the width is divided over the columns.
> 3. Any remaining columns equally divide the remaining horizontal table space (minus borders or cell spacing).

How that translates to us:

1. The CSS width of the table is the maximum width possible. There will never be horizontal scrolling unless we explicitly set the table to be wide enough. The default is 1024px, which is set as part of this PR.
2. If a `<th>` sets a width, the column will be that width exactly. In FOAM if we set `tableWidth` on any property it'll be used to set the width of the `<th>`.
3. All of the properties that didn't set a `tableWidth` will get an equal fraction of the remaining space.