### PR TITLE
Attribute map name added to radio input name

### DIFF
--- a/src/foam/u2/view/RadioView.js
+++ b/src/foam/u2/view/RadioView.js
@@ -70,7 +70,7 @@ foam.CLASS({
           start('input').
             attrs({
               type: 'radio',
-              name: c[0] + '',
+              name: self.attributeMap ? self.attributeMap.name.value : c[0] + '',
               value: c[0],
               checked: self.slot(function (data) { return data === c[0]; })
             }).


### PR DESCRIPTION
I encountered an issue when having two properties each with a radio view with the same choice values 
ie. ( choices: [ [ true, 'yes' ], [ false, 'no' ] ] )


I did some investigation and saw that we were assigning the name of our radio inputs as the first index in our choices. This presents issues when several properties share the same values since HTML registers them as a group - making only one capable of being selected.

The following changes specifies the name on the radio input if an attributeMap is present.
