### PR TITLE
Change showActions default to true for DetailView.

### DIFF
--- a/src/foam/u2/DetailView.js
+++ b/src/foam/u2/DetailView.js
@@ -62,7 +62,8 @@ foam.CLASS({
     },
     {
       class: 'Boolean',
-      name: 'showActions'
+      name: 'showActions',
+      value: true
     },
     {
       name: 'properties',


### PR DESCRIPTION
This seems like the better default as I can't think of a situation where I didn't want the actions.