### PR TITLE
DO NOT MERGE: ExpressionSlot fallback to context

### DIFF
--- a/src/foam/core/Slot.js
+++ b/src/foam/core/Slot.js
@@ -420,7 +420,12 @@ foam.CLASS({
 
         var args = foam.Function.argNames(this.code);
         for ( var i = 0 ; i < args.length ; i++ ) {
-          args[i] = obj.slot(args[i]);
+          try {
+            args[i] = obj.slot(args[i]);
+          } catch {
+            args[i] = this.__context__[args[i]+'$'] ||
+              foam.core.ConstantSlot.create();
+          }
         }
 
         // this.invalidate(); // ???: Is this needed?

--- a/src/foam/layout/Section.js
+++ b/src/foam/layout/Section.js
@@ -33,7 +33,7 @@ foam.CLASS({
     {
       class: 'Function',
       name: 'createIsAvailableFor',
-      value: function(data$) {
+      value: function(x, data$) {
         return foam.core.ConstantSlot.create({value: true});
       }
     }

--- a/src/foam/layout/SectionAxiom.js
+++ b/src/foam/layout/SectionAxiom.js
@@ -40,11 +40,11 @@ foam.CLASS({
     }
   ],
   methods: [
-    function createIsAvailableFor(data$) {
+    function createIsAvailableFor(x, data$) {
       var slot = foam.core.ExpressionSlot.create({
         obj$: data$,
         code: this.isAvailable
-      });
+      }, x);
 
       if ( this.permissionRequired ) {
         var permSlot = data$.map(data => {

--- a/src/foam/u2/detail/SectionView.js
+++ b/src/foam/u2/detail/SectionView.js
@@ -44,7 +44,7 @@ foam.CLASS({
         .add(self.slot(function(section, showTitle, section$title) {
           if ( ! section ) return;
           return self.Rows.create()
-            .show(section.createIsAvailableFor(self.data$))
+            .show(section.createIsAvailableFor(self.__subSubContext__, self.data$))
             .callIf(showTitle && section$title, function () {
               this.start('h2').add(section$title).end();
             })

--- a/src/foam/u2/detail/SectionedDetailView.js
+++ b/src/foam/u2/detail/SectionedDetailView.js
@@ -42,7 +42,7 @@ foam.CLASS({
                 this
                   .start()
                     .style({ padding: '16px 0' })
-                    .show(s.createIsAvailableFor(self.data$))
+                    .show(s.createIsAvailableFor(self.__subSubContext__, self.data$))
                     .start('h2').add(s.title$).end()
                     .start(self.CardBorder)
                       .addClass('inner-card')


### PR DESCRIPTION
Allow ExpressionSlot to fallback onto the context it was created in and make the Section's createIsAvailableFor's ExpressionSlot use the context that's passed in. With this, the isAvailable for SectionAxioms can use things like controllerMode in their expression.