### PR TITLE
Create an AxiomCloner and fix up a couple bugs

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -91,6 +91,7 @@ FOAM_FILES([
   { name: "foam/core/AbstractFObject" },
   { name: "foam/core/ContextAgent" },
   { name: "foam/core/Validatable" },
+  { name: "foam/core/AxiomCloner" },
   { name: "foam/java/Authorizable" },
   { name: "foam/i18n/TranslationFormatStringParser", flags: ['swift'] },
   { name: "foam/swift/SwiftLib", flags: ['swift'] },

--- a/src/foam/core/AxiomCloner.js
+++ b/src/foam/core/AxiomCloner.js
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2019 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core',
+  name: 'AxiomCloner',
+  documentation: 'An axiom that clones an axiom from another model.',
+  properties: [
+    {
+      class: 'Class',
+      name: 'from'
+    },
+    {
+      class: 'String',
+      name: 'axiom'
+    },
+    {
+      class: 'String',
+      name: 'name',
+      transient: true,
+      expression: function(axiom) {
+        return axiom + '_cloner';
+      }
+    },
+    {
+      class: 'Map',
+      name: 'config'
+    }
+  ],
+  methods: [
+    function installInClass(cls) {
+      var axiom = this.from.getAxiomByName(this.axiom);
+      if ( ! axiom ) {
+        throw `Cannot find ${this.axiom} on ${this.from.id}`;
+      }
+      axiom = axiom.clone().copyFrom(this.config);
+      cls.installAxiom(axiom);
+    }
+  ]
+});
+
+foam.SCRIPT({
+  package: 'foam.core',
+  name: 'AxiomClonerConvenienceMethod',
+  code: function() {
+    foam.axiomCloner = function(from, axiom, config) {
+      return foam.core.AxiomCloner.create({
+        from: from,
+        axiom: axiom,
+        config: config
+      });
+    };
+  }
+});

--- a/src/foam/core/AxiomCloner.js
+++ b/src/foam/core/AxiomCloner.js
@@ -42,16 +42,16 @@ foam.CLASS({
   ]
 });
 
-foam.SCRIPT({
-  package: 'foam.core',
-  name: 'AxiomClonerConvenienceMethod',
-  code: function() {
-    foam.axiomCloner = function(from, axiom, config) {
-      return foam.core.AxiomCloner.create({
+foam.LIB({
+  name: 'foam',
+  methods: [
+    function axiomCloner(from, axiom, config) {
+      return {
+        class: 'foam.core.AxiomCloner',
         from: from,
         axiom: axiom,
         config: config
-      });
-    };
-  }
+      };
+    }
+  ]
 });

--- a/src/foam/core/Property.js
+++ b/src/foam/core/Property.js
@@ -308,6 +308,10 @@ foam.CLASS({
       if ( this.forClass_ && this.forClass_ !== c.id && prop === this ) {
         // Clone this property if it's been installed before.
         prop = this.clone();
+
+        // sourceCls_ isn't a real property so it gets lost during the clone.
+        prop.sourceCls_ = c; 
+
         c.axiomMap_[prop.name] = prop;
       }
 

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -233,7 +233,7 @@ if ( ! ${foam.java.asJavaValue(vp.predicate)}.f(obj) ) {
     {
       name: 'asJavaValue',
       code: function() {
-        return `${this.sourceCls_.id}.${foam.String.constantize(this.name)}`;
+        return `${this.forClass_}.${foam.String.constantize(this.name)}`;
       }
     },
     function createJavaPropertyInfo_(cls) {


### PR DESCRIPTION
The two bugs that were found remove the need for the AxiomCloner but I still think it's the better way to go rather than cloning axioms directly like we do because it can allow us to be lazier about instantiating classes.