### PR TITLE
Fix issues using FOAM inside Google

### DIFF
--- a/src/foam/core/Script.js
+++ b/src/foam/core/Script.js
@@ -13,7 +13,10 @@ foam.CLASS({
       class: 'String',
       name: 'id',
       expression: function(package, name) {
-        return package ? package + '.' + name : name;
+        // Can't reference 'package' directly as a local variable, it's a
+        // keyword and makes Closure compiler fail to parse the expression.
+        const pkg = arguments[0];
+        return pkg ? pkg + '.' + name : name;
       },
     },
     {

--- a/test/helpers/generic_dao.js
+++ b/test/helpers/generic_dao.js
@@ -22,14 +22,6 @@
 // This will run a suite of generic DAO tests against it, that should work
 // against any DAO.
 
-if ( global.indexedDB === undefined
-  && global.webkitIndexedDB === undefined
-  && global.mozIndexedDB === undefined
-) {
-  // Load fake indexedDB into global
-  require('fake-indexeddb/auto');
-}
-
 global.genericDAOTestBattery = function(daoFactory) {
   describe('generic DAO tests', function() {
     beforeEach(function() {


### PR DESCRIPTION
Closure compiler doesn't like using `package` as a local, and relaxing the dependency on `fake-indexeddb`, so I needn't import that into Google.