### PR TITLE
Table multi select support

### DIFF
--- a/src/foam/u2/md/CheckBox.js
+++ b/src/foam/u2/md/CheckBox.js
@@ -28,6 +28,10 @@ foam.CLASS({
       transition: background-color 140ms, border-color 140ms;
     }
 
+    ^:hover {
+      cursor: pointer;
+    }
+
     ^:checked {
       background-color: #093649;
       border-color: #093649;

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -154,12 +154,16 @@ foam.CLASS({
     },
     {
       name: 'idsOfObjectsTheUserHasInteractedWith_',
-      value: new Set()
+      factory: function() {
+        return {};
+      }
     },
     {
       name: 'checkboxes_',
       documentation: 'The checkbox elements when multi-select support is enabled. Used internally to implement the select all feature.',
-      value: new Map()
+      factory: function() {
+        return {};
+      }
     },
     {
       class: 'Boolean',
@@ -223,11 +227,9 @@ foam.CLASS({
                   view.allCheckBoxesEnabled_ = checked;
 
                   if ( checked ) {
-                    view.data.select().then(function(arraySink) {
-                      view.selectedObjects = arraySink.array.reduce(function(acc, obj) {
-                        acc[obj.id] = obj;
-                        return acc;
-                      }, {});
+                    view.selectedObjects = {};
+                    view.data.select(function(obj) {
+                      view.selectedObjects[obj.id] = obj;
                     });
                   } else {
                     view.selectedObjects = {};
@@ -235,8 +237,8 @@ foam.CLASS({
 
                   // Update the existing CheckBox views.
                   view.togglingCheckBoxes_ = true;
-                  view.checkboxes_.forEach(function(checkbox) {
-                    checkbox.data = checked;
+                  Object.keys(view.checkboxes_).forEach(function(key) {
+                    view.checkboxes_[key].data = checked;
                   });
                   view.togglingCheckBoxes_ = false;
                 }));
@@ -350,7 +352,7 @@ foam.CLASS({
                   var slot = view.SimpleSlot.create();
                   this
                     .start('td')
-                      .tag(view.CheckBox, { data: view.idsOfObjectsTheUserHasInteractedWith_.has(obj.id) ? !!view.selectedObjects[obj.id] : view.allCheckBoxesEnabled_ }, slot)
+                      .tag(view.CheckBox, { data: view.idsOfObjectsTheUserHasInteractedWith_[obj.id] ? !!view.selectedObjects[obj.id] : view.allCheckBoxesEnabled_ }, slot)
                     .end();
 
                   // Set up a listener so that when the user checks or unchecks
@@ -380,7 +382,7 @@ foam.CLASS({
                     // use a separate set to remember which checkboxes the user
                     // has interacted with, then we don't need to clutter up
                     // `selectedObjects`.
-                    view.idsOfObjectsTheUserHasInteractedWith_.add(obj.id);
+                    view.idsOfObjectsTheUserHasInteractedWith_[obj.id] = true;
 
                     var checked = newValueSlot.get();
 
@@ -399,9 +401,9 @@ foam.CLASS({
                   // to them so we can set the `data` property of them when the
                   // user checks the box to enable or disable all checkboxes.
                   var checkbox = slot.get();
-                  view.checkboxes_.set(obj.id, checkbox);
+                  view.checkboxes_[obj.id] = checkbox;
                   checkbox.onDetach(function() {
-                    view.checkboxes_.delete(obj.id);
+                    delete view.checkboxes_[obj.id];
                   });
                 }).
 

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -14,7 +14,9 @@ foam.CLASS({
   ],
 
   requires: [
+    'foam.core.SimpleSlot',
     'foam.dao.ProxyDAO',
+    'foam.u2.md.CheckBox',
     'foam.u2.md.OverlayDropdown',
     'foam.u2.view.OverlayActionListView',
     'foam.u2.view.EditColumnsView',
@@ -136,6 +138,38 @@ foam.CLASS({
       name: 'showHeader',
       value: true,
       documentation: 'Set to false to not render the header.'
+    },
+    {
+      class: 'Boolean',
+      name: 'multiSelectEnabled',
+      documentation: 'Set to true to support selecting multiple table rows.'
+    },
+    {
+      class: 'Map',
+      name: 'selectedObjects',
+      documentation: `
+        The objects selected by the user when multi-select support is enabled.
+        It's a map where the key is the object id and the value is the object.
+      `
+    },
+    {
+      name: 'idsOfObjectsTheUserHasInteractedWith_',
+      value: new Set()
+    },
+    {
+      name: 'checkboxes_',
+      documentation: 'The checkbox elements when multi-select support is enabled. Used internally to implement the select all feature.',
+      value: new Map()
+    },
+    {
+      class: 'Boolean',
+      name: 'togglingCheckBoxes_',
+      documentation: 'Used internally to improve performance when toggling all checkboxes on or off.'
+    },
+    {
+      class: 'Boolean',
+      name: 'allCheckBoxesEnabled_',
+      documentation: 'Used internally to denote when the user has pressed the checkbox in the header to enable all checkboxes.'
     }
   ],
 
@@ -173,6 +207,42 @@ foam.CLASS({
           show(this.showHeader$).
           add(this.slot(function(columns_) {
             return this.E('tr').
+              // If multi-select is enabled, then we show a checkbox in the
+              // header that allows you to select all or select none.
+              callIf(view.multiSelectEnabled, function() {
+                var slot = view.SimpleSlot.create();
+                this.start('th').
+                  tag(view.CheckBox, {}, slot).
+                  style({ width: '42px' }).
+                end();
+
+                // Set up a listener so we can update the existing CheckBox
+                // views when a user wants to select all or select none.
+                view.onDetach(slot.value.dot('data').sub(function(_, __, ___, newValueSlot) {
+                  var checked = newValueSlot.get();
+                  view.allCheckBoxesEnabled_ = checked;
+
+                  if ( checked ) {
+                    view.data.select().then(function(arraySink) {
+                      view.selectedObjects = arraySink.array.reduce(function(acc, obj) {
+                        acc[obj.id] = obj;
+                        return acc;
+                      }, {});
+                    });
+                  } else {
+                    view.selectedObjects = {};
+                  }
+
+                  // Update the existing CheckBox views.
+                  view.togglingCheckBoxes_ = true;
+                  view.checkboxes_.forEach(function(checkbox) {
+                    checkbox.data = checked;
+                  });
+                  view.togglingCheckBoxes_ = false;
+                }));
+              }).
+
+              // Render the table headers for the property columns.
               forEach(columns_, function(column) {
                 this.start('th').
                   addClass(view.myClass('th-' + column.name)).
@@ -192,6 +262,10 @@ foam.CLASS({
                   }).
                 end();
               }).
+
+              // Render a th at the end for the column that contains the context
+              // menu. If the column-editing feature is enabled, add that to the
+              // th we create here.
               call(function() {
                 this.start('th').
                   callIf(view.editColumnsEnabled, function() {
@@ -214,6 +288,17 @@ foam.CLASS({
     {
       name: 'rowsFrom',
       code: function(dao) {
+        /**
+         * Given a DAO, add a tbody containing the data from the DAO to the
+         * table and return a reference to the tbody.
+         *
+         * NOTE: This exists so that ScrollTableView can create and manage
+         * several different tbody elements inside the TableView it uses. It
+         * needs to manage several tbody elements so it can provide performant
+         * infinite scroll on tables of any size. So this method exists solely
+         * as an implementation detail of ScrollTableView at the time of
+         * writing.
+         */
         var view = this;
         return this.slot(function(columns_) {
           // Make sure the DAO set here responds to ordering when a user clicks
@@ -258,6 +343,68 @@ foam.CLASS({
                       view.myClass('selected') : '';
                 })).
                 addClass(view.myClass('row')).
+
+                // If the multi-select feature is enabled, then we render a
+                // Checkbox in the first cell of each row.
+                callIf(view.multiSelectEnabled, function() {
+                  var slot = view.SimpleSlot.create();
+                  this
+                    .start('td')
+                      .tag(view.CheckBox, { data: view.idsOfObjectsTheUserHasInteractedWith_.has(obj.id) ? !!view.selectedObjects[obj.id] : view.allCheckBoxesEnabled_ }, slot)
+                    .end();
+
+                  // Set up a listener so that when the user checks or unchecks
+                  // a box, we update the `selectedObjects` property.
+                  view.onDetach(slot.value$.dot('data').sub(function(_, __, ___, newValueSlot) {
+                    // If the user is checking or unchecking all boxes at once,
+                    // we only want to publish one propertyChange event, so we
+                    // trigger it from the listener in the table header instead
+                    // of here. This way we prevent a propertyChange being fired
+                    // for every single CheckBox's data changing.
+                    if ( view.togglingCheckBoxes_ ) return;
+
+                    // Remember that the user has interacted with this checkbox
+                    // directly. We need this because the ScrollTableView loads
+                    // tbody's in and out while the user scrolls, so we need to
+                    // handle the case when a user selects all, then unselects
+                    // a particular row, then scrolls far enough that the tbody
+                    // the selection was in unloads, then scrolls back into the
+                    // range where it reloads. We need to know if they've set
+                    // it to something already and we can't simply look at the
+                    // value on `selectedObjects` because then we won't know if
+                    // `selectedObjects[obj.id] === undefined` means they
+                    // haven't interacted with that checkbox or if it means they
+                    // explicitly set it to false. We could keep the key but set
+                    // the value to null, but that clutters up `selectedObjects`
+                    // because some values are objects and some are null. If we
+                    // use a separate set to remember which checkboxes the user
+                    // has interacted with, then we don't need to clutter up
+                    // `selectedObjects`.
+                    view.idsOfObjectsTheUserHasInteractedWith_.add(obj.id);
+
+                    var checked = newValueSlot.get();
+
+                    if ( checked ) {
+                      var modification = {};
+                      modification[obj.id] = checked ? obj : null;
+                      view.selectedObjects = Object.assign({}, view.selectedObjects, modification);
+                    } else {
+                      var temp = Object.assign({}, view.selectedObjects);
+                      delete temp[obj.id];
+                      view.selectedObjects = temp;
+                    }
+                  }));
+
+                  // Store each CheckBox Element in a map so we have a reference
+                  // to them so we can set the `data` property of them when the
+                  // user checks the box to enable or disable all checkboxes.
+                  var checkbox = slot.get();
+                  view.checkboxes_.set(obj.id, checkbox);
+                  checkbox.onDetach(function() {
+                    view.checkboxes_.delete(obj.id);
+                  });
+                }).
+
                 forEach(columns_, function(column) {
                   this.
                     start('td').
@@ -274,8 +421,8 @@ foam.CLASS({
                       }).
                     end();
                 }).
-                start('td')
-                  .attrs({ name:'contextMenuCell' }).
+                start('td').
+                  attrs({ name: 'contextMenuCell' }).
                   addClass(view.myClass('context-menu-cell')).
                   tag(view.OverlayActionListView, {
                     data: actions,


### PR DESCRIPTION
## Notes
* Adds support to `UnstyledTableView` to let the user select multiple rows. It can be turned on via a flag property named `multiSelectEnabled` and when it's on, the `selectedObjects` property is updated to reflect the selections the user has made.
* There's a checkbox in the header that selects all rows when checked and deselects all rows when unchecked.
* Supports the ScrollTableView by making sure checkboxes know their state even when they're loaded in and out of the DOM as the user scrolls.
* It isn't integrated with the DAO controller yet (ie: you can't do anything once you've made selections), but I wanted to put this up for review before I start integrating this with other things.

## Screenshot with some rows selected
<img width="1029" alt="Screen Shot 2019-06-18 at 3 26 12 PM" src="https://user-images.githubusercontent.com/4259165/59713426-764bf480-91dd-11e9-9035-f76e67dc6b7f.png">
