### PR TITLE
Use a factory to set the data_ in CalendarDatePicker. Otherwise, all …

### DIFF
--- a/src/foam/u2/view/date/CalendarDatePicker.js
+++ b/src/foam/u2/view/date/CalendarDatePicker.js
@@ -15,7 +15,7 @@ foam.CLASS({
     {
       class: 'Date',
       name: 'data_',
-      value: new Date(),
+      factory: function() { return new Date(); },
       postSet: function(_, n) {
         if ( this.skipDateUpdate ) {
           this.skipDateUpdate = false;


### PR DESCRIPTION
…CalendarDatePickers will be initialized with the same date which will be the time that the CalendarDatePicker was parsed.