### PR TITLE
Enhance Ace Editor

### DIFF
--- a/src/io/c9/ace/Editor.js
+++ b/src/io/c9/ace/Editor.js
@@ -33,15 +33,11 @@ foam.CLASS({
       name: 'editor'
     },
     {
+      class: 'FObjectProperty',
+      of: 'io.c9.ace.Config',
       name: 'config',
       factory: function() {
         return this.Config.create();
-      },
-      adapt: function(_, nu) {
-        if ( typeof nu === 'object' && ! this.Config.isInstance(nu) ) {
-          return this.Config.create(nu);
-        }
-        return nu;
       }
     },
     {

--- a/src/io/c9/ace/Editor.js
+++ b/src/io/c9/ace/Editor.js
@@ -36,6 +36,12 @@ foam.CLASS({
       name: 'config',
       factory: function() {
         return this.Config.create();
+      },
+      adapt: function(_, nu) {
+        if ( typeof nu === 'object' && ! this.Config.isInstance(nu) ) {
+          return this.Config.create(nu);
+        }
+        return nu;
       }
     },
     {


### PR DESCRIPTION
This is to allow configuring Ace editor with `config` as an object literal. For example,
```
foam.CLASS({
  name: 'Thing',
  properties: [
    {
        name: 'jsonString',
        view: {
          class: 'io.c9.ace.Editor',
          config: {
            width: 600, height: 200,
            mode: 'JSON'
          }
        }
    }
  ]
});
```