### PR TITLE
fixing an incorrect url for USBankAccounts

### DIFF
--- a/src/foam/u2/view/FileView.js
+++ b/src/foam/u2/view/FileView.js
@@ -14,23 +14,16 @@ foam.CLASS({
     'foam.nanos.fs.File'
   ],
 
-  imports: [
-    'blobService'
-  ],
-
   properties: [
     'data'
   ],
 
   methods: [
     function initE() {
-      var view = this;
       this.setNodeName('span')
         .start('input').attrs({ type: 'file' }).on('change', this.onChange).end()
         .add(this.slot(function(data) {
-          var file = data && data.data;
-          var url = file && view.blobService.urlFor(file);
-          return ! url ? this.E('span') : this.E('a').attrs({ href: url }).add('Download')
+          return ! data ? this.E('span') : this.E('a').attrs({ href: data.address }).add('Download');
         }, this.data$));
     }
   ],


### PR DESCRIPTION
So this view is only used as the default for FileProperty. 

However the issue with blobService, was the url that was returned contained the wrong Id. 

Switching this to data.address lets us use the preset url on files and avoid the incorrect result returned from blobService.