### PR TITLE
Fix bugs in DAO controller related to detail views

### DIFF
--- a/src/foam/comics/DAOControllerView.js
+++ b/src/foam/comics/DAOControllerView.js
@@ -231,6 +231,7 @@ foam.CLASS({
     function onEdit(s, edit, id) {
       this.stack.push({
         class: this.updateView.class,
+        of: this.data.data.of,
         detailView: this.data.detailView,
         key: id
       }, this);

--- a/src/foam/comics/DAOControllerView.js
+++ b/src/foam/comics/DAOControllerView.js
@@ -231,7 +231,6 @@ foam.CLASS({
     function onEdit(s, edit, id) {
       this.stack.push({
         class: this.updateView.class,
-        of: this.data.data.of,
         detailView: this.data.detailView,
         key: id
       }, this);

--- a/src/foam/comics/DAOCreateController.js
+++ b/src/foam/comics/DAOCreateController.js
@@ -42,7 +42,6 @@ foam.CLASS({
     },
     {
       name: 'data',
-      view: { class: 'foam.u2.DetailView' },
       factory: function() {
         return this.dao ? this.dao.of.create({}, this) : null;
       }

--- a/src/foam/comics/DAOCreateControllerView.js
+++ b/src/foam/comics/DAOCreateControllerView.js
@@ -84,8 +84,11 @@ foam.CLASS({
                 add(this.data.cls_.getAxiomsByClass(foam.core.Action)).
               end().
             end().
-            tag({class: this.detailView}, {data: this.data.obj}).
-            add(this.data$.dot('data')).
+            tag({
+              class: this.detailView,
+              of: this.dao.of,
+              data$: this.data$.dot('data')
+            }).
           end().
         end().
       end();

--- a/src/foam/comics/DAOUpdateController.js
+++ b/src/foam/comics/DAOUpdateController.js
@@ -36,7 +36,6 @@ foam.CLASS({
     },
     {
       name: 'obj',
-      view: { class: 'foam.u2.DetailView', showActions: true },
       factory: function() {
         var self = this;
         this.dao.find(this.data).then(function(obj) {

--- a/src/foam/comics/DAOUpdateControllerView.js
+++ b/src/foam/comics/DAOUpdateControllerView.js
@@ -70,9 +70,6 @@ foam.CLASS({
     {
       class: 'String',
       name: 'detailView'
-    },
-    {
-      name: 'of'
     }
   ],
 
@@ -103,7 +100,7 @@ foam.CLASS({
             end().
             tag({
               class: this.detailView,
-              of: this.of,
+              of: this.dao.of,
               data$: this.data$.dot('obj')
             }).
           end().

--- a/src/foam/comics/DAOUpdateControllerView.js
+++ b/src/foam/comics/DAOUpdateControllerView.js
@@ -70,6 +70,9 @@ foam.CLASS({
     {
       class: 'String',
       name: 'detailView'
+    },
+    {
+      name: 'of'
     }
   ],
 
@@ -98,8 +101,11 @@ foam.CLASS({
                 add(this.data.cls_.getAxiomsByClass(foam.core.Action)).
               end().
             end().
-            tag({class: this.detailView}, {data: this.data.obj}).
-            add(this.DAOUpdateController.OBJ).
+            tag({
+              class: this.detailView,
+              of: this.of,
+              data$: this.data$.dot('obj')
+            }).
           end().
         end().
       end();

--- a/src/foam/nanos/auth/User.js
+++ b/src/foam/nanos/auth/User.js
@@ -54,7 +54,7 @@ foam.CLASS({
       class: 'Long',
       name: 'id',
       final: true,
-      tableWidth: 45
+      tableWidth: 50
     },
     {
       class: 'Boolean',


### PR DESCRIPTION
## Changes

* Faceted won't work unless we set the 'of' of the view. We weren't doing that so the facet DetailView's weren't getting picked up. I fixed this for the update and create controllers.
* In https://github.com/foam-framework/foam2/commit/569bb74ec543bf644f980e61a3bec0d9785ef540 we introduced a bug where two detail views were being put in the view when creating or editing. Removed the duplicate in each case and corrected the data binding.
* Made the column for user ids a little wider since it was being cut off (unrelated to the rest of the PR, but we need this).