### PR TITLE
Update tab style

### DIFF
--- a/src/foam/u2/DetailView.js
+++ b/src/foam/u2/DetailView.js
@@ -188,7 +188,7 @@ foam.CLASS({
             add(self.title$).
           end();
 
-        var tabs = foam.u2.Tabs.create().style({ width: '1200px' });
+        var tabs = foam.u2.Tabs.create({}, self);
 
         return self.actionBorder(
           this.

--- a/src/foam/u2/Tabs.js
+++ b/src/foam/u2/Tabs.js
@@ -33,42 +33,24 @@ foam.CLASS({
   name: 'Tabs',
   extends: 'foam.u2.UnstyledTabs',
   css: `
-    ^ {
-      background: gray;
-      display: block;
-      padding: 10px 4px;
-      width: 600px;
+    ^tabRow {
+      height: 48px;
+      border-bottom: 1px solid #e7eaec;
+      background-color: white;
     }
-    ^tabRow { height: 38px; }
     ^tab {
-      background: lightgray;
-      border: 1px solid black;
-      border-radius: 3px 3px 0 0;
+      border-top: 3px solid transparent;
+      border-bottom: 3px solid transparent;
       display: inline-block;
-      height: 12px;
-      padding: 8px;
+      height: 48px;
+      box-sizing: border-box;
+      padding: 13px 16px;
+    }
+    ^tab:hover {
+      cursor: pointer;
     }
     ^tab.selected {
-      background: white;
-      position: relative;
-      z-index: 1;
-    }
-    ^bottomEdge {
-      background: white;
-      height: 2.5px;
-      left: 0;
-      position: absolute;
-      top: 27px;
-      width: 100%;
-    }
-    ^content {
-      margin: 4px;
-      padding: 6px;
-      background: white;
-      border: 1px solid black;
-      position: relative;
-      top: -13px;
-      left: -4px;
+      border-bottom: 3px solid %SECONDARYCOLOR%;
     }
   `,
 });


### PR DESCRIPTION
Updates the tab style to match the Liquid designs.

I can leave `foam.u2.Tabs` as is and create a new component in the nanopay repo if we'd rather not lose the existing style of tabs.

<img width="1059" alt="Screen Shot 2019-05-11 at 3 13 11 PM" src="https://user-images.githubusercontent.com/4259165/57574114-0b9ae280-7401-11e9-8f06-c5a9f5909aef.png">