### PR TITLE
Only set FOAM_ROOT once

### DIFF
--- a/src/foam.js
+++ b/src/foam.js
@@ -46,8 +46,8 @@
 
     path = path.substring(0, path.lastIndexOf('src/')+4);
 
-    if ( typeof global !== 'undefined' ) global.FOAM_ROOT = path;
-    if ( typeof window !== 'undefined' ) window.FOAM_ROOT = path;
+    if ( typeof global !== 'undefined' && ! global.FOAM_ROOT ) global.FOAM_ROOT = path;
+    if ( typeof window !== 'undefined' && ! window.FOAM_ROOT ) window.FOAM_ROOT = path;
 
     return function(filename) {
       document.writeln(
@@ -59,7 +59,7 @@
     var caller = flags.src || __filename;
     var path = caller.substring(0, caller.lastIndexOf('src/')+4);
 
-    if ( typeof global !== 'undefined' ) global.FOAM_ROOT = path;
+    if ( typeof global !== 'undefined' && ! global.FOAM_ROOT ) global.FOAM_ROOT = path;
 
     return function (filename) {
       require(path + filename + '.js');


### PR DESCRIPTION
It's currently getting clobbered whenever we call FOAM_FILES from other files.js files.