### PR TITLE
Fix major memory leak in Boxes

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -370,6 +370,8 @@ FOAM_FILES([
   { name: "foam/box/ForwardingBox" },
   { name: "foam/box/SessionClientBox" },
   { name: "foam/box/AuthServiceClientBox" },
+  { name: "foam/box/OneTimeBox" },
+  { name: "foam/box/ExportBox" },
 
   { name: "foam/swift/refines/Stub", flags: ['swift'] },
   { name: "foam/swift/refines/Promised", flags: ['swift'] },

--- a/src/foam/box/BoxRegistryBox.js
+++ b/src/foam/box/BoxRegistryBox.js
@@ -86,10 +86,10 @@ if let object = msg.object as? foam_box_SubBoxMessage {
         if ( this.SubBoxMessage.isInstance(msg.object) ) {
           var name = msg.object.name;
 
-          if ( this.registry_[name] && this.registry_[name].localBox ) {
+          if ( this.registry_[name] ) {
             // Unpack sub box object... is this right?
             msg.object = msg.object.object;
-            this.registry_[name].localBox.send(msg);
+            this.registry_[name].send(msg);
           } else {
             if ( msg.attributes.replyBox ) {
               msg.attributes.replyBox.send(
@@ -110,11 +110,11 @@ if ( obj instanceof foam.box.SubBoxMessage ) {
   foam.box.SubBoxMessage sbm = (foam.box.SubBoxMessage)obj;
   String name = sbm.getName();
 
-  Registration dest = (Registration)getRegistry_().get(name);
+  foam.box.Box dest = (foam.box.Box)getRegistry_().get(name);
 
   if ( dest != null ) {
     msg.setObject(sbm.getObject());
-    dest.getLocalBox().send(msg);
+    dest.send(msg);
   } else if ( msg.getAttributes().containsKey("replyBox") ) {
     foam.box.Box replyBox = (foam.box.Box)msg.getAttributes().get("replyBox");
     foam.box.Message errorMessage = getX().create(foam.box.Message.class);

--- a/src/foam/box/ExportBox.js
+++ b/src/foam/box/ExportBox.js
@@ -1,0 +1,41 @@
+foam.CLASS({
+  package: 'foam.box',
+  name: 'ExportBox',
+  documentation: 'The standard class for a reply box.  Holds both the local box that messages are delivered to, and the messenger box which is what is serialized over the network and should be configured to deliver messages back to us.',
+  implements: [ 'foam.box.Box' ],
+  properties: [
+    {
+      class: 'FObjectProperty',
+      of: 'foam.box.Box',
+      networkTransient: true,
+      name: 'localBox'
+    },
+    {
+      class: 'FObjectProperty',
+      of: 'foam.box.Box',
+      name: 'messengerBox'
+    }
+  ],
+  methods: [
+    {
+      name: 'outputJSON',
+      code: function(outputter) {
+        // This is purely an optimization. The localBox is marked as
+        // network transient, so we could serialize the ReplyBox as a
+        // whole to the remote side, but that provides no utility,
+        // only overhead.  We would need to remove this if at some
+        // point we decide to store ReplyBox's in long term storage.
+        // Although doing so is unlikely to be useful as the localBox
+        // is typically not serializable.
+        outputter.output(this.messengerBox);
+      }
+    },
+    {
+      name: 'send',
+      code: function(msg) {
+        this.localBox.send(msg);
+      },
+      javaCode: `getLocalBox().send(msg);`
+    }
+  ]
+});

--- a/src/foam/box/LocalBoxRegistry.js
+++ b/src/foam/box/LocalBoxRegistry.js
@@ -22,6 +22,7 @@ foam.CLASS({
 
   requires: [
     'foam.box.NoSuchNameException',
+    'foam.box.ExportBox',
     'foam.box.SubBox'
   ],
 
@@ -42,33 +43,12 @@ foam.CLASS({
     }
   ],
 
-  classes: [
-    {
-      name: 'Registration',
-      properties: [
-        {
-          class: 'FObjectProperty',
-          of: 'foam.box.Box',
-          required: true,
-          name: 'exportBox'
-        },
-        {
-          class: 'FObjectProperty',
-          of: 'foam.box.Box',
-          required: true,
-          name: 'localBox'
-        }
-      ]
-    }
-  ],
-
   methods: [
     {
       name: 'doLookup',
       code: function doLookup(name) {
-        if ( this.registry_[name] &&
-             this.registry_[name].exportBox )
-          return this.registry_[name].exportBox;
+        if ( this.registry_[name] )
+          return this.registry_[name];
 
         throw this.NoSuchNameException.create({ name: name });
       },
@@ -84,7 +64,7 @@ Object registration = getRegistry_().get(name);
 if ( registration == null ) {
   throw new RuntimeException("No such name");
 }
-return ((Registration)registration).getExportBox();
+return (foam.box.ExportBox)registration;
 `
     },
     {
@@ -92,15 +72,22 @@ return ((Registration)registration).getExportBox();
       code: function(name, service, localBox) {
         name = name || foam.next$UID();
 
-        var exportBox = this.SubBox.create({ name: name, delegate: this.me });
-        exportBox = service ? service.clientBox(exportBox) : exportBox;
+        var box = this.ExportBox.create({
+          localBox: localBox,
+          messengerBox: this.SubBox.create({
+            name: name,
+            delegate: this.me
+          })
+        });
 
-        this.registry_[name] = {
-          exportBox: exportBox,
-          localBox: service ? service.serverBox(localBox) : localBox
-        };
+        this.registry_[name] = box;
 
-        return this.registry_[name].exportBox;
+        box.onDetach(function() {
+          if ( this.registry_[name] === box )
+            this.unregister(name);
+        }.bind(this));
+
+        return box;
       },
       swiftSynchronized: true,
       swiftCode: function() {/*
@@ -122,35 +109,21 @@ return registration.exportBox
       javaCode: `
 if ( name == null ) name = Integer.toString(foam.box.IdGenerator.nextId());
 
-foam.box.SubBox exportBox = getX().create(foam.box.SubBox.class);
-exportBox.setName(name);
-exportBox.setDelegate(getMe());
-Registration registration = new Registration();
-registration.setX(getX());
-registration.setExportBox(exportBox);
-registration.setLocalBox(box);
-// TODO(adamvy): Apply service policy
+foam.box.ExportBox exportBox = getX().create(foam.box.ExportBox.class);
+foam.box.SubBox subBox = getX().create(foam.box.SubBox.class);
+subBox.setName(name);
+subBox.setDelegate(getMe());
+exportBox.setMessengerBox(subBox);
+exportBox.setLocalBox(box);
 
-getRegistry_().put(name, registration);
+getRegistry_().put(name, exportBox);
+
 return exportBox;
 `
     },
     {
       name: 'unregister',
       code: function(name) {
-        if ( foam.box.Box.isInstance(name) ) {
-          for ( var key in this.registry_ ) {
-            // TODO(markdittmer): Should there be a specialized compare() should
-            // be implemented by NamedBox (to cut out delegate) and
-            // foam.util.compare()?
-            if ( this.registry_[key].exportBox === name ) {
-              delete this.registry_[key];
-              return;
-            }
-          }
-          return;
-        }
-
         delete this.registry_[name];
       },
       swiftSynchronized: true,

--- a/src/foam/box/OneTimeBox.js
+++ b/src/foam/box/OneTimeBox.js
@@ -1,0 +1,14 @@
+foam.CLASS({
+  package: 'foam.box',
+  name: 'OneTimeBox',
+  extends: 'foam.box.ProxyBox',
+  methods: [
+    {
+      name: 'send',
+      code: function(msg) {
+        this.detach();
+        this.SUPER(msg);
+      }
+    }
+  ]
+});

--- a/src/foam/box/RawWebSocketBox.js
+++ b/src/foam/box/RawWebSocketBox.js
@@ -72,16 +72,6 @@ foam.CLASS({
       name: 'send',
       code: function send(msg) {
         var replyBox = msg.attributes.replyBox;
-        if ( replyBox ) {
-          // TODO: Should replyBox just be a property on message with
-          // custom serialization?
-
-          // TODO: Add one-time service policy
-
-          msg.attributes.replyBox =
-            this.__context__.registry.register(null, null, msg.attributes.replyBox);
-        }
-
         var payload = this.JSONOutputter.create().copyFrom(foam.json.Network).stringify(msg);
 
         try {

--- a/src/foam/core/Stub.js
+++ b/src/foam/core/Stub.js
@@ -133,6 +133,7 @@ foam.CLASS({
         'foam.box.RPCReturnBox',
         'foam.box.ReplyBox',
         'foam.box.RPCMessage',
+        'foam.box.OneTimeBox',
         'foam.box.Message'
       ].map(function(s) {
         var path = s.split('.');

--- a/src/foam/core/StubMethod.js
+++ b/src/foam/core/StubMethod.js
@@ -25,6 +25,16 @@ foam.CLASS({
           var replyBox = this.RPCReturnBox.create();
           var ret      = replyBox.promise;
 
+          var replyBox = this.OneTimeBox.create({
+            delegate: replyBox
+          });
+
+          var exportBox = this.registry.register(null, null, replyBox);
+
+          replyBox.onDetach(exportBox);
+
+          replyBox = exportBox;
+
           // Automatically wrap RPCs that return a "PromisedAbc" or similar
           // TODO: Move this into RPCReturnBox ?
           var cls = this.__context__.lookup(type, true);

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -77,6 +77,7 @@ var classes = [
   'foam.box.HTTPBox',
   'foam.box.HTTPReplyBox',
   'foam.box.AuthServiceClientBox',
+  'foam.box.ExportBox',
   'foam.nanos.app.AppConfig',
   'foam.nanos.app.ContextLookupAppConfigService',
   'foam.nanos.http.WebAgent',


### PR DESCRIPTION
The response to every single RPC was being held in memory forever.

This change introduces a OneTimeBox which decorates the
replyBox of an RPC request.  We also introduce an ExportBox
which represents a combination of an local box to deliver a received
and a messenger box to given to others which should deliver messages
back to the local box.

Refactored LocalBoxRegistry to use ExportBox instead of the previous
"Registration" class.

Finally updated code to do the registration in the Stub method, rather than
in places like WebSocketService.