### PR TITLE
Fix CSS generation

### DIFF
--- a/src/foam/u2/Element.js
+++ b/src/foam/u2/Element.js
@@ -84,10 +84,7 @@ foam.CLASS({
   properties: [
     {
       class: 'String',
-      name: 'code',
-      postSet: function(_, code) {
-        this.expands_ = code.indexOf('^') != -1;
-      }
+      name: 'code'
     },
     {
       name: 'name',
@@ -101,7 +98,10 @@ foam.CLASS({
     {
       class: 'Boolean',
       name: 'expands_',
-      documentation: 'True iff the CSS contains a ^ which needs to be expanded.'
+      documentation: 'True iff the CSS contains a ^ which needs to be expanded.',
+      expression: function(code) {
+        return code.includes('^');
+      }
     }
   ],
 


### PR DESCRIPTION
We have a model like this:

```JavaScript
foam.CLASS({
  package: 'a.b.c',
  name: 'SpecialCssAxiom',
  extends: 'foam.u2.CSS',
  properties: [
    {
      name: 'code',
      value: `
        ^ {
          background-color: red;
        }
      `
    }
  ]
});
```

and another model that looks like this:

```JavaScript
foam.CLASS({
  package: 'a.b.c',
  name: 'MyWizardView',
  
  axioms: [
    { class: 'a.b.c.MyCssAxiom' }
  ],

  css: `
    ^ .title {
      font-size: 26px;
    }
  `
});
```

The problem was that the CSS in `MyCssAxiom` wasn't getting expanded to replace `^` with `.a-b-c-MyWizardView`. This was happening because `expands_` wasn't being set properly. The changes in this PR fix that.