### PR TITLE
When pulling in constants from a library, Check if objects have a `cl…

### DIFF
--- a/src/foam/core/lib.js
+++ b/src/foam/core/lib.js
@@ -124,7 +124,13 @@ foam.LIB = function LIB(model) {
       typeof model.constants === 'object',
       'Constants must be a map.');
 
-    for ( var key in model.constants ) root[key] = model.constants[key];
+    for ( var key in model.constants ) {
+      var v = root[key] = model.constants[key];
+      if ( foam.Object.isInstance(v) && v.class ) {
+        v = foam.lookup(v.class).create(v);
+      }
+      root[key] = v;
+    }
   }
 
   if ( model.methods ) {


### PR DESCRIPTION
…ass` property and create an instance of them if so.

When the builder runs, it serializes everything and can result in constants in a foam.LIB to go from something like:
```
    Compact: foam.json.Outputter.create({
      pretty: false,
      formatDatesAsNumbers: true,
      formatFunctionsAsStrings: false,
      outputDefaultValues: false,
      pretty: false,
      strict: false
    },
```
to this:
```
Compact: {
                       class: "foam.json.Outputter",
                       indentStr: "",
                       nlStr: "",
                       postColonStr: "",
                       alwaysQuoteKeys: false,
                       formatDatesAsNumbers: true,
                       formatFunctionsAsStrings: false,
                       outputDefaultValues: false,
                       pretty: false,
                       strict: false
},
```

This PR makes constants in foam.LIB convert objects with a `class` property to an instance of that class.