### PR TITLE
uncaught exception - notification in ablii fail because of this

### DIFF
--- a/src/foam/nanos/auth/twofactor/GoogleTOTPAuthService.js
+++ b/src/foam/nanos/auth/twofactor/GoogleTOTPAuthService.js
@@ -86,7 +86,13 @@ foam.CLASS({
     {
       name: 'verifyToken',
       javaCode: `
-        long code      = Long.parseLong(token, 10);
+        long code;
+        try {
+          code = Long.parseLong(token, 10);
+        } catch(Exception e){
+          return false;
+        }
+
         User user      = (User) (x.get("agent") != null ?
           x.get("agent") :
           x.get("user")) ;


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/CPF-350

#CPF-350 was caused here because Long.parseLong throws a NumberFormatException that was not being handled. 

Hence my solution was to wrap in a try catch, if we have a failed attempt to convert token to a long then simply token is not in the right format and verification should simply return false.