### PR TITLE
FloatView Fixes

### DIFF
--- a/src/foam/u2/FloatView.js
+++ b/src/foam/u2/FloatView.js
@@ -70,27 +70,27 @@ foam.CLASS({
       if ( ! foam.Undefined.isInstance(this.data) ) view.set(this.dataToText(this.data));
 
       if ( this.onKey ) {
-        this.on('blur', function() {
-          var value = data.get();
-          view.set(self.formatNumber(value));
+        // When onKey is enabled, we aren't notified when the view is blurred.
+        // This forces reformatting of the field when the view is blurred.
+        // Reformatting on the keystroke makes for a poor user experience.
+        this.on('blur', function () {
+          view.set(self.dataToText(data.get()));
         });
-       }
+      }
 
+      var preventFeedback = false;
       view.sub(function() {
-        var text = view.get();
-        var val = data.get();
-        if ( val == self.textToData(text) && self.needsTrim(text, self.precision) ) {
-          // trim trailing 0's
-          view.set(text.substring(0, text.indexOf('.') + self.precision + 1));
-        };
+        if ( preventFeedback ) return;
+        preventFeedback = true;
         data.set(self.textToData(view.get()));
+        preventFeedback = false;
       });
 
       data.sub(function() {
-        var text = view.get();
-        // no need to trim input if its value is the same as data, and it's not too long 
-        if ( self.textToData(text) == data.get() && ! self.needsTrim(text, self.precision) ) return;
+        if ( preventFeedback ) return;
+        preventFeedback = true;
         view.set(self.dataToText(data.get()));
+        preventFeedback = false;
       });
     },
 
@@ -103,7 +103,7 @@ foam.CLASS({
     },
 
     function formatNumber(val) {
-      if ( ! val ) return '0';
+      if ( ! val ) val = 0;
       val = val.toFixed(this.precision);
       return val;
     },
@@ -116,10 +116,6 @@ foam.CLASS({
 
     function textToData(text) {
       return parseFloat(text) || 0;
-    },
-
-    function needsTrim(text, precision) {
-      return text.indexOf('.') > 0 && text.length - text.indexOf('.') - 1 > precision;
     }
   ]
 });

--- a/src/foam/u2/FloatView.js
+++ b/src/foam/u2/FloatView.js
@@ -69,14 +69,11 @@ foam.CLASS({
 
       if ( ! foam.Undefined.isInstance(this.data) ) view.set(this.dataToText(this.data));
 
-      if ( this.onKey ) {
-        // When onKey is enabled, we aren't notified when the view is blurred.
-        // This forces reformatting of the field when the view is blurred.
-        // Reformatting on the keystroke makes for a poor user experience.
-        this.on('blur', function () {
-          view.set(self.dataToText(data.get()));
-        });
-      }
+      // When focus is lost on the view, force the view's value to equal the data
+      // to ensure it's formatted properly.
+      this.on('blur', function () {
+        view.set(self.dataToText(data.get()));
+      });
 
       var preventFeedback = false;
       view.sub(function() {

--- a/src/foam/u2/tag/Input.js
+++ b/src/foam/u2/tag/Input.js
@@ -137,7 +137,7 @@ foam.CLASS({
       this.SUPER(p);
 
       this.visibility$.follow(p.createVisibilityFor(this.__context__.data$));
-      if ( ! this.onKey && p.validateObj ) this.onKey = true;
+      if ( ! this.hasOwnProperty('onKey') && p.validateObj ) this.onKey = true;
     },
 
     function updateMode_(mode) {


### PR DESCRIPTION
Make the FloatView only format when the view loses focus. It's now independent of onKey and a bit simpler than before.

Also make fromProperty not force onKey to true when validation is present if the view already has onKey manually set.