### PR TITLE
Move the code to adapt a date to foam.Date.toDate and make it handle …

### DIFF
--- a/src/foam/core/stdlib.js
+++ b/src/foam/core/stdlib.js
@@ -740,6 +740,19 @@ foam.LIB({
     },
     // Hash n & n: Truncate to 32 bits.
     function hashCode(d) { var n = d.getTime(); return n & n; },
+    function toDate(d) {
+      if (foam.Object.isInstance(d) && d.class == '__Timestamp__')
+        return new Date(d.value);
+      if (typeof d === 'number') return new Date(d);
+      if (typeof d === 'string') {
+        var ret = new Date(d);
+
+        if (isNaN(ret.getTime())) throw 'Invalid Date: ' + d;
+
+        return ret;
+      }
+      return d;
+    },
     function relativeDateString(date) {
       // FUTURE: make this translatable for i18n, including plurals
       //   "hours" vs. "hour"

--- a/src/foam/core/types.js
+++ b/src/foam/core/types.js
@@ -94,18 +94,12 @@ foam.CLASS({
       }
     },
     {
+      name: 'value',
+      adapt: function (_, d) { return foam.Date.toDate(d); }
+    },
+    {
       name: 'adapt',
-      value: function (_, d) {
-        if ( typeof d === 'number' ) return new Date(d);
-        if ( typeof d === 'string' ) {
-          var ret = new Date(d);
-
-          if ( isNaN(ret.getTime()) ) throw 'Invalid Date: ' + d;
-
-          return ret;
-        }
-        return d;
-      }
+      value: function (_, d) { return foam.Date.toDate(d); }
     },
     [ 'type', 'Date' ],
     {


### PR DESCRIPTION
…objects with class: '__Timestamp__'. Use this method to adapt values.