### PR TITLE
Allow validation predicates on FObjectProperty

### DIFF
--- a/src/foam/core/Validation.js
+++ b/src/foam/core/Validation.js
@@ -151,7 +151,7 @@ foam.CLASS({
     },
     {
       name: 'validateObj',
-      expression: function(autoValidate, name, label, required) {
+      expression: function(name, label, required, validationPredicates, autoValidate) {
         if ( autoValidate ) {
           return [
             [`${name}$errors_`],
@@ -160,10 +160,7 @@ foam.CLASS({
             }
           ];
         }
-        return !required ? null : [[name],
-          function() {
-            return !this.hasOwnProperty(name) && (label + ' is required.');
-          }]
+        return foam.core.Property.VALIDATE_OBJ.expression.apply(this, arguments);
       },
     },
   ]


### PR DESCRIPTION
Before, it wouldn't take validationPredicates into account when the expression for validateObj fires. Now, it calls into the base foam.core.Property's validateObj's expression but this feels a tad hacky. Open to suggestions on better ways to do this to reuse that code. Or I could just copy the code from foam.core.Property as it's not a whole lot.