### PR TITLE
File upload view

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -423,6 +423,7 @@ FOAM_FILES([
   { name: "foam/u2/view/RadioView", flags: ['web'] },
   { name: "foam/u2/view/TextField", flags: ['web'] },
   { name: "foam/u2/view/TreeView", flags: ['web'] },
+  { name: "foam/u2/view/FileUploadTextField", flags: ['web'] },
   { name: "foam/u2/view/AltView", flags: ['web'] },
   { name: "foam/u2/view/SimpleAltView", flags: ['web'] },
   { name: "foam/u2/view/DualView", flags: ['web'] },

--- a/src/foam/u2/view/FileUploadTextField.js
+++ b/src/foam/u2/view/FileUploadTextField.js
@@ -19,6 +19,17 @@ foam.CLASS({
       name: 'fileInput_'
     }
   ],
+  actions: [
+    {
+      name: 'upload',
+      isAvailable: function(fileInput_) {
+        return !! fileInput_;
+      },
+      code: function() {
+        this.fileInput_.el().click();
+      }
+    }
+  ],
   listeners: [
     {
       name: 'onFileUpload',
@@ -42,12 +53,18 @@ foam.CLASS({
     function initE() {
       this.SUPER();
       this
-        .start('input', null, this.fileInput_$)
-          .attrs({type: 'file'})
-          .on('change', this.onFileUpload)
-        .end()
-        .startContext({data: this})
-          .add(this.IS_SET)
+        .startContext({ data: this })
+          .addClass(this.myClass())
+          .start('input', null, this.fileInput_$)
+            .hide()
+            .attrs({ type: 'file' })
+            .on('change', this.onFileUpload)
+          .end()
+          .add(this.UPLOAD)
+          .start('span')
+            .style({'margin-left': '8px'})
+            .add(this.IS_SET)
+          .end()
         .endContext();
     }
   ]

--- a/src/foam/u2/view/FileUploadTextField.js
+++ b/src/foam/u2/view/FileUploadTextField.js
@@ -1,0 +1,54 @@
+foam.CLASS({
+  package: 'foam.u2.view',
+  name: 'FileUploadTextField',
+  extends: 'foam.u2.View',
+  properties: [
+    {
+      name: 'data',
+      hidden: true,
+      postSet: function(_, n) {
+        this.isSet = !!n;
+      }
+    },
+    {
+      class: 'Boolean',
+      name: 'isSet',
+      visibility: 'RO'
+    },
+    {
+      name: 'fileInput_'
+    }
+  ],
+  listeners: [
+    {
+      name: 'onFileUpload',
+      code: function() {
+        if ( ! this.fileInput_ ) return;
+        var el = this.fileInput_.el();
+        if ( el.value == '' ) return;
+        if ( el.files.length == 0 ) return;
+        var file = el.files[0];
+        var reader = new FileReader();
+        reader.onload = function(e) {
+          var csv = e.target.result;
+          this.data = csv;
+        }.bind(this);
+        reader.readAsBinaryString(file);
+        el.value = '';
+      }
+    }
+  ],
+  methods: [
+    function initE() {
+      this.SUPER();
+      this
+        .start('input', null, this.fileInput_$)
+          .attrs({type: 'file'})
+          .on('change', this.onFileUpload)
+        .end()
+        .startContext({data: this})
+          .add(this.IS_SET)
+        .endContext();
+    }
+  ]
+});


### PR DESCRIPTION
Create a view that can take a file and stores it as a string.

![FileUpload](https://user-images.githubusercontent.com/8106568/59308903-341c3380-8c70-11e9-8db0-2101d1b81aae.gif)

The video just shows this view in action. It's just a button with a checkbox beside it. The checkbox is checked when the value of the property isn't empty. The video just shows two views bound to eachother. The uploaded document set the `uploaded` field and then when I clear the text of that field, the checkbox on the upload field goes away.