### PR TITLE
Fix syntax error

### DIFF
--- a/src/foam/nanos/auth/Address.js
+++ b/src/foam/nanos/auth/Address.js
@@ -241,10 +241,11 @@ foam.CLASS({
       class: 'FObjectArray',
       of: 'foam.nanos.auth.Hours',
       name: 'hours',
-      documentation: `The opening and closing hours for this address if the address 
-        represents a business.',
-
-      factory: function () { return []; },
+      documentation: `
+        The opening and closing hours for this address if the address represents
+        a business.
+      `,
+      factory: function() { return []; },
       javaFactory: 'return new Hours[] {};'
     }
   ],


### PR DESCRIPTION
The documentation comment was being opened with a backtick but closed with a single apostrophe.