### PR TITLE
Fix bug in Rule Engine

### DIFF
--- a/src/foam/nanos/ruler/Rule.js
+++ b/src/foam/nanos/ruler/Rule.js
@@ -197,9 +197,6 @@
       ],
       javaCode: `
         getAction().applyAction(x, obj, oldObj, ruler);
-        if ( ! getAfter() ) {
-          ruler.getDelegate().cmd_(x.put("OBJ", obj), getCmd());
-        }
       `
     },
     {


### PR DESCRIPTION
There's a bug where after each sync rule executes the object is put to
the underlying DAO. This was only intended to happen for async actions
according to Chanmann.

Say you have a rule that performs some validation and throws an error if some condition is met to prevent the put to the underlying DAO from happening. If this rule is executed after any other rule, the code that I'm removing in this PR will cause the put to happen after the first rule runs and before the validation rule can run.