### PR TITLE
Respect escaped backslashes when parsing strings.

### DIFF
--- a/src/foam/lib/json/ASCIIEscapeParser.java
+++ b/src/foam/lib/json/ASCIIEscapeParser.java
@@ -17,6 +17,7 @@ public class ASCIIEscapeParser
       new Whitespace(),
       new Literal("\\"),
       new Alt(
+        new Literal("\\"),
         new Literal("n"),
         new Literal("t"),
         new Literal("r"),
@@ -33,6 +34,8 @@ public class ASCIIEscapeParser
       char c = values[2].toString().charAt(0);
 
       switch ( c ) {
+        case '\\': c = '\\';
+          break;
         case 'n': c = '\n';
           break;
         case 't': c = '\t';

--- a/src/foam/lib/json/StringParser.java
+++ b/src/foam/lib/json/StringParser.java
@@ -54,17 +54,13 @@ public class StringParser
       if ( c == ESCAPE ) {
         char   nextChar        = ps.tail().head();
         Parser escapeSeqParser = nextChar == 'u' ?
-          unicodeParser.get() : nextChar == 'n' ?
-          asciiEscapeParser.get() : null;
+          unicodeParser.get() : asciiEscapeParser.get();
+        PStream escapePS = ps.apply(escapeSeqParser, x);
+        if ( escapePS != null ) {
+          builder.append(escapePS.value());
+          tail = escapePS;
 
-        if ( escapeSeqParser != null ) {
-          PStream escapePS = ps.apply(escapeSeqParser, x);
-          if ( escapePS != null ) {
-            builder.append(escapePS.value());
-            tail = escapePS;
-
-            c = (Character) escapePS.value();
-          }
+          c = (Character) escapePS.value();
         }
       } else {
         builder.append(c);


### PR DESCRIPTION
Now, we still only use the unicodeParser when we encounter a \u but now we'll use asciiEscapeParser for everything else when we encounter a \