### PR TITLE
Create reusable component for list of actions

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -407,6 +407,7 @@ FOAM_FILES([
   { name: "foam/u2/view/FObjectArrayView", flags: ['web'] },
   { name: "foam/u2/view/ChoiceView", flags: ['web'] },
   { name: "foam/u2/view/RichChoiceView", flags: ['web'] },
+  { name: "foam/u2/view/OverlayActionListView", flags: ['web'] },
   { name: "foam/u2/view/RadioView", flags: ['web'] },
   { name: "foam/u2/view/TextField", flags: ['web'] },
   { name: "foam/u2/view/TreeView", flags: ['web'] },

--- a/src/foam/u2/view/OverlayActionListView.js
+++ b/src/foam/u2/view/OverlayActionListView.js
@@ -155,9 +155,7 @@ foam.CLASS({
       this.overlay_.forEach(this.data, function(action) {
         this.
           start().
-            show(action.createIsAvailable$(self.ConstantSlot.create({
-              value: self.obj
-            }))).
+            show(action.createIsAvailable$(self.obj$)).
             addClass(self.myClass('action')).
             add(action.label).
             on('click', function(evt) {

--- a/src/foam/u2/view/OverlayActionListView.js
+++ b/src/foam/u2/view/OverlayActionListView.js
@@ -13,6 +13,7 @@ foam.CLASS({
 
   requires: [
     'foam.core.ConstantSlot',
+    'foam.core.ExpressionSlot',
     'foam.u2.md.OverlayDropdown'
   ],
 
@@ -22,35 +23,35 @@ foam.CLASS({
 
   properties: [
     {
-      type: 'Action[]',
+      class: 'FObjectArray',
+      of: 'foam.core.Action',
       name: 'data'
     },
     {
-      type: 'FObject',
       name: 'obj'
     },
     {
-      type: 'URL',
+      class: 'URL',
       name: 'activeImageURL',
       value: 'images/Icon_More_Active.svg'
     },
     {
-      type: 'URL',
+      class: 'URL',
       name: 'restingImageURL',
       value: 'images/Icon_More_Resting.svg'
     },
     {
-      type: 'URL',
+      class: 'URL',
       name: 'hoverImageURL',
       value: 'images/Icon_More_Hover.svg'
     },
     {
-      type: 'URL',
+      class: 'URL',
       name: 'disabledImageURL',
       value: 'images/Icon_More_Disabled.svg'
     },
     {
-      type: 'URL',
+      class: 'URL',
       name: 'imageURL_',
       expression: function(restingImageURL, hoverImageURL, disabledImageURL, activeImageURL, hovered_, disabled_, active_) {
         if ( disabled_ ) {
@@ -64,16 +65,28 @@ foam.CLASS({
       }
     },
     {
-      type: 'Boolean',
+      class: 'Boolean',
       name: 'hovered_'
     },
     {
-      type: 'Boolean',
+      class: 'Boolean',
       name: 'disabled_'
     },
     {
-      type: 'Boolean',
+      class: 'Boolean',
       name: 'active_'
+    },
+    {
+      class: 'FObjectProperty',
+      of: 'foam.u2.Element',
+      name: 'overlay_',
+      factory: function() {
+        return this.OverlayDropdown.create();
+      }
+    },
+    {
+      class: 'Boolean',
+      name: 'overlayInitialized_'
     }
   ],
 
@@ -82,11 +95,11 @@ foam.CLASS({
       padding: 10px;
     }
 
-    ^action.disabled {
+    ^action[disabled] {
       color: #aaa;
     }
 
-    ^action:hover:not(.disabled) {
+    ^action:hover:not([disabled]) {
       cursor: pointer;
       background-color: %ACCENTCOLOR%;
     }
@@ -106,57 +119,58 @@ foam.CLASS({
     function initE() {
       var self = this;
 
-      var overlay = this.OverlayDropdown.create();
-      this.active_$.follow(overlay.opened$);
-      this.disabled_$.follow(foam.core.ExpressionSlot.create({
-        args: this.data.map((a) => a.createIsAvailable$(this.obj$)),
+      this.onDetach(this.active_$.follow(this.overlay_.opened$));
+      this.onDetach(this.disabled_$.follow(this.ExpressionSlot.create({
+        args: this.data.map((action) => action.createIsAvailable$(this.obj$)),
         code: (...rest) => ! rest.reduce((l, r) => l || r, false)
-      }));
+      })));
 
       this.
-        callIf(this.data.length > 0, function() {
-          overlay.forEach(this.data, function(action) {
-            this.
-              start().
-                show(action.createIsAvailable$(self.ConstantSlot.create({
-                  value: self.obj
-                }))).
-                addClass(self.myClass('action')).
-                add(action.label).
-                call(async function() {
-                  if ( await action.isEnabledFor(self.obj) ) {
-                    this.on('click', function(evt) {
-                      overlay.close();
-                      action.maybeCall(self.obj.__subContext__, self.obj);
-                    });
-                  } else {
-                    this.addClass('disabled');
-                  }
-                }).
-              end();
-          });
-
-          // Add the overlay to the controller so if the table is inside a
-          // container with `overflow: hidden` then this overlay won't be cut
-          // off.
-          this.ctrl.add(overlay);
-        }).
-
         start('span').
           addClass('noselect').
           start().
             addClass(this.myClass('icon')).
             style({ 'background-image': this.imageURL_$ }).
-            on('mouseover', this.onMouseOver).
-            on('mouseout', this.onMouseOut).
             callIf(this.data.length > 0, function() {
-              this.on('click', function(evt) {
-                if ( self.disabled_ ) return;
-                overlay.open(evt.clientX, evt.clientY);
-              });
+              this.
+                on('mouseover', self.onMouseOver).
+                on('mouseout', self.onMouseOut).
+                on('click', function(evt) {
+                  if ( self.disabled_ ) return;
+                  if ( ! self.overlayInitialized_ ) self.initializeOverlay();
+                  self.overlay_.open(evt.clientX, evt.clientY);
+                });
             }).
           end().
         end();
+    },
+
+    function initializeOverlay() {
+      var self = this;
+      this.overlay_.forEach(this.data, function(action) {
+        this.
+          start().
+            show(action.createIsAvailable$(self.ConstantSlot.create({
+              value: self.obj
+            }))).
+            addClass(self.myClass('action')).
+            add(action.label).
+            on('click', function(evt) {
+              self.overlay_.close();
+              action.maybeCall(self.obj.__subContext__, self.obj);
+            }).
+            attrs({
+              disabled: action.createIsEnabled$(self.obj$).map(function(e) {
+                return e ? false : 'disabled';
+              })
+            }).
+          end();
+      });
+
+      // Add the overlay to the controller so if the table is inside a container
+      // with `overflow: hidden` then this overlay won't be cut off.
+      this.ctrl.add(this.overlay_);
+      this.overlayInitialized_ = true;
     }
   ],
 

--- a/src/foam/u2/view/OverlayActionListView.js
+++ b/src/foam/u2/view/OverlayActionListView.js
@@ -1,0 +1,172 @@
+/**
+ * @license
+ * Copyright 2019 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.u2.view',
+  name: 'OverlayActionListView',
+  extends: 'foam.u2.View',
+
+  documentation: 'An overlay that presents a list of actions a user can take.',
+
+  requires: [
+    'foam.core.ConstantSlot',
+    'foam.u2.md.OverlayDropdown'
+  ],
+
+  imports: [
+    'ctrl'
+  ],
+
+  properties: [
+    {
+      type: 'Action[]',
+      name: 'data'
+    },
+    {
+      type: 'FObject',
+      name: 'obj'
+    },
+    {
+      type: 'URL',
+      name: 'activeImageURL',
+      value: 'images/Icon_More_Active.svg'
+    },
+    {
+      type: 'URL',
+      name: 'restingImageURL',
+      value: 'images/Icon_More_Resting.svg'
+    },
+    {
+      type: 'URL',
+      name: 'hoverImageURL',
+      value: 'images/Icon_More_Hover.svg'
+    },
+    {
+      type: 'URL',
+      name: 'disabledImageURL',
+      value: 'images/Icon_More_Disabled.svg'
+    },
+    {
+      type: 'URL',
+      name: 'imageURL_',
+      expression: function(restingImageURL, hoverImageURL, disabledImageURL, activeImageURL, hovered_, disabled_, active_) {
+        if ( disabled_ ) {
+          return `url(${disabledImageURL})`;
+        } else if ( active_ ) {
+          return `url(${activeImageURL})`;
+        } else if ( hovered_ ) {
+          return `url(${hoverImageURL})`;
+        }
+        return `url(${restingImageURL})`;
+      }
+    },
+    {
+      type: 'Boolean',
+      name: 'hovered_'
+    },
+    {
+      type: 'Boolean',
+      name: 'disabled_'
+    },
+    {
+      type: 'Boolean',
+      name: 'active_'
+    }
+  ],
+
+  css: `
+    ^action {
+      padding: 10px;
+    }
+
+    ^action.disabled {
+      color: #aaa;
+    }
+
+    ^action:hover:not(.disabled) {
+      cursor: pointer;
+      background-color: %ACCENTCOLOR%;
+    }
+
+    ^icon {
+      background-size: 24px;
+      width: 24px;
+      height: 24px;
+    }
+
+    ^icon:hover {
+      cursor: pointer;
+    }
+  `,
+
+  methods: [
+    function initE() {
+      var self = this;
+
+      var overlay = this.OverlayDropdown.create();
+      this.active_$.follow(overlay.opened$);
+      this.disabled_$.follow(foam.core.ExpressionSlot.create({
+        args: this.data.map((a) => a.createIsAvailable$(this.obj$)),
+        code: (...rest) => ! rest.reduce((l, r) => l || r, false)
+      }));
+
+      this.
+        callIf(this.data.length > 0, function() {
+          overlay.forEach(this.data, function(action) {
+            this.
+              start().
+                show(action.createIsAvailable$(self.ConstantSlot.create({
+                  value: self.obj
+                }))).
+                addClass(self.myClass('action')).
+                add(action.label).
+                call(async function() {
+                  if ( await action.isEnabledFor(self.obj) ) {
+                    this.on('click', function(evt) {
+                      overlay.close();
+                      action.maybeCall(self.obj.__subContext__, self.obj);
+                    });
+                  } else {
+                    this.addClass('disabled');
+                  }
+                }).
+              end();
+          });
+
+          // Add the overlay to the controller so if the table is inside a
+          // container with `overflow: hidden` then this overlay won't be cut
+          // off.
+          this.ctrl.add(overlay);
+        }).
+
+        start('span').
+          addClass('noselect').
+          start().
+            addClass(this.myClass('icon')).
+            style({ 'background-image': this.imageURL_$ }).
+            on('mouseover', this.onMouseOver).
+            on('mouseout', this.onMouseOut).
+            callIf(this.data.length > 0, function() {
+              this.on('click', function(evt) {
+                if ( self.disabled_ ) return;
+                overlay.open(evt.clientX, evt.clientY);
+              });
+            }).
+          end().
+        end();
+    }
+  ],
+
+  listeners: [
+    function onMouseOver() {
+      this.hovered_ = true;
+    },
+
+    function onMouseOut() {
+      this.hovered_ = false;
+    }
+  ]
+});

--- a/src/foam/u2/view/OverlayActionListView.js
+++ b/src/foam/u2/view/OverlayActionListView.js
@@ -54,13 +54,9 @@ foam.CLASS({
       class: 'URL',
       name: 'imageURL_',
       expression: function(restingImageURL, hoverImageURL, disabledImageURL, activeImageURL, hovered_, disabled_, active_) {
-        if ( disabled_ ) {
-          return `url(${disabledImageURL})`;
-        } else if ( active_ ) {
-          return `url(${activeImageURL})`;
-        } else if ( hovered_ ) {
-          return `url(${hoverImageURL})`;
-        }
+        if ( disabled_ ) return `url(${disabledImageURL})`;
+        if ( active_ ) return `url(${activeImageURL})`;
+        if ( hovered_ ) return `url(${hoverImageURL})`;
         return `url(${restingImageURL})`;
       }
     },

--- a/src/foam/u2/view/OverlayActionListView.js
+++ b/src/foam/u2/view/OverlayActionListView.js
@@ -109,6 +109,15 @@ foam.CLASS({
     ^icon:hover {
       cursor: pointer;
     }
+
+    ^noselect {
+      -webkit-touch-callout: none;
+      -webkit-user-select: none;
+      -khtml-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+    }
   `,
 
   methods: [
@@ -123,7 +132,7 @@ foam.CLASS({
 
       this.
         start('span').
-          addClass('noselect').
+          addClass(this.myClass('noselect')).
           start().
             addClass(this.myClass('icon')).
             style({ 'background-image': this.imageURL_$ }).

--- a/src/foam/u2/view/TableView.js
+++ b/src/foam/u2/view/TableView.js
@@ -70,13 +70,13 @@ foam.CLASS({
       background: #eee;
     }
 
-    ^ .vertDots {
+    ^vertDots {
       font-size: 20px;
       font-weight: bold;
-      padding-right: 12px;
+      padding-right: 21px;
     }
 
-    ^ .noselect {
+    ^noselect {
       -webkit-touch-callout: none;
       -webkit-user-select: none;
       -khtml-user-select: none;

--- a/src/foam/u2/view/TableView.js
+++ b/src/foam/u2/view/TableView.js
@@ -27,7 +27,7 @@ foam.CLASS({
       box-sizing: border-box;
     }
 
-    ^ th > img {
+    ^ th:not(:last-child) > img {
       margin-left: 8px;
     }
 
@@ -70,13 +70,13 @@ foam.CLASS({
       background: #eee;
     }
 
-    ^vertDots {
+    ^ .vertDots {
       font-size: 20px;
       font-weight: bold;
       padding-right: 12px;
     }
 
-    ^noselect {
+    ^ .noselect {
       -webkit-touch-callout: none;
       -webkit-user-select: none;
       -khtml-user-select: none;
@@ -85,17 +85,12 @@ foam.CLASS({
       user-select: none;
     }
 
-    ^context-menu-item {
-      padding: 10px;
-    }
-
     ^ .disabled {
       color: #aaa;
     }
 
-    ^context-menu-item:hover:not(.disabled) {
-      cursor: pointer;
-      background-color: %ACCENTCOLOR%;
+    ^context-menu-cell {
+      margin-right: 12px;
     }
   `,
 });

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -177,7 +177,7 @@ foam.CLASS({
                 this.start('th').
                   addClass(view.myClass('th-' + column.name)).
                   callIf(column.tableWidth, function() {
-                    this.style({ width: column.tableWidth });
+                    this.style({ width: column.tableWidth + 'px' });
                   }).
                   on('click', function(e) {
                     view.sortBy(column);
@@ -203,7 +203,7 @@ foam.CLASS({
                     addClass('vertDots').
                     addClass('noselect');
                   }).
-                  style({ width: 60 }).
+                  style({ width: '60px' }).
                   tag('div', null, view.dropdownOrigin$).
                 end();
               });
@@ -276,8 +276,7 @@ foam.CLASS({
                 }).
                 start('td').
                   addClass(view.myClass('context-menu-cell')).
-                  tag({
-                    class: 'foam.u2.view.OverlayActionListView',
+                  tag(view.OverlayActionListView, {
                     data: actions,
                     obj: obj
                   }).

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -200,8 +200,8 @@ foam.CLASS({
                       columnSelectionE.open(e.clientX, e.clientY);
                     }).
                     tag(view.Image, { data: '/images/Icon_More_Resting.svg' }).
-                    addClass('vertDots').
-                    addClass('noselect');
+                    addClass(view.myClass('vertDots')).
+                    addClass(view.myClass('noselect'));
                   }).
                   style({ width: '60px' }).
                   tag('div', null, view.dropdownOrigin$).
@@ -245,7 +245,7 @@ foam.CLASS({
                     // don't do anything.
                     if (
                       evt.target.nodeName === 'DROPDOWN-OVERLAY' ||
-                      evt.target.classList.contains('vertDots')
+                      evt.target.classList.contains(view.myClass('vertDots'))
                     ) return;
 
                     view.selection = obj;


### PR DESCRIPTION
Required for https://nanopay.atlassian.net/browse/CPF-966.

## Changes

* Moved the logic that generates the context menu in the table view into it's own view so that it can be reused.
  * In particular, I want to use it in the `tableCellFormatter` for properties on models being displayed in the table. For example, on an Invoice model that has a list of attachments, we can generate a dropdown action list view where each action opens the attachment in a new tab.
* Updated the "three vertical dots" icon to match the designs.

## Screenshots

### Resting and disabled are the same (as specified by design)
<img width="256" alt="Screen Shot 2019-04-17 at 11 44 35 AM" src="https://user-images.githubusercontent.com/4259165/56301676-43ff1780-6106-11e9-8fa7-44ecd49bc646.png">

### Hover (disabled entries won't transition to this state)
<img width="275" alt="Screen Shot 2019-04-17 at 11 44 48 AM" src="https://user-images.githubusercontent.com/4259165/56301677-43ff1780-6106-11e9-8ed5-d82a8e624996.png">

### Active
<img width="280" alt="Screen Shot 2019-04-17 at 11 44 55 AM" src="https://user-images.githubusercontent.com/4259165/56301678-43ff1780-6106-11e9-91dd-9ef9308a7bcf.png">

### The new view being reused in a different tableCellFormatter
<img width="336" alt="Screen Shot 2019-04-17 at 11 46 23 AM" src="https://user-images.githubusercontent.com/4259165/56301773-7d378780-6106-11e9-99ec-33898886ecc9.png">
