### PR TITLE
RadioView fix

### DIFF
--- a/src/foam/u2/view/RadioView.js
+++ b/src/foam/u2/view/RadioView.js
@@ -60,7 +60,7 @@ foam.CLASS({
             }).
             setID(id = self.NEXT_ID()).
             on('change', function(evt) {
-              self.data = evt.srcElement.value;
+              self.data = c[0];
             }).
           end().
           start('label').


### PR DESCRIPTION
Set the data to c[0] instead of the element's value because we can't put things like objects or booleans in the attributes.