### PR TITLE
Fix double render issue in ScrollTableView

### DIFF
--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -223,7 +223,7 @@
   methods: [
     function init() {
       this.onDetach(this.data$proxy.listen(this.FnSink.create({ fn: this.onDAOUpdate })));
-      this.onDAOUpdate();
+      this.updateCount();
     },
 
     function initE() {
@@ -332,6 +332,14 @@
         var x = this.table_.childNodes.filter((x) => x.nodeName === 'TBODY');
         this.topBufferTable_ = x[0];
       }
+    },
+    {
+      name: 'updateCount',
+      code: function() {
+        return this.data$proxy.select(this.Count.create()).then((s) => {
+          this.daoCount = s.value;
+        });
+      }
     }
   ],
 
@@ -371,11 +379,7 @@
       name: 'onDAOUpdate',
       isFramed: true,
       code: function() {
-        var self = this;
-        this.data$proxy.select(this.Count.create()).then(function(s) {
-          self.daoCount = s.value;
-          self.refresh();
-        });
+        this.updateCount().then(() => this.refresh());
       }
     },
     {


### PR DESCRIPTION
This was causing the DAOs to be hit twice every time a ScrollTableView
was initialized.