### PR TITLE
Handle/ignore promise rejections in Promised postSet handler

### DIFF
--- a/src/foam/core/Promised.js
+++ b/src/foam/core/Promised.js
@@ -94,7 +94,15 @@ foam.CLASS({
           this[stateName]    = undefined;
           this[delegateName] = undefined;
 
-          p.then(function(d) { self[delegateName] = d; });
+          p.then(function(d) {
+            self[delegateName] = d;
+          }).catch(function(err) {
+            // Silently do nothing to avoid unhandled promise rejections
+            // in this fork of the promise chain. As long as some other code
+            // uses the promise (`p.then` or similar) then there would still
+            // be an unhandled promise rejection if *that* fork of the promise
+            // chain lacks error handling.
+          });
         };
       }
     }


### PR DESCRIPTION
The original code introduced a promise which wasn't returned, and
which if rejected would cause an unhandled promise rejection. The new
code is conceptually similar to this:

```js
function demo() {
  const p = Promise.reject(new Error('demo'));
  p.then(() => {}, () => console.log('handled rejection'));
  return p;
}
```

Calling just `demo()` without doing anything with the return value
will now unfortunately not result in an unhandled promise rejection,
but `demo().then(() => {})` or `await demo()` fortunately would, so if
one actually uses the returned promise errors aren't silenced.

This caused unhandled promise rejections in the confluence test suite.