### PR TITLE
Jasmine 3.3 compatibility fix

### DIFF
--- a/test/src/net/RetryHTTPRequest.js
+++ b/test/src/net/RetryHTTPRequest.js
@@ -50,7 +50,7 @@ describe('RetryHTTPRequest', function() {
   }
 
   it('should fail when number of tries is too low', function(done) {
-    mkRequest({ numTries: 2 }).send().then(done.fail, done);
+    mkRequest({ numTries: 2 }).send().then(done.fail, () => done());
   });
   it('should succeed when number of tries is sufficiently high', function(done) {
     mkRequest({ numTries: 3 }).send().then(done, done.fail);


### PR DESCRIPTION
Jasmine 3.3 done() now looks for exceptions and fails automatically. In this one case we need to ignore the exception and succeed in the exceptional case.