### PR TITLE
Call sink.eof before returning the sink in MDAO's select and remove a…

### DIFF
--- a/src/foam/dao/MDAO.java
+++ b/src/foam/dao/MDAO.java
@@ -188,6 +188,7 @@ public class MDAO
 
     if ( pm != null ) pm.log(x);
 
+    sink.eof();
     return sink;
   }
 

--- a/src/foam/dao/index/TreeNode.java
+++ b/src/foam/dao/index/TreeNode.java
@@ -496,7 +496,6 @@ public class TreeNode {
       } else {
         sink = decorateSink(null, sink, skip, limit, order, predicate);
         select_(currentNode, sink, skip, limit, size, tail);
-        sink.eof();
       }
     } else if ( ! reverseSort ) {
       skipLimitTreeNode(currentNode, sink, skip, limit, size, tail);


### PR DESCRIPTION
…n eof call from TreeNode that should not longer be needed.