### PR TITLE
Revert "Don't update when a listener is attached"

### DIFF
--- a/src/foam/dao/daoUtils.js
+++ b/src/foam/dao/daoUtils.js
@@ -67,6 +67,7 @@ if let oldValue = oldValue as? foam_dao_AbstractDAO {
         }, context);
 
         listener.onDetach(this.sub('propertyChange', 'delegate', listener.update));
+        listener.update();
 
         return listener;
       },


### PR DESCRIPTION
Reverts foam-framework/foam2#2239

This is breaking a number of things. Will continue to investigate the double render issue to see if it can be fixed another way.