### PR TITLE
A few mlang Java implementations

### DIFF
--- a/src/foam/dao/MDAO.java
+++ b/src/foam/dao/MDAO.java
@@ -159,7 +159,7 @@ public class MDAO
     // TODO: if plan cost is >= size, log a warning
     if ( state != null && predicate != null && plan.cost() > 1000 && plan.cost() >= index_.size(state) ) {
       Logger logger = (Logger) x.get("logger");
-      logger.error(predicate.createStatement(), " Unindexed search on MDAO");
+      logger.error(simplePredicate.createStatement(), " Unindexed search on MDAO");
     }
 
     plan.select(state, sink, skip, limit, order, simplePredicate);

--- a/src/foam/dao/MDAO.java
+++ b/src/foam/dao/MDAO.java
@@ -156,10 +156,10 @@ public class MDAO
       plan = index_.planSelect(state, sink, skip, limit, order, simplePredicate);
     }
 
-    // TODO: if plan cost is >= size, log a warning
     if ( state != null && predicate != null && plan.cost() > 1000 && plan.cost() >= index_.size(state) ) {
       Logger logger = (Logger) x.get("logger");
-      logger.error(simplePredicate.createStatement(), " Unindexed search on MDAO");
+      if ( ! predicate.equals(simplePredicate) ) logger.debug(String.format("The original predicate was %s but it was simplified to %s.", predicate.toString(), simplePredicate.toString()));
+      logger.warning("Unindexed search on MDAO", simplePredicate.toString());
     }
 
     plan.select(state, sink, skip, limit, order, simplePredicate);

--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -703,11 +703,16 @@ foam.CLASS({
     function toIndex(tail) {
       return this.arg1 && this.arg1.toIndex(tail);
     },
-
-    function toString() {
-      return foam.String.constantize(this.cls_.name) + '(' +
-          this.arg1.toString() + ', ' +
-          this.arg2.toString() + ')';
+    {
+      name: 'toString',
+      code: function() {
+        return foam.String.constantize(this.cls_.name) + '(' +
+            this.arg1.toString() + ', ' +
+            this.arg2.toString() + ')';
+      },
+      javaCode: `
+        return String.format("%s(%s, %s)", getClass().getSimpleName(), getArg1().toString(), getArg2().toString());
+      `
     },
     {
       name: 'prepareStatement',

--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -1449,6 +1449,12 @@ foam.CLASS({
 
   requires: [ 'foam.mlang.Constant' ],
 
+  javaImports: [
+    'foam.mlang.ArrayConstant',
+    'foam.mlang.Constant',
+    'foam.mlang.predicate.False'
+  ],
+
   properties: [
     {
       name: 'arg1',
@@ -1551,12 +1557,30 @@ return false
       type: 'String',
       javaCode: 'return " " + getArg1().createStatement() + " in " + getArg2().createStatement();'
     },
+    {
+      name: 'partialEval',
+      code: function partialEval() {
+        if ( ! this.Constant.isInstance(this.arg2) ) return this;
 
-    function partialEval() {
-      if ( ! this.Constant.isInstance(this.arg2) ) return this;
+        return ( ! this.arg2.value ) || this.arg2.value.length === 0 ?
+            this.FALSE : this;
+      },
+      javaCode: `
+        if ( ! (getArg2() instanceof ArrayConstant) ) return this;
 
-      return ( ! this.arg2.value ) || this.arg2.value.length === 0 ?
-          this.FALSE : this;
+        Object[] arr = ((ArrayConstant) getArg2()).getValue();
+
+        if ( arr.length == 0 ) {
+          return new False();
+        } else if ( arr.length == 1 ) {
+          return new Eq.Builder(getX())
+            .setArg1(getArg1())
+            .setArg2(new Constant(arr[0]))
+            .build();
+        }
+
+        return this;
+      `
     }
   ]
 });

--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -1650,7 +1650,7 @@ foam.CLASS({
     },
     {
       name: 'createStatement',
-      javaCode: 'return getValue().toString(); '
+      javaCode: 'return " ? "; '
     },
     {
       name: 'prepareStatement',
@@ -1722,7 +1722,7 @@ foam.CLASS({
     },
     {
       name: 'createStatement',
-      javaCode: 'return toString();'
+      javaCode: 'return " ? "; '
     },
     {
       name: 'prepareStatement',

--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -1645,7 +1645,7 @@ foam.CLASS({
     },
     {
       name: 'createStatement',
-      javaCode: 'return " ? "; '
+      javaCode: 'return getValue().toString(); '
     },
     {
       name: 'prepareStatement',
@@ -1682,6 +1682,8 @@ foam.CLASS({
     }
   ],
 
+  javaImports: [ 'java.util.Arrays' ],
+
   axioms: [
     {
       name: 'javaExtras',
@@ -1715,7 +1717,7 @@ foam.CLASS({
     },
     {
       name: 'createStatement',
-      javaCode: 'return " ? "; '
+      javaCode: 'return toString();'
     },
     {
       name: 'prepareStatement',
@@ -1764,14 +1766,17 @@ s = s.replace(",", "\\\\,");
 builder.append(s);
 `
     },
-
-    function toString_(x) {
-      return Array.isArray(x) ? '[' + x.map(this.toString_.bind(this)).join(', ') + ']' :
-        x.toString ? x.toString :
-        x;
-    },
-
-    function toString() { return this.toString_(this.value); }
+    {
+      name: 'toString',
+      code: function() {
+        return Array.isArray(this.value) ? '[' + this.value.map(this.toString_.bind(this)).join(', ') + ']' :
+          this.value.toString ? this.value.toString :
+          x;
+      },
+      javaCode: `
+        return Arrays.toString(getValue());
+      `
+    }
   ]
 });
 


### PR DESCRIPTION
- Log the partially evaluated predicate since that's what gets used
- Add Java implementation for `partialEval` for `In` mlang
  - Fixes unoptimized queries on MDAO when we're selecting from a ManyToManyRelationshipDAO since it uses `In` on the server side. Without the Java implementation of `partialEval`, if no junctions were found, then it was selecting with a query like `id in []`, which was causing the "unoptimized query" warning.
  - I think the query parser on the client is doing this optimization for us, but since I was using a ManyToManyRelationshipDAO on the backend for the feature I'm working on, it was never going through the query parser.
- Add Java implementation for `toString` for `ArrayConstant`
  - This was just to make debugging easier since " ? " isn't very helpful, which is the current value shown for `Constant` and `ArrayConstant`.