### PR TITLE
Fix editing via relationship table

### DIFF
--- a/src/foam/comics/DAOController.js
+++ b/src/foam/comics/DAOController.js
@@ -216,6 +216,7 @@ foam.CLASS({
       name: 'addSelection',
       label: 'Add',
       isAvailable: function(addEnabled) { return addEnabled; },
+      isEnabled: function(selection) { return !! selection },
       code: function() {
         var self = this;
         this.relationship.add(this.selection).then(function() {

--- a/src/foam/comics/DAOController.js
+++ b/src/foam/comics/DAOController.js
@@ -136,8 +136,8 @@ foam.CLASS({
     {
       class: 'String',
       name: 'title',
-      expression: function(data$data$of) {
-        return 'Browse ' + data$data$of.model_.plural;
+      expression: function(data$of) {
+        return 'Browse ' + data$of.model_.plural;
       }
     },
     {

--- a/src/foam/comics/DAOController.js
+++ b/src/foam/comics/DAOController.js
@@ -151,7 +151,14 @@ foam.CLASS({
       documentation: `
         The most important action on the page. The view for this controller may
         choose to display this action prominently.
-      `
+      `,
+      factory: function() {
+        return this.relationship
+          ? this.addEnabled
+            ? this.ADD_SELECTION
+            : this.SELECT
+          : this.cls_.CREATE;
+      }
     },
     {
       class: 'foam.u2.ViewSpec',

--- a/src/foam/comics/DAOControllerView.js
+++ b/src/foam/comics/DAOControllerView.js
@@ -146,21 +146,13 @@ foam.CLASS({
                 .add(this.data.subtitle$)
               .end()
             .end()
-            .callIfElse(this.data.primaryAction, function() {
-              this.startContext({ data: self })
-                .start()
-                  .tag(self.data.primaryAction, { size: 'LARGE' })
-                .end()
-              .endContext();
+            .callIfElse(self.data.createLabel, function() {
+              this.tag(self.data.primaryAction, {
+                label$: self.data.createLabel$,
+                size: 'LARGE'
+              });
             }, function() {
-              if ( self.data.createLabel ) {
-                this.tag(self.cls.CREATE, {
-                  label$: self.data.createLabel$,
-                  size: 'LARGE'
-                });
-              } else {
-                this.start().tag(self.cls.CREATE, { size: 'LARGE' }).end();
-              }
+              this.start().tag(self.data.primaryAction, { size: 'LARGE' }).end();
             })
           .end()
           .start()
@@ -189,10 +181,7 @@ foam.CLASS({
                   .show(self.mode$.map((m) => m === foam.u2.DisplayMode.RW))
                   .start()
                     .forEach(self.cls.getAxiomsByClass(foam.core.Action).filter((action) => {
-                      var rtn = true;
-                      if ( ! self.primaryAction ) {
-                        rtn = rtn && action.name !== 'create';
-                      }
+                      var rtn = action.name !== self.data.primaryAction.name;
                       if ( self.data.searchMode !== self.SearchMode.FULL ) {
                         rtn = rtn && action.name !== 'toggleFilters';
                       }

--- a/src/foam/dao/Relationship.js
+++ b/src/foam/dao/Relationship.js
@@ -551,15 +551,14 @@ return junction`
         var controller = foam.comics.DAOController.create({
           createEnabled: false,
           editEnabled: false,
-          selectEnabled: true,
-          addEnabled: false,
+          selectEnabled: false,
+          addEnabled: true,
+          exportEnabled: false,
           relationship: this,
-          data: dao
+          data: dao,
+          title: `Add a ${dao.of.name}`,
+          subtitle: `Select a ${dao.of.name} from the table and click "Add" to add it.`
         }, x);
-
-        controller.sub('select', function(s, _, id) {
-          dao.find(id).then(function(obj) { self.add(obj); });
-        });
 
         x.stack.push({
           class: 'foam.comics.DAOControllerView',
@@ -580,7 +579,9 @@ return junction`
           selectEnabled: true,
           addEnabled: false,
           relationship: this,
-          data: dao
+          data: dao,
+          title: `Remove a ${dao.of.name}`,
+          subtitle: `Select a ${dao.of.name} from the table and click "Select" to add it.`
         }, x);
 
         controller.sub('select', function(s, _, id) {


### PR DESCRIPTION
## Changes

* Fixes the feature that lets you add and remove objects via the GUI for a many-to-many relationship
  * An error was being thrown when using those controls (the "Add" and "Remove" buttons under the table when a table is shown inline for a ManyToManyRelationship property. This PR fixes that error and slightly improves the UX.