### PR TITLE
Add DAO decorator to cause one property to reflect the value of another

### DIFF
--- a/src/foam/dao/LinkPropertiesDAO.js
+++ b/src/foam/dao/LinkPropertiesDAO.js
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2019 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.dao',
+  name: 'LinkPropertiesDAO',
+  extends: 'foam.dao.ProxyDAO',
+  flags: ['java'],
+
+  documentation: `
+    When you have two models with a relationship between them and you want a
+    property on one of the models to reflect the value of a property on the
+    other model, you can use this decorator to make that happen.
+  `,
+
+  javaImports: [
+    'foam.core.FObject',
+    'foam.core.PropertyInfo',
+    'java.util.List',
+    'static foam.mlang.MLang.EQ',
+  ],
+
+  properties: [
+    {
+      javaType: 'foam.core.PropertyInfo',
+      javaInfoType: 'foam.core.AbstractObjectPropertyInfo',
+      name: 'sourceProperty',
+      documentation: `This property will be watched for changes.`
+    },
+    {
+      javaType: 'foam.core.PropertyInfo',
+      javaInfoType: 'foam.core.AbstractObjectPropertyInfo',
+      name: 'targetProperty',
+      documentation: `This property will follow the value of 'sourceProperty'.`
+    },
+    {
+      javaType: 'foam.core.PropertyInfo',
+      javaInfoType: 'foam.core.AbstractObjectPropertyInfo',
+      name: 'relationshipProperty',
+      documentation: 'The property on the target model that references the source model.'
+    },
+    {
+      class: 'String',
+      name: 'targetDAOKey',
+      documentation: 'The DAO that the target objects are stored in.'
+    }
+  ],
+
+  methods: [
+    {
+      name: 'put_',
+      javaCode: `
+        DAO targetDAO = ((DAO) x.get(getTargetDAOKey())).inX(x);
+        PropertyInfo idProperty = (PropertyInfo) getOf().getAxiomByName("id");
+        List<FObject> targetObjects = ((ArraySink) targetDAO
+          .where(EQ(getRelationshipProperty(), idProperty.get(obj)))
+          .select(new ArraySink())).getArray();
+
+        for ( FObject targetObj : targetObjects ) {
+          targetObj = targetObj.fclone();
+          getTargetProperty().set(targetObj, getSourceProperty().get(obj));
+          targetDAO.put(targetObj);
+        }
+
+        return super.put_(x, obj);
+      `
+    }
+  ]
+});

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -128,6 +128,7 @@ var classes = [
   'foam.dao.index.PersistedIndexTest',
   'foam.dao.SequenceNumberDAO',
   'foam.dao.SequenceNumberDAOTest',
+  'foam.dao.LinkPropertiesDAO',
   'foam.mlang.order.Comparator',
   'foam.mlang.order.Desc',
   'foam.mlang.sink.Count',


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/CPF-854

## Changes

* Added `LinkPropertiesDAO`, which lets you set up a dependency between properties across models.
  * You supply:
    * a `targetProperty` whose value you want to "follow" or "reflect" the value of a different property (possibly on another model), which is called the
    * `sourceProperty`.
    * A `relationshipProperty` is also supplied, which is what's used to look up the target objects in the target DAO, which is specified by
    * the `targetDAOKey`

We can add properties like `payeeName` and `payerName` to the `Invoice` model and then use this decorator to keep `payeeName` and `payerName` updated whenever `Business.businessName` or `User.legalName` changes. In this example:
*  `Invoice.payeeName` is the target property,
* `Business.businessName` is the source property,
* `Invoice.payeeId` is the relationship property, and
* `"invoiceDAO"` is the target DAO key.