### PR TITLE
Let ActionView support sizes

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -376,6 +376,7 @@ FOAM_FILES([
   { name: "foam/u2/TableView", flags: ['web'] },
   { name: "foam/u2/TableSelection", flags: ['web'] },
   { name: "foam/u2/Scroller", flags: ['web'] },
+  { name: "foam/u2/ButtonSize", flags: ['web'] },
   { name: "foam/u2/UnstyledActionView", flags: ['web'] },
   { name: "foam/u2/ActionView", flags: ['web'] },
   { name: "foam/u2/DetailPropertyView", flags: ['web'] },

--- a/src/files2.js
+++ b/src/files2.js
@@ -367,6 +367,7 @@ FOAM_FILES([
   { name: "foam/u2/TableView", flags: ['web'] },
   { name: "foam/u2/TableSelection", flags: ['web'] },
   { name: "foam/u2/Scroller", flags: ['web'] },
+  { name: "foam/u2/ButtonSize", flags: ['web'] },
   { name: "foam/u2/ActionView", flags: ['web'] },
   { name: "foam/u2/UnstyledActionView", flags: ['web'] },
   { name: "foam/u2/DetailPropertyView", flags: ['web'] },

--- a/src/foam/comics/DAOControllerView.js
+++ b/src/foam/comics/DAOControllerView.js
@@ -149,14 +149,17 @@ foam.CLASS({
             .callIfElse(this.data.primaryAction, function() {
               this.startContext({ data: self })
                 .start()
-                  .add(self.data.primaryAction)
+                  .tag(self.data.primaryAction, { size: 'LARGE' })
                 .end()
               .endContext();
             }, function() {
               if ( self.data.createLabel ) {
-                this.tag(self.cls.CREATE, { label$: self.data.createLabel$ });
+                this.tag(self.cls.CREATE, {
+                  label$: self.data.createLabel$,
+                  size: 'LARGE'
+                });
               } else {
-                this.start().add(self.cls.CREATE).end();
+                this.start().tag(self.cls.CREATE, { size: 'LARGE' }).end();
               }
             })
           .end()

--- a/src/foam/core/Action.js
+++ b/src/foam/core/Action.js
@@ -131,6 +131,20 @@ foam.CLASS({
         When set to true, this action should be styled in a way that indicates
         that this action is not as important as other actions.
       `
+    },
+    {
+      class: 'Boolean',
+      name: 'isLink',
+      documentation: `
+        When set to true, this action should be styled without a background or
+        border.
+      `
+    },
+    {
+      class: 'Enum',
+      of: 'foam.u2.ButtonSize',
+      name: 'size',
+      value: 'MEDIUM'
     }
   ],
 

--- a/src/foam/core/Action.js
+++ b/src/foam/core/Action.js
@@ -131,20 +131,6 @@ foam.CLASS({
         When set to true, this action should be styled in a way that indicates
         that this action is not as important as other actions.
       `
-    },
-    {
-      class: 'Boolean',
-      name: 'isLink',
-      documentation: `
-        When set to true, this action should be styled without a background or
-        border.
-      `
-    },
-    {
-      class: 'Enum',
-      of: 'foam.u2.ButtonSize',
-      name: 'size',
-      value: 'MEDIUM'
     }
   ],
 

--- a/src/foam/u2/ButtonSize.js
+++ b/src/foam/u2/ButtonSize.js
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright 2019 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.ENUM({
+  package: 'foam.u2',
+  name: 'ButtonSize',
+
+  values: [
+    { name: 'SMALL', label: 'Small' },
+    { name: 'MEDIUM', label: 'Medium' },
+    { name: 'LARGE', label: 'Large' }
+  ]
+});

--- a/src/foam/u2/UnstyledActionView.js
+++ b/src/foam/u2/UnstyledActionView.js
@@ -88,6 +88,12 @@ foam.CLASS({
     {
       name: 'label',
       factory: function(action) { return this.action.label; }
+    },
+    {
+      class: 'Enum',
+      of: 'foam.u2.ButtonSize',
+      name: 'size',
+      value: 'MEDIUM'
     }
   ],
 
@@ -110,9 +116,7 @@ foam.CLASS({
           this.attrs({ disabled: this.action.createIsEnabled$(this.data$).map((e) => e ? false : 'disabled') });
         }
 
-        if ( this.action.isLink ) {
-          this.addClass(this.myClass('link'));
-        } else if ( this.action.isDestructive && this.action.isSecondary ) {
+        if ( this.action.isDestructive && this.action.isSecondary ) {
           this.addClass(this.myClass('secondary-destructive'));
         } else if ( this.action.isDestructive ) {
           this.addClass(this.myClass('destructive'));
@@ -120,7 +124,7 @@ foam.CLASS({
           this.addClass(this.myClass('secondary'));
         }
 
-        this.addClass(this.myClass(this.action.size.label.toLowerCase()));
+        this.addClass(this.myClass(this.size.label.toLowerCase()));
       }
     },
 

--- a/src/foam/u2/UnstyledActionView.js
+++ b/src/foam/u2/UnstyledActionView.js
@@ -110,13 +110,17 @@ foam.CLASS({
           this.attrs({ disabled: this.action.createIsEnabled$(this.data$).map((e) => e ? false : 'disabled') });
         }
 
-        if ( this.action.isDestructive && this.action.isSecondary ) {
+        if ( this.action.isLink ) {
+          this.addClass(this.myClass('link'));
+        } else if ( this.action.isDestructive && this.action.isSecondary ) {
           this.addClass(this.myClass('secondary-destructive'));
         } else if ( this.action.isDestructive ) {
           this.addClass(this.myClass('destructive'));
         } else if ( this.action.isSecondary ) {
           this.addClass(this.myClass('secondary'));
         }
+
+        this.addClass(this.myClass(this.action.size.label.toLowerCase()));
       }
     },
 

--- a/src/foam/u2/view/TableCellFormatter.js
+++ b/src/foam/u2/view/TableCellFormatter.js
@@ -82,7 +82,7 @@ foam.CLASS({
       value: function(_, obj, axiom) {
         this.
           startContext({ data: obj }).
-          add(axiom).
+          tag(axiom, { size: 'SMALL' }).
           endContext();
       }
     },


### PR DESCRIPTION
So we can support things like

<img width="113" alt="Screen Shot 2019-04-30 at 9 52 08 AM" src="https://user-images.githubusercontent.com/4259165/56966715-b40d9480-6b2d-11e9-993d-2a4d684d51ab.png">

for Liquid and

<img width="125" alt="Screen Shot 2019-04-30 at 9 52 56 AM" src="https://user-images.githubusercontent.com/4259165/56966743-bec82980-6b2d-11e9-9b8e-686bcfbce8dc.png">

for Ablii, as well as different button sizes specified by the model rather than custom CSS everywhere.