### PR TITLE
removing a password test based off arch. decision. More to come.

### DIFF
--- a/src/foam/util/PasswordTest.js
+++ b/src/foam/util/PasswordTest.js
@@ -39,7 +39,7 @@ foam.CLASS({
         // isValid tests
         Password_IsValid(x, null, false, "isValid method returns false given null");
         Password_IsValid(x, "", false, "isValid method returns false given empty string");
-        Password_IsValid(x, "foam", false, "isValid returns false given password shorter than 6 characters");
+        // Password_IsValid(x, "foam", false, "isValid returns false given password shorter than 6 characters");
         Password_IsValid(x, "F0amframew0rk", true, "isValid returns true given password longer than 6 characters");
       `
     },


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/CPF-2169
--> this pr starts the above ticket. Which came into question because of:
https://github.com/nanoPayinc/NANOPAY/pull/7067
Which is the adjustments to the SignUp model.


The argument here, is that password strength should not dictate what the user chooses to as their password.

The idea is to show the user the level of strength for the password they are choosing with the entropy (net.nanopay.ui.NewPasswordView) but not have the backend validators demand any regulations.

