### PR TITLE
Fix bug where editing fails when you go through a relationship table row

### DIFF
--- a/src/foam/dao/Relationship.js
+++ b/src/foam/dao/Relationship.js
@@ -15,7 +15,6 @@ foam.CLASS({
     'foam.dao.ManyToManyRelationshipAxiom',
     'foam.dao.ManyToManyRelationshipDAO',
     'foam.dao.OneToManyRelationshipAxiom',
-    'foam.dao.ReadOnlyDAO',
     'foam.dao.RelationshipDAO'
   ],
 
@@ -418,20 +417,16 @@ foam.CLASS({
         var targetDAO = this.__context__[this.targetDAOKey];
         foam.assert(targetDAO, 'Missing DAO for targetDAOKey', this.targetDAOKey);
 
-        return foam.dao.ReadOnlyDAO.create({
-          delegate: foam.dao.ManyToManyRelationshipDAO.create({
-            relationship: this,
-            delegate: targetDAO
-          }, this)
+        return foam.dao.ManyToManyRelationshipDAO.create({
+          relationship: this,
+          delegate: targetDAO
         }, this);
       },
       javaFactory: `
         try {
-          return new foam.dao.ReadOnlyDAO.Builder(getX()).
-            setDelegate(new foam.dao.ManyToManyRelationshipDAO.Builder(getX()).
-              setRelationship(this).
-              setDelegate((foam.dao.DAO)getX().get(getTargetDAOKey())).
-              build()).
+          return new foam.dao.ManyToManyRelationshipDAO.Builder(getX()).
+            setRelationship(this).
+            setDelegate((foam.dao.DAO)getX().get(getTargetDAOKey())).
             build();
         } catch ( NullPointerException e ) {
           foam.nanos.logger.Logger logger = (foam.nanos.logger.Logger) getX().get("logger");
@@ -441,11 +436,9 @@ foam.CLASS({
         `
   ,
       swiftFactory:
-`return __context__.create(foam_dao_ReadOnlyDAO.self, args: [
-  "delegate": __context__.create(foam_dao_ManyToManyRelationshipDAO.self, args: [
-    "relationship": self,
-    "delegate": __context__[targetDAOKey]
-  ])
+`return __context__.create(foam_dao_ManyToManyRelationshipDAO.self, args: [
+  "relationship": self,
+  "delegate": __context__[targetDAOKey]
 ])`
     },
     {

--- a/src/foam/u2/DetailView.js
+++ b/src/foam/u2/DetailView.js
@@ -70,10 +70,10 @@ foam.CLASS({
       // TODO: Make an FObjectArray when it validates properly
       preSet: function(_, ps) {
         foam.assert(ps, 'Properties required.');
-        for ( var i = 0 ; i < ps.length ; i++ ) {
+        for ( var i = 0; i < ps.length; i++ ) {
           foam.assert(
               foam.core.Property.isInstance(ps[i]),
-              "Non-Property in 'properties' list:",
+              `Non-Property in 'properties' list:`,
               ps);
         }
         return ps;
@@ -82,7 +82,9 @@ foam.CLASS({
         if ( ! of ) return [];
         return this.of.getAxiomsByClass(foam.core.Property).
           // TODO: this is a temporary fix, but Visibility.HIDDEN should be included and could be switched
-          filter(function(p) { return ! ( p.hidden || p.visibility === foam.u2.Visibility.HIDDEN ); });
+          filter(function(p) {
+            return ! ( p.hidden || p.visibility === foam.u2.Visibility.HIDDEN );
+          });
       }
     },
     {
@@ -100,13 +102,11 @@ foam.CLASS({
     {
       name: 'title',
       attribute: true,
-      expression: function(of) { return this.of ? this.of.model_.label : ''; },
-      // documentation: function() {/*
-      //  <p>The display title for the $$DOC{ref:'foam.ui.View'}.
-      //  </p>
-      //*/}
+      expression: function(of) {
+        return this.of ? this.of.model_.label : '';
+      },
     },
-    [ 'nodeName', 'div' ]
+    ['nodeName', 'div']
   ],
 
   css: `
@@ -184,11 +184,11 @@ foam.CLASS({
         self.currentData = self.data;
 
         var title = self.title && this.E('tr').
-          start('td').addClass(this.myClass('title')).attrs({colspan: 2}).
+          start('td').addClass(this.myClass('title')).attrs({ colspan: 2 }).
             add(self.title$).
           end();
 
-        var tabs = foam.u2.Tabs.create().style({width: '1200px'});
+        var tabs = foam.u2.Tabs.create().style({ width: '1200px' });
 
         return self.actionBorder(
           this.
@@ -202,27 +202,35 @@ foam.CLASS({
               if ( config ) {
                 p = p.clone();
                 for ( var key in config ) {
-                  p[key] = config[key];
+                  if ( config.hasOwnProperty(key) ) {
+                    p[key] = config[key];
+                  }
                 }
               }
-              if ( p.cls_ == foam.dao.OneToManyRelationshipProperty || p.cls_ == foam.dao.ManyToManyRelationshipProperty ) {
+
+              if (
+                p.cls_ == foam.dao.OneToManyRelationshipProperty ||
+                p.cls_ == foam.dao.ManyToManyRelationshipProperty
+              ) {
                 hasTabs = true;
                 var label = p.label;
-                let tab = self.Tab.create({label: label});
-                var dao = p.cls_ == foam.dao.ManyToManyRelationshipProperty ? p.get(self.data).getJunctionDAO() : p.get(self.data);
+                let tab = self.Tab.create({ label: label });
+                var dao = p.cls_ == foam.dao.ManyToManyRelationshipProperty
+                  ? p.get(self.data).getJunctionDAO()
+                  : p.get(self.data);
                 dao.select(expr.COUNT()).then(function(c) {
                   tab.label = label + ' (' + c.value + ')';
                 });
                 p = p.clone();
                 p.label = '';
-                tab.start('table').tag(self.DetailPropertyView, {prop: p});
+                tab.start('table').tag(self.DetailPropertyView, { prop: p });
                 tabs.add(tab);
               } else {
-                this.tag(self.DetailPropertyView, {prop: p});
+                this.tag(self.DetailPropertyView, { prop: p });
               }
             }).
             callIf(hasTabs, function() {
-              this.start('tr').start('td').setAttribute('colspan','2').add(tabs).end().end();
+              this.start('tr').start('td').setAttribute('colspan', '2').add(tabs).end().end();
             }));
           }));
     },


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/CPF-1060

## Problem

When you edit an FObject in the DAO controller view, you get brought to a DetailView for that FObject. If that FObject has relationship properties, they will get rendered as DetailViews in tabs. In each relationship property's DetailView, there is only one property displayed (for ManyToManyRelationshipProperties): `dao :: DAOProperty`. The default view for DAOProperties is an InlineBrowserView, which contains a table view. When you double click a row in that table view, you get brought to a new DetailView for that object. However, now the underlying DAO is the relationship property, which is currently decorated with a `ReadOnlyDAO` decorator. This means that when you try to edit the FObject you double-clicked on in the relationship property table and click "Save", it throws an error because you can't put to a `ReadOnlyDAO`.

## Changes

* Removed the `ReadOnlyDAO` decorator on the `dao` property of the `ManyToManyRelationshipImpl` model
* Fixed linter errors in `DetailView`

## Discussion

I'm not aware of why it was added in the first place. I'm not saying it wasn't necessary, I'm just saying that I'm not aware of the reason. I'm expecting there was a good reason and so this won't be merged. In that case, does anyone have any ideas on how I can do this? I tried making a custom DetailView for `ManyToManyRelationshipImpl` but the data of that view is always set to the `dao` property's value anyway, so that doesn't fix anything. I was hoping that if the detail view specified the data then the property's value wouldn't be used, but that's not the case because of this bit of code that overwrites it: https://github.com/foam-framework/foam2/blob/master/src/foam/u2/Element.js#L2145-L2147. If I could override `toE` on just that `ManyToManyRelationshipImpl.dao` property then it would work, but I couldn't find a way to do that.