### PR TITLE
Fix CSS generation

### DIFF
--- a/src/foam/u2/Element.js
+++ b/src/foam/u2/Element.js
@@ -133,15 +133,18 @@ foam.CLASS({
 
         if ( ! lastClassToInstallCSSFor || lastClassToInstallCSSFor == cls ) {
           // Install CSS if not already installed in this document for this cls
-          var key = axiom.asKey(X.document, cls);
+          var key = axiom.asKey(X.document, this);
           if ( X.document && ! axiom.installedDocuments_[key] ) {
-            X.installCSS(axiom.expandCSS(this, axiom.code), cls.id);
+            X.installCSS(axiom.expandCSS(this, axiom.code), this.id);
             axiom.installedDocuments_[key] = true;
           }
         }
 
-        if ( ! lastClassToInstallCSSFor && ! cls.model_.inheritCSS ) {
-          X = X.createSubContext({lastClassToInstallCSSFor: cls, originalX: X});
+        if ( ! lastClassToInstallCSSFor && ! this.model_.inheritCSS ) {
+          X = X.createSubContext({
+            lastClassToInstallCSSFor: this,
+            originalX: X
+          });
         }
 
         if ( lastClassToInstallCSSFor && isFirstCSS ) X = X.originalX;


### PR DESCRIPTION
The problem this fixes:

We have 2 views: `IntView` and `TextField`. `IntView` extends `TextField`. `TextField` has a bunch of CSS.

Currently, if an `IntView` gets created before a `TextField` does, then when a `TextField` gets created later, its CSS is not generated. The CSS is generated for the `IntView` though.

These changes avoid that problem though and the CSS gets generated for both.

I'm not exactly sure how or why this fixes the issue though.