### PR TITLE
When outputting CSS, track the ID of the class doing the outputting

### DIFF
--- a/src/foam/u2/Element.js
+++ b/src/foam/u2/Element.js
@@ -110,9 +110,13 @@ foam.CLASS({
           foam.__context__;
 
         // Install our own CSS, and then all parent models as well.
-        if ( X.document && ! axiom.installedDocuments_.has(X.document) ) {
-          X.installCSS(axiom.expandCSS(this, axiom.code), cls.id);
-          axiom.installedDocuments_.set(X.document, true);
+        if ( X.document ) {
+          var map = axiom.installedDocuments_.get(X.document) || {};
+          if ( ! map[this.id] ) {
+            X.installCSS(axiom.expandCSS(this, axiom.code), this.id);
+            map[this.id] = true;
+            axiom.installedDocuments_.set(X.document, map);
+          }
         }
 
         // Now call through to the original create.


### PR DESCRIPTION
A single CSS axiom can get outputted multiple times if it is inherited from a subclass so CSS may need to be output more than once to ensure all of the classes expecting the CSS can get it.

Currently, there's an issue where the ordering in which we render things can affect the CSS applied to the document. See https://github.com/foam-framework/foam2/pull/2062 for a demo showing the bug.