### PR TITLE
table cell formatter displays id for FObjectProperties

### DIFF
--- a/src/foam/nanos/auth/User.js
+++ b/src/foam/nanos/auth/User.js
@@ -491,6 +491,12 @@ foam.CLASS({
           throw new RuntimeException("You do not have permission to delete that user.");
         }
       `
+    },
+    {
+      name: 'toSummary',
+      code: function() {
+        return this.label();
+      }
     }
   ]
 });

--- a/src/foam/u2/view/TableCellFormatter.js
+++ b/src/foam/u2/view/TableCellFormatter.js
@@ -127,7 +127,7 @@ foam.CLASS({
       name: 'tableCellFormatter',
       value: function(obj) {
         this.start()
-          .add(obj.id)
+          .add(obj.toSummary())
         .end();
       }
     }

--- a/src/foam/u2/view/TableCellFormatter.js
+++ b/src/foam/u2/view/TableCellFormatter.js
@@ -121,7 +121,17 @@ foam.CLASS({
   name: 'FObjectPropertyTableCellFormatterRefinement',
   refines: 'foam.core.FObjectProperty',
 
-  properties: [ [ 'tableCellFormatter', null ] ]
+  properties: [
+    {
+      class: 'foam.u2.view.TableCellFormatter',
+      name: 'tableCellFormatter',
+      value: function(obj) {
+        this.start()
+          .add(obj.id)
+        .end();
+      }
+    }
+  ]
 });
 
 


### PR DESCRIPTION
Previously, TableViews displaying FObjectProperties in a column would not display anything, throwing a null value error.