### PR TITLE
Fix ConcurrentModificationException

### DIFF
--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -185,6 +185,7 @@ FOAM_FILES([
   { name: "foam/nanos/ruler/Operations" },
   { name: "foam/nanos/ruler/RuleHistory" },
   { name: "foam/nanos/ruler/RuleHistoryStatus" },
+  { name: "foam/nanos/ruler/UpdateRulesListSink" },
   { name: "foam/nanos/test/EchoService" },
   { name: "foam/nanos/test/SerializationTestEchoService" },
   { name: "foam/nanos/analytics/Foldable" },

--- a/src/foam/nanos/ruler/UpdateRulesListSink.js
+++ b/src/foam/nanos/ruler/UpdateRulesListSink.js
@@ -1,0 +1,82 @@
+foam.CLASS({
+  package: 'foam.nanos.ruler',
+  name: 'UpdateRulesListSink',
+  extends: 'foam.dao.AbstractSink',
+
+  documentation: 'Updates rules list of RulerDAO.',
+
+  javaImports: [
+    'foam.dao.ArraySink',
+    'foam.mlang.order.Desc',
+    'foam.mlang.predicate.Predicate',
+    'foam.mlang.sink.GroupBy',
+    'java.util.Collections',
+    'java.util.List',
+    'java.util.Map'
+  ],
+
+  properties: [
+    {
+      class: 'FObjectProperty',
+      of: 'foam.nanos.ruler.RulerDAO',
+      name: 'dao'
+    }
+  ],
+
+  methods: [
+    {
+      name: 'put',
+      javaCode: `
+        Rule rule = (Rule) obj;
+        if ( ! rule.getDaoKey().equals(dao_.getDaoKey()) ) {
+          return;
+        }
+
+        Map rulesList = dao_.getRulesList();
+        String ruleGroup = rule.getRuleGroup();
+        for ( Object key : rulesList.keySet() ) {
+          if ( ((Predicate) key).f(obj) ) {
+            GroupBy group = (GroupBy) rulesList.get(key);
+            if ( group.getGroupKeys().contains(ruleGroup) ) {
+              List<Rule> rules = ((ArraySink) group.getGroups().get(ruleGroup)).getArray();
+              Rule foundRule = Rule.findById(rules, rule.getId());
+              if ( foundRule != null ) {
+                rules.remove(foundRule);
+                rules.add(foundRule.updateRule(rule));
+              } else {
+                rules.add(rule);
+              }
+              Collections.sort(rules, new Desc(Rule.PRIORITY));
+            } else {
+              group.putInGroup_(sub, ruleGroup, obj);
+            }
+          }
+        }
+      `
+    },
+    {
+      name: 'remove',
+      javaCode: `
+        Rule rule = (Rule) obj;
+        if ( ! rule.getDaoKey().equals(dao_.getDaoKey()) ) {
+          return;
+        }
+
+        Map rulesList = dao_.getRulesList();
+        String ruleGroup = rule.getRuleGroup();
+        for ( Object key : rulesList.keySet() ) {
+          if ( ((Predicate) key).f(obj) ) {
+            GroupBy group = (GroupBy) rulesList.get(key);
+            if ( group.getGroupKeys().contains(ruleGroup) ) {
+              List<Rule> rules = ((ArraySink) group.getGroups().get(ruleGroup)).getArray();
+              Rule foundRule = Rule.findById(rules, rule.getId());
+              if ( foundRule != null ) {
+                rules.remove(foundRule);
+              }
+            }
+          }
+        }
+      `
+    }
+  ]
+});

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -336,6 +336,7 @@ var classes = [
   'foam.nanos.ruler.ScriptPredicate',
   'foam.nanos.ruler.RuleHistory',
   'foam.nanos.ruler.RuleHistoryStatus',
+  'foam.nanos.ruler.UpdateRulesListSink',
   'foam.comics.SearchMode',
 
   // Support Files


### PR DESCRIPTION
Move rules sorting out of applyRules because sorting is considered as modification and re-entrant would throw ConcurrentModificationException. If re-entrant was on a different rule group it would not throw but sorting could make rule engine slow.

Sorting is moved to ruleDAO.listen.put instead.