### PR TITLE
Modified Session Model To Account For Proxied Requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ build/*
 nano.log*
 /cronjobs
 .vscode/
+android/nanos_example_client/.settings/

--- a/src/foam/box/SessionServerBox.java
+++ b/src/foam/box/SessionServerBox.java
@@ -51,17 +51,30 @@ public class SessionServerBox
         session = new Session();
         session.setId(sessionID);
 
-        // check if 'x-forwarded-for' exists
+        /**
+         * Since we are now accounting for requests which are sent through proxies which have the X-Forwarded-For header
+         * We need to take care of 2 cases:
+         * 1. if the request was sent through a proxy (X-Forwarded-For != null)
+         * 2. if the request was not sent through a proxy (X-Forwarded-For == null)
+         */
         if ( req.getHeader("X-Forwarded-For") != null ) {
-          // set x forwarded for as sourceHost
-          // set req.getRemoteHost() as proxyHost
+
+          /**
+           * Case 1. Sent through proxy
+           * SourceHost should be the IP stored in the X-Forwarded-For header
+           * ProxyHost should the IP returned by getRemoteHost() since it is the most recent node that the request was passed through
+           */
           session.setSourceHost(req.getHeader("X-Forwarded-For"));
           session.setProxyHost(req.getRemoteHost());
         } else {
-          // otherwise set source host as remote host because not going through a proxy
+          /**
+           * Case 2. Not sent through proxy
+           * SourceHost should be the IP returned by getRemoteHost() since there are no proxies
+           * ProxyHost should be null by default
+           */
           session.setSourceHost(req.getRemoteHost());
-          // ProxyHost will be null by default
         }
+        
         // Set the user to null to avoid the system user from leaking into
         // newly created sessions. If we don't do this, then a user has admin
         // privileges before they log in, which is obviously a big security
@@ -72,26 +85,23 @@ public class SessionServerBox
         // if req == null it means that we're being accessed via webSockets
         // we should be sure to handle both cases
 
-        // check if 'x-forwarded-for' exists
-        // could probably refactor this into one conditional
-        if ( req.getHeader("X-Forwarded-For") != null ) {
-          if ( ! SafetyUtil.equals(session.getSourceHost(), req.getHeader("X-Forwarded-For")) ) {
-            // If an existing session is reused with a different remote host then
-            // logout the session and force a re-login.
-            // logger.warning("Attempt to use session create for ", session.getRemoteHost(), " from ", req.getRemoteHost());
-            // session.setContext(getX().put(Session.class, session));
-            // session.setRemoteHost(req.getRemoteHost());
-            // sessionDAO.put(session);
-          }
-        } else {
-          if ( ! SafetyUtil.equals(session.getSourceHost(), req.getRemoteHost()) ) {
-            // If an existing session is reused with a different remote host then
-            // logout the session and force a re-login.
-            // logger.warning("Attempt to use session create for ", session.getRemoteHost(), " from ", req.getRemoteHost());
-            // session.setContext(getX().put(Session.class, session));
-            // session.setRemoteHost(req.getRemoteHost());
-            // sessionDAO.put(session);
-          }
+        /**
+         * similar to above, we have to account for two cases: proxy and non-proxy
+         * 1. isProxiedReqDifferent: X-Forwarded-For header exists and session source host is equivalent to the X-Forwarded-For header
+         * 2. isNonProxiedReqDifferent: X-Forwarded-For header does not exist and session source host is equivalent to req.getRemoteHost()
+         * If one is true, the other will be automatically false since the X-Forwarded-For header can either exist or not exist
+         */
+        boolean isProxiedReqDifferent = req.getHeader("X-Forwarded-For") != null && ! SafetyUtil.equals(session.getSourceHost(), req.getHeader("X-Forwarded-For"));
+        boolean isNonProxiedReqDifferent = req.getHeader("X-Forwarded-For") == null && ! SafetyUtil.equals(session.getSourceHost(), req.getRemoteHost());
+
+        // e.g. isProxedReqDifferent will automatically be false if the request is non-proxied, that is why we use the logical OR operator
+        if ( isProxiedReqDifferent || isNonProxiedReqDifferent ) {
+          // If an existing session is reused with a different remote host then
+          // logout the session and force a re-login.
+          // logger.warning("Attempt to use session create for ", session.getRemoteHost(), " from ", req.getRemoteHost());
+          // session.setContext(getX().put(Session.class, session));
+          // session.setRemoteHost(req.getRemoteHost());
+          // sessionDAO.put(session);
         }
       }
 

--- a/src/foam/box/SessionServerBox.java
+++ b/src/foam/box/SessionServerBox.java
@@ -52,7 +52,7 @@ public class SessionServerBox
         session.setId(sessionID);
 
         // check if 'x-forwarded-for' exists
-        if ( req.getHeader("X-Forwarded-For") ) {
+        if ( req.getHeader("X-Forwarded-For") != null ) {
           // set x forwarded for as sourceHost
           // set req.getRemoteHost() as proxyHost
           session.setSourceHost(req.getHeader("X-Forwarded-For"));
@@ -74,7 +74,7 @@ public class SessionServerBox
 
         // check if 'x-forwarded-for' exists
         // could probably refactor this into one conditional
-        if ( req.getHeader("X-Forwarded-For") ) {
+        if ( req.getHeader("X-Forwarded-For") != null ) {
           if ( ! SafetyUtil.equals(session.getSourceHost(), req.getHeader("X-Forwarded-For")) ) {
             // If an existing session is reused with a different remote host then
             // logout the session and force a re-login.

--- a/src/foam/nanos/http/AuthWebAgent.java
+++ b/src/foam/nanos/http/AuthWebAgent.java
@@ -214,18 +214,30 @@ public class AuthWebAgent
     HttpServletRequest req     = x.get(HttpServletRequest.class);
     Session            session = new Session((X) x.get(Boot.ROOT));
 
-    // need to handle case for proxies
-    // check if 'x-forwarded-for' exists
+    /**
+     * Since we are now accounting for requests which are sent through proxies which have the X-Forwarded-For header
+     * We need to take care of 2 cases:
+     * 1. if the request was sent through a proxy (X-Forwarded-For != null)
+     * 2. if the request was not sent through a proxy (X-Forwarded-For == null)
+     */
     if ( req.getHeader("X-Forwarded-For") != null ) {
-      // set x forwarded for as sourceHost
-      // set req.getRemoteHost() as proxyHost
+
+      /**
+       * Case 1. Sent through proxy
+       * SourceHost should be the IP stored in the X-Forwarded-For header
+       * ProxyHost should the IP returned by getRemoteHost() since it is the most recent node that the request was passed through
+       */
       session.setSourceHost(req.getHeader("X-Forwarded-For"));
       session.setProxyHost(req.getRemoteHost());
     } else {
-      // otherwise set source host as remote host because not going through a proxy
+      /**
+       * Case 2. Not sent through proxy
+       * SourceHost should be the IP returned by getRemoteHost() since there are no proxies
+       * ProxyHost should be null by default
+       */
       session.setSourceHost(req.getRemoteHost());
-      // ProxyHost will be null by default
     }
+    
     return session;
   }
 

--- a/src/foam/nanos/http/AuthWebAgent.java
+++ b/src/foam/nanos/http/AuthWebAgent.java
@@ -212,8 +212,20 @@ public class AuthWebAgent
 
   public Session createSession(X x) {
     HttpServletRequest req     = x.get(HttpServletRequest.class);
-    Session            session = new Session((X) x.get(Boot.ROOT)); 
-    session.setRemoteHost(req.getRemoteHost());
+    Session            session = new Session((X) x.get(Boot.ROOT));
+
+    // need to handle case for proxies
+    // check if 'x-forwarded-for' exists
+    if ( req.getHeader("X-Forwarded-For") ) {
+      // set x forwarded for as sourceHost
+      // set req.getRemoteHost() as proxyHost
+      session.setSourceHost(req.getHeader("X-Forwarded-For"));
+      session.setProxyHost(req.getRemoteHost());
+    } else {
+      // otherwise set source host as remote host because not going through a proxy
+      session.setSourceHost(req.getRemoteHost());
+      // ProxyHost will be null by default
+    }
     return session;
   }
 

--- a/src/foam/nanos/http/AuthWebAgent.java
+++ b/src/foam/nanos/http/AuthWebAgent.java
@@ -216,7 +216,7 @@ public class AuthWebAgent
 
     // need to handle case for proxies
     // check if 'x-forwarded-for' exists
-    if ( req.getHeader("X-Forwarded-For") ) {
+    if ( req.getHeader("X-Forwarded-For") != null ) {
       // set x forwarded for as sourceHost
       // set req.getRemoteHost() as proxyHost
       session.setSourceHost(req.getHeader("X-Forwarded-For"));

--- a/src/foam/nanos/jetty/errorPage.html
+++ b/src/foam/nanos/jetty/errorPage.html
@@ -1,0 +1,10 @@
+<html>
+    <head>
+     <meta charset="utf-8" />
+    </head>
+    <body>
+        <div class="content">
+            <h1>Unauthorized Access</h1>
+        </div>
+    </body>
+</html>

--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -55,7 +55,11 @@ foam.CLASS({
     },
     {
       class: 'String',
-      name: 'remoteHost'
+      name: 'sourceHost'
+    },
+    {
+      class: 'String',
+      name: 'proxyHost'
     },
     {
       class: 'Object',

--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -53,9 +53,17 @@ foam.CLASS({
       class: 'Long',
       name: 'uses'
     },
+
+    /**
+     * NOTE: sourceHost and proxyHost:
+     * were put in place to account for requests who have the X-Forwarded-For header
+     * sourceHost would be the IP detailed in the X-Forwarded-For header
+     * proxyHost would be what ever req.getRemoteHost returns (which is always the last node that sent the request which in this case is the proxy)
+     * in cases without proxies, sourceHost would be req.getRemoteHost and proxyHost would be null
+     */
     {
       class: 'String',
-      name: 'sourceHost'
+      name: 'sourceHost',
     },
     {
       class: 'String',


### PR DESCRIPTION
This PR is in regards to ticket [CPF-867](https://nanopay.atlassian.net/browse/CPF-867).

Rather than making a new whitelistedXForwardedForDAO, Joel and I decided that it would be unnecessary as we could just modify the Session model instead.

Here are the following changes that were made:
1. Rather than the Session model only including one remoteHost property which stores the IP returned from req.getRemoteHost(), I replaced that property with two new properties: **sourceHost** and **proxyHost**.

**sourceHost** and **proxyHost** were put in place to account for requests who have the **X-Forwarded-For** header:
     * sourceHost would be the IP detailed in the X-Forwarded-For header
     * proxyHost would be what ever req.getRemoteHost returns (which is always the last node that sent the request which in this case is the proxy)
     * in cases without proxies, sourceHost would be req.getRemoteHost and proxyHost would be null

2. Modified the logic in **AuthWebAgent.java** and **SessionServerBox.java** which previously contained session.getRemoteHost() to account for sourceHost and proxyHost by factoring in cases for proxies and non-proxies

**BONUS**: Added "_android/nanos_example_client/.settings/_" to the foam2 .gitignore after talking to numerous people facing the same problem of always having to remove this file in particular from git in order to make a proper commit to foam2