### PR TITLE
Add remove operation as valid cmd

### DIFF
--- a/src/foam/nanos/ruler/Rule.js
+++ b/src/foam/nanos/ruler/Rule.js
@@ -199,7 +199,7 @@
       ],
       javaCode: `
         getAction().applyAction(x, obj, oldObj, ruler);
-        if ( ! getAfter() && getCmd() != null ) {
+        if ( ! getAfter() ) {
           ruler.getDelegate().cmd_(x.put("OBJ", obj), getCmd());
         }
       `
@@ -226,7 +226,7 @@
       ],
       javaCode: `
         getAsyncAction().applyAction(x, obj, oldObj, ruler);
-        if ( ! getAfter() && getCmd() != null ) {
+        if ( ! getAfter() ) {
           ruler.getDelegate().cmd_(x.put("OBJ", obj), getCmd());
         }
       `

--- a/src/foam/nanos/ruler/Rule.js
+++ b/src/foam/nanos/ruler/Rule.js
@@ -144,7 +144,6 @@
         if ( Operations.CREATE == getOperation()
           || Operations.UPDATE == getOperation()
           || Operations.CREATE_OR_UPDATE == getOperation()
-          || Operations.REMOVE == getOperation()
         ) {
           return RulerDAO.PUT_CMD;
         }
@@ -200,7 +199,7 @@
       ],
       javaCode: `
         getAction().applyAction(x, obj, oldObj, ruler);
-        if ( ! getAfter() ) {
+        if ( ! getAfter() && getCmd() != null ) {
           ruler.getDelegate().cmd_(x.put("OBJ", obj), getCmd());
         }
       `
@@ -227,7 +226,7 @@
       ],
       javaCode: `
         getAsyncAction().applyAction(x, obj, oldObj, ruler);
-        if ( ! getAfter() ) {
+        if ( ! getAfter() && getCmd() != null ) {
           ruler.getDelegate().cmd_(x.put("OBJ", obj), getCmd());
         }
       `

--- a/src/foam/nanos/ruler/Rule.js
+++ b/src/foam/nanos/ruler/Rule.js
@@ -144,6 +144,7 @@
         if ( Operations.CREATE == getOperation()
           || Operations.UPDATE == getOperation()
           || Operations.CREATE_OR_UPDATE == getOperation()
+          || Operations.REMOVE == getOperation()
         ) {
           return RulerDAO.PUT_CMD;
         }

--- a/src/foam/nanos/ruler/RulerDAO.js
+++ b/src/foam/nanos/ruler/RulerDAO.js
@@ -99,7 +99,7 @@
           getDelegate().put((FObject) x.get("OBJ"));
           return true;
         }
-        return super.cmd(obj);
+        getDelegate().cmd(obj);
       `
     },
     {


### PR DESCRIPTION
Rule Engine: Rules that were to be applied on REMOVE operation were causing infinite loops. 
Add REMOVE as a valid command. 