### PR TITLE
added CONTAINS_IC to mlang for use in java code

### DIFF
--- a/src/foam/mlang/MLang.java
+++ b/src/foam/mlang/MLang.java
@@ -179,4 +179,11 @@ public class MLang
       throw new RuntimeException("Attempt to call CLASS_OF on non Modelled class." + cls);
     }
   }
+
+  public static Predicate CONTAINS_IC(Object o1, Object o2) {
+    return new ContainsIC.Builder(null)
+    .setArg1(MLang.prepare(o1))
+    .setArg2(MLang.prepare(o2))
+      .build();
+  }
 }


### PR DESCRIPTION
Need this in java code.

this allows us to use:

javaCode: `

dao.where(CONTAINS_IC(...,...))...

`