### PR TITLE
Add text key for 2FA

### DIFF
--- a/src/foam/nanos/auth/twofactor/GoogleTOTPAuthService.js
+++ b/src/foam/nanos/auth/twofactor/GoogleTOTPAuthService.js
@@ -56,9 +56,6 @@ foam.CLASS({
           x.get("user")) ;
         DAO userDAO = (DAO) x.get("localUserDAO");
 
-        // fetch from user dao to get secret key
-        user = (User) userDAO.find(user.getId());
-
         // generate secret key, encode as base32 and store
         String key = BaseEncoding.base32().encode(generateSecret(KEY_SIZE));
         key = key.replaceFirst("[=]*$", "");

--- a/src/foam/nanos/auth/twofactor/GoogleTOTPAuthService.js
+++ b/src/foam/nanos/auth/twofactor/GoogleTOTPAuthService.js
@@ -65,17 +65,17 @@ foam.CLASS({
         user.setTwoFactorSecret(key);
         userDAO.put_(x, user);
 
-        if ( ! generateQrCode ) {
-          return key;
-        }
-
         try {
           EmailConfig service = (EmailConfig) x.get("emailConfig");
           String name = service == null ? "FOAM" : service.getDisplayName();
           String path = String.format("/%s:%s", name, user.getEmail());
           String query = String.format("secret=%s&issuer=%s&algorithm=%s", key, name, getAlgorithm());
           URI uri = new URI("otpauth", "totp", path, query, null);
-          return "data:image/svg+xml;charset=UTF-8," + QrCode.encodeText(uri.toASCIIString(), QrCode.Ecc.MEDIUM).toSvgString(0);
+          String[] arr = new String[2];
+          arr[0] = key;
+          arr[1] = "data:image/svg+xml;charset=UTF-8,"
+            + QrCode.encodeText(uri.toASCIIString(), QrCode.Ecc.MEDIUM).toSvgString(0);
+          return arr; 
         } catch ( Throwable t ) {
           throw new RuntimeException(t);
         }

--- a/src/foam/nanos/auth/twofactor/GoogleTOTPAuthService.js
+++ b/src/foam/nanos/auth/twofactor/GoogleTOTPAuthService.js
@@ -16,6 +16,7 @@ foam.CLASS({
     'foam.dao.DAO',
     'foam.nanos.app.EmailConfig',
     'foam.nanos.auth.User',
+    'foam.nanos.logger.Logger',
     'foam.nanos.session.Session',
     'foam.util.SafetyUtil',
     'io.nayuki.qrcodegen.QrCode',
@@ -48,6 +49,8 @@ foam.CLASS({
     {
       name: 'generateKey',
       javaCode: `
+        Logger logger = (Logger) x.get("logger");
+
         User user = (User) (x.get("agent") != null ?
           x.get("agent") :
           x.get("user")) ;
@@ -77,8 +80,12 @@ foam.CLASS({
             + QrCode.encodeText(uri.toASCIIString(), QrCode.Ecc.MEDIUM).toSvgString(0);
           return arr; 
         } catch ( Throwable t ) {
-          throw new RuntimeException(t);
+          logger.error("Error when generating QR code: " + t);
         }
+
+        String[] arr = new String[1];
+        arr[0] = key;
+        return arr;
       `
     },
     {

--- a/src/foam/nanos/auth/twofactor/OTPAuthService.js
+++ b/src/foam/nanos/auth/twofactor/OTPAuthService.js
@@ -14,7 +14,7 @@ foam.INTERFACE({
     {
       name: 'generateKey',
       async: true,
-      type: 'String',
+      type: 'String[]',
       javaThrows: [ 'foam.nanos.auth.AuthenticationException' ],
       args: [
         {


### PR DESCRIPTION
I would prefer to let `generateKey` method return an array which can contain both QR and text-key.

GoogleTOTPAuthService extends AbstractTOTPAuthService
AbstractTOTPAuthService extends AbstractOTPAuthService
AbstractOTPAuthService implements OTPAuthService
OTPAuthService is an interface.