### PR TITLE
Context menu dynamic availability & permission check

### DIFF
--- a/src/foam/core/Action.js
+++ b/src/foam/core/Action.js
@@ -94,14 +94,14 @@ foam.CLASS({
       name: 'isAvailable',
       label: 'Available',
       help: 'Function to determine if action is available.',
-      value: null
+      value: function() { return true; }
     },
     {
       class: 'Function',
       name: 'isEnabled',
       label: 'Enabled',
       help: 'Function to determine if action is enabled.',
-      value: null
+      value: function() { return true; }
     },
     {
       class: 'Function',

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -14,6 +14,7 @@ foam.CLASS({
   ],
 
   requires: [
+    'foam.core.ConstantSlot',
     'foam.dao.ProxyDAO',
     'foam.u2.md.OverlayDropdown',
     'foam.u2.view.EditColumnsView',
@@ -277,18 +278,16 @@ foam.CLASS({
                 }).
                 call(function() {
                   var modelActions = view.of.getAxiomsByClass(foam.core.Action);
-                  var allActions = Array.isArray(view.contextMenuActions) ?
+                  var actions = Array.isArray(view.contextMenuActions) ?
                     view.contextMenuActions.concat(modelActions) :
                     modelActions;
-                  var actions = allActions.filter(function(action) {
-                    return action.isAvailableFor(obj);
-                  });
                   var overlay = view.OverlayDropdown.create();
                   return this.start('td').
                     callIf(actions.length > 0, function() {
                       overlay.forEach(actions, function(action) {
                         this.
                           start().
+                            show(action.createIsAvailable$(view.ConstantSlot.create({ value: obj }))).
                             addClass(view.myClass('context-menu-item')).
                             add(action.label).
                             call(async function() {


### PR DESCRIPTION
## Changes

* Changed call in `UnstyledTableView` from `isAvailableFor` to `createIsAvailable$`, which will do the permission check.
* Set default `isAvailable` and `isEnabled` functions
  * This way when we make an ExpressionSlot using either of those functions, we won't get an error in ExpressionSlot because the `code` argument was null.
* Fix bug where context menu actions weren't dynamically showing/hiding based on availability.