### PR TITLE
Set trim default back to false

### DIFF
--- a/src/foam/core/types.js
+++ b/src/foam/core/types.js
@@ -40,7 +40,7 @@ foam.CLASS({
     {
       class: 'Boolean',
       name: 'trim',
-      value: true
+      value: false
     },
     { class: 'Int', name: 'width', value: 30 },
     [ 'adapt', function(_, a) {


### PR DESCRIPTION
Setting it to true breaks the build because the code generation logic
strips out newlines and spaces that are necessary.