### PR TITLE
Make error message more descriptive

### DIFF
--- a/src/foam/core/FObject.js
+++ b/src/foam/core/FObject.js
@@ -773,10 +773,13 @@ foam.CLASS({
       var names = obj.split('$');
       var axiom = this.cls_.getAxiomByName(names.shift());
 
-      foam.assert(axiom, 'slot() called with unknown axiom name:', obj);
-      foam.assert(axiom.toSlot, 'Called slot() on unslottable axiom:', obj);
+      if ( axiom == null ) {
+        throw new Error(`slot() called with unknown axiom: '${obj}' on model '${this.cls_.id}'.`);
+      } else if ( ! axiom.toSlot ) {
+        throw new Error(`Called slot() on unslottable axiom: '${obj}' on model '${this.cls_.id}'.`);
+      }
 
-      var slot = axiom.toSlot(this)
+      var slot = axiom.toSlot(this);
       names.forEach(function(n) {
         slot = slot.dot(n);
       });


### PR DESCRIPTION
Including the model the slot() method was called on makes it easier to track down where the error might be coming from.

Also it's nicer to explicitly throw an error here rather than get a "Can't read property '...' of undefined" error shortly after the assert.