### PR TITLE
Improved action permission support

### DIFF
--- a/src/foam/core/Action.js
+++ b/src/foam/core/Action.js
@@ -220,7 +220,7 @@ foam.CLASS({
 
     function hasPermissions_(configKey, data$) {
       if ( this.permissionConfig == null ) return Promise.resolve(true);
-      return Promise.all(this.permissionConfig[configKey].map((p) => this.checkPermission(data$.get().__subContext__, p))).then((values) => values.reduce((l, r) => l && r), true);
+      return Promise.all(this.permissionConfig[configKey].map((p) => this.checkPermission(data$.get().__subContext__, p))).then((values) => values.reduce((l, r) => l && r, true));
     }
   ]
 });

--- a/src/foam/core/Action.js
+++ b/src/foam/core/Action.js
@@ -114,7 +114,15 @@ foam.CLASS({
     {
       class: 'Boolean',
       name: 'permissionRequired',
-      documentation: 'When set to true, package.model.permission.action is needed to execute this action.'
+      documentation: 'When set to true, a permission is needed to execute this action.'
+    },
+    {
+      class: 'String',
+      name: 'permission',
+      documentation: 'The permission required to view this action.',
+      factory: function() {
+        return this.sourceCls_.id + '.permission.' + this.name;
+      }
     }
   ],
 
@@ -136,8 +144,7 @@ foam.CLASS({
 
     function checkPermission(x) {
       if ( ! this.permissionRequired || ! x.auth ) return Promise.resolve(true);
-      var permission = this.sourceCls_.id + '.permission.' + this.name;
-      return x.auth.check(null, permission);
+      return x.auth.check(null, this.permission);
     },
 
     function isEnabledFor(data) {

--- a/src/foam/nanos/auth/ActionPermissionConfiguration.js
+++ b/src/foam/nanos/auth/ActionPermissionConfiguration.js
@@ -1,0 +1,17 @@
+foam.CLASS({
+  package: 'foam.nanos.auth',
+  name: 'ActionPermissionConfiguration',
+
+  documentation: 'Used to configure which permissions are required to access Actions.',
+
+  properties: [
+    {
+      class: 'StringArray',
+      name: 'enabled'
+    },
+    {
+      class: 'StringArray',
+      name: 'available'
+    }
+  ]
+});

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -81,6 +81,7 @@ FOAM_FILES([
   { name: "foam/nanos/auth/twofactor/TwoFactorSignInView" },
   { name: "foam/nanos/auth/twofactor/refinements" },
   { name: "foam/nanos/auth/UserAndGroupAuthService" },
+  { name: "foam/nanos/auth/ActionPermissionConfiguration" },
   { name: "foam/nanos/bench/Benchmark" },
   { name: "foam/nanos/boot/NSpec" },
   { name: "foam/nanos/boot/DAOConfigSummaryView", flags: ['web'] },

--- a/src/foam/u2/ActionView.js
+++ b/src/foam/u2/ActionView.js
@@ -344,11 +344,11 @@ foam.CLASS({
       if ( this.action ) {
         this.attrs({ name: this.action.name });
 
-        if ( this.action.isAvailable ) {
+        if ( this.action.isAvailable || this.action.permissionConfig != null ) {
           this.enableClass(this.myClass('unavailable'), this.action.createIsAvailable$(this.data$), true);
         }
 
-        if ( this.action.isEnabled ) {
+        if ( this.action.isEnabled || this.action.permissionConfig != null ) {
           this.attrs({ disabled: this.action.createIsEnabled$(this.data$).map((e) => e ? false : 'disabled') });
         }
 


### PR DESCRIPTION
* maybeCall respects permissions
* permissions can apply to enabled now, not just available
* you can specify multiple permissions for each

Lets you do things like this:

### Multiple permissions
```JavaScript
actions: [
  {
    name: 'foo',
    permissionConfig: { enabled: ['currency.read.CAD', 'invoice.pay'] }
  }
]
```

### Different permissions for available vs enabled
```JavaScript
actions: [
  {
    name: 'foo',
    permissionConfig: {
      enabled: ['currency.read.CAD']
      available: ['invoice.pay']
    }
  }
]
```

### Same as before (still works)
```JavaScript
actions: [
  {
    name: 'foo',
    permissionRequired: true
  }
]
```