### PR TITLE
update grp.getAppConfig()

### DIFF
--- a/src/foam/nanos/auth/Group.js
+++ b/src/foam/nanos/auth/Group.js
@@ -211,39 +211,39 @@ foam.CLASS({
         }
       ],
       javaCode: `
-AppConfig config = (AppConfig) ((AppConfig) x.get("appConfig")).fclone();
+        AppConfig config = (AppConfig) ((AppConfig) x.get("appConfig")).fclone();
+        String configUrl = "";
 
-String configUrl = config.getUrl();
+        // FIND URL
+        Group group = (Group) x.get("group");
+        if ( ! SafetyUtil.isEmpty(group.getUrl()) ) {
+          configUrl = group.getUrl();
+        } else {
+          // populate AppConfig url with request's RootUrl
+          HttpServletRequest req = x.get(HttpServletRequest.class);
+          if ( (req != null) && ! SafetyUtil.isEmpty(req.getRequestURI()) ) {
+            configUrl = ((Request) req).getRootURL().toString();
+          }
+        }
+        // FORCE HTTPS IN URL?
+        if ( config.getForceHttps() ) {
+          if ( ! configUrl.startsWith("https://") ) {
+            if ( configUrl.startsWith("http://") ) {
+              configUrl = "https" + configUrl.substring(4);
+            } else {
+              configUrl = "https://" + configUrl;
+            }
+          }
+        }
+        // SET URL
+        config.setUrl(configUrl);
 
-HttpServletRequest req = x.get(HttpServletRequest.class);
-if ( (req != null) && ! SafetyUtil.isEmpty(req.getRequestURI()) ) {
-  // populate AppConfig url with request's RootUrl
-  configUrl = ((Request) req).getRootURL().toString();
-} else {
-  // populate AppConfig url with group url
-  Group group = (Group) x.get("group");
-  if ( ! SafetyUtil.isEmpty(group.getUrl()) ) {
-    configUrl = group.getUrl();
-  }
-  if ( ! SafetyUtil.isEmpty(group.getSupportEmail()) ) {
-    config.setSupportEmail(group.getSupportEmail());
-  }
-}
+        // SET SupportEmail
+        if ( ! SafetyUtil.isEmpty(group.getSupportEmail()) ) {
+          config.setSupportEmail(group.getSupportEmail());
+        }
 
-if ( config.getForceHttps() ) {
-  if ( configUrl.startsWith("https://") ) {
-    config.setUrl(configUrl);
-    return config;
-  } else if ( configUrl.startsWith("http://") ) {
-    configUrl = "https" + configUrl.substring(4);
-  } else {
-    configUrl = "https://" + configUrl;
-  }
-}
-
-config.setUrl(configUrl);
-
-return config;
+        return config;
         `
     },
     {

--- a/src/foam/nanos/auth/Group.js
+++ b/src/foam/nanos/auth/Group.js
@@ -221,13 +221,15 @@ foam.CLASS({
         String grp                = "";
         DAO groupDAO              = (DAO) x.get("groupDAO");
 
-        while ( group != null && ! (urlFound && supportEmailFound)) {
+        while ( group != null ) {
           configUrl          = urlFound ? configUrl : group.getUrl();
           configSupportEmail = supportEmailFound ? configSupportEmail : group.getSupportEmail();
       
           // Once true, stay true
           urlFound          = urlFound   ? urlFound   : ! SafetyUtil.isEmpty(configUrl);
           supportEmailFound = supportEmailFound ? supportEmailFound : ! SafetyUtil.isEmpty(configSupportEmail);
+
+          if ( urlFound && supportEmailFound ) break;
 
           grp   = group.getParent();
           group = (Group)groupDAO.find(grp);


### PR DESCRIPTION
grp.getAppConfig() previously picked up the group from the context and set the properties of the context group onto a copy of appConfig and returned.

This was a problem for when the logged in user was someone from paymentOps and was triggering an email to an ablii user.

The solution/changes include:
1) using the ```Group group = this;``` instead of ```Group group = x.get("group");```
2) If properties are not set on the current group, iterate through to root(getParent()) and set properties. Taking president with the first property settings found. With ablii users, the properties are set on sme.