### PR TITLE
Make VIEW the default controller mode

### DIFF
--- a/src/foam/comics/DAOUpdateController.js
+++ b/src/foam/comics/DAOUpdateController.js
@@ -20,7 +20,6 @@ foam.CLASS({
   name: 'DAOUpdateController',
 
   topics: [
-    'finished',
     'throwError'
   ],
 
@@ -47,9 +46,6 @@ foam.CLASS({
   ],
 
   actions: [
-    function cancel() {
-      this.finished.pub();
-    },
     {
       name: 'save',
       isEnabled: function(obj) { return !! obj; },

--- a/src/foam/comics/DAOUpdateControllerView.js
+++ b/src/foam/comics/DAOUpdateControllerView.js
@@ -23,6 +23,7 @@ foam.CLASS({
   requires: [
     'foam.comics.DAOUpdateController',
     'foam.u2.ControllerMode',
+    'foam.u2.DisplayMode',
     'foam.u2.dialog.NotificationMessage'
   ],
 
@@ -134,18 +135,11 @@ foam.CLASS({
           // Actions grouped to the right
           .start()
             .start()
-              .show(this.mode$.map(function(m) {
-                return m == foam.u2.DisplayMode.RW;
-              }))
-              .startContext({ data: this })
-                .add(this.VIEW)
-              .endContext()
+              .show(this.mode$.map((m) => m === this.DisplayMode.RW))
               .add(this.data.cls_.getAxiomsByClass(foam.core.Action))
             .end()
             .start()
-              .show(this.mode$.map(function(m) {
-                return m == foam.u2.DisplayMode.RO;
-              }))
+              .show(this.mode$.map((m) => m === this.DisplayMode.RO))
               .startContext({ data: this })
                 .add(this.EDIT)
               .endContext()

--- a/src/foam/comics/DAOUpdateControllerView.js
+++ b/src/foam/comics/DAOUpdateControllerView.js
@@ -47,19 +47,11 @@ foam.CLASS({
       justify-content: space-between;
       margin: 8px 0;
     }
-    ^detail-container {
-      overflow-x: scroll;
-    }
-    /* TODO: Remove references to nanopay */
-    ^ .net-nanopay-ui-ActionView {
-      background: #59aadd;
-      color: white;
-    }
-    ^ .net-nanopay-ui-ActionView + .net-nanopay-ui-ActionView {
+    ^action-container > div > div > * + * {
       margin-left: 8px;
     }
-    ^ .net-nanopay-ui-ActionView-delete {
-      background: #d55;
+    ^detail-container {
+      overflow-x: scroll;
     }
   `,
 

--- a/src/foam/comics/DAOUpdateControllerView.js
+++ b/src/foam/comics/DAOUpdateControllerView.js
@@ -56,7 +56,7 @@ foam.CLASS({
       color: white;
     }
     ^ .net-nanopay-ui-ActionView + .net-nanopay-ui-ActionView {
-      margin-left: 4px;
+      margin-left: 8px;
     }
     ^ .net-nanopay-ui-ActionView-delete {
       background: #d55;

--- a/src/foam/u2/DetailView.js
+++ b/src/foam/u2/DetailView.js
@@ -118,7 +118,7 @@ foam.CLASS({
 
     ^toolbar {
       display: flex;
-      padding-top: 4px;
+      padding-top: 8px;
     }
   `,
 

--- a/src/foam/u2/DetailView.js
+++ b/src/foam/u2/DetailView.js
@@ -110,6 +110,12 @@ foam.CLASS({
   ],
 
   css: `
+    /* Temporary fix until we refactor DetailView to not use a table. */
+    ^ {
+      margin: auto;
+      width: 100%;
+    }
+
     ^toolbar {
       display: flex;
       padding-top: 4px;


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/CPF-988

## Notes

* Made the default `controllerMode` of `DAOUpdateControllerView` `VIEW`.
* Moved the cancel action off of `DAOUpdateController` and on to `DAOUpdateControllerView`
  * This was so we can always show the cancel button on the left and not include it on the right. I can filter the list of actions we show on the right instead if people think that's a better solution.
* Updated the layout of the actions so cancel is always on the left and the other actions are on the right
* Updated the width of the view and made it horizontally scrollable if it's too wide
* Added and "Edit" button that lets the user switch to edit mode

## Screenshots

### Read-only mode

<img width="1036" alt="Screen Shot 2019-04-24 at 10 39 50 AM" src="https://user-images.githubusercontent.com/4259165/56668450-89c75d00-667d-11e9-8ea7-e4b13f6895c3.png">

### After clicking "Edit"

<img width="1040" alt="Screen Shot 2019-04-24 at 10 51 50 AM" src="https://user-images.githubusercontent.com/4259165/56669357-04dd4300-667f-11e9-8143-394ce1241918.png">

### Showing horizontal overflow (it's scrollable)

<img width="1041" alt="Screen Shot 2019-04-24 at 10 41 01 AM" src="https://user-images.githubusercontent.com/4259165/56668452-8a5ff380-667d-11e9-8f3c-12d20c8ff089.png">
