### PR TITLE
Don't account for trailing whitespace in the ASCIIEscapeParser

### DIFF
--- a/src/foam/lib/json/ASCIIEscapeParser.java
+++ b/src/foam/lib/json/ASCIIEscapeParser.java
@@ -21,8 +21,7 @@ public class ASCIIEscapeParser
         new Literal("t"),
         new Literal("r"),
         new Literal("f"),
-        new Literal("b")),
-      new Whitespace()));
+        new Literal("b"))));
   }
 
   public PStream parse(PStream ps, ParserContext x) {


### PR DESCRIPTION
This is causing any whitespace after a line break to get stripped.