### PR TITLE
Fix errors related to setting the title attribute on table cells

### DIFF
--- a/src/foam/core/stdlib.js
+++ b/src/foam/core/stdlib.js
@@ -1011,6 +1011,12 @@ foam.LIB({
           return false;
         }
       },
+      function isPrimitive(value) {
+        return typeof value === 'string' ||
+          typeof value === 'number' ||
+          typeof value === 'boolean' ||
+          foam.Date.isInstance(value);
+      }
     ]
   });
 })();

--- a/src/foam/u2/Element.js
+++ b/src/foam/u2/Element.js
@@ -1181,9 +1181,7 @@ foam.CLASS({
         if ( foam.core.Slot.isInstance(value) ) {
           this.slotAttr_(name, value);
         } else {
-          foam.assert(
-              typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean' || foam.Date.isInstance(value),
-              'Attribute value must be a primitive type.');
+          foam.assert(foam.util.isPrimitive(value), 'Attribute value must be a primitive type.');
 
           var attr = this.getAttributeNode(name);
 

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -266,7 +266,12 @@ foam.CLASS({
                         column.f ? column.f(obj) : null, obj, column
                       ]).
                       callIf(column.f, function() {
-                        this.attr('title', column.f(obj));
+                        try {
+                          var value = column.f(obj);
+                          if ( foam.util.isPrimitive(value) ) {
+                            this.attr('title', value);
+                          }
+                        } catch (err) {}
                       }).
                     end();
                 }).


### PR DESCRIPTION
On certain DAOs we were getting a lot of errors (assertions, actually) being thrown. This PR fixes that by making sure we only set the `title` attribute on `<td>`'s to primitive values.