### PR TITLE
Fix RuleEngine context

### DIFF
--- a/src/foam/nanos/ruler/RuleEngine.java
+++ b/src/foam/nanos/ruler/RuleEngine.java
@@ -149,17 +149,17 @@ public class RuleEngine extends ContextAwareSupport {
   private boolean isRuleApplicable(Rule rule, FObject obj, FObject oldObj) {
     currentRule_ = rule;
     return rule.getAction() != null
-      && rule.f(x_, obj, oldObj);
+      && rule.f(userX_, obj, oldObj);
   }
 
   private void asyncApplyRules(List<Rule> rules, FObject obj, FObject oldObj) {
-    ((FixedThreadPool) getX().get("threadPool")).submit(getX(), x -> {
+    ((FixedThreadPool) getX().get("threadPool")).submit(userX_, x -> {
       for (Rule rule : rules) {
         if ( stops_.get() ) return;
 
         currentRule_ = rule;
         if ( rule.getAsyncAction() != null
-          && rule.f(getX(), obj, oldObj)
+          && rule.f(x, obj, oldObj)
         ) {
           try {
             rule.asyncApply(x, obj, oldObj, RuleEngine.this);


### PR DESCRIPTION
Pass user context instead of system context when applying async rules and checking rules applicability so that rules action and predicate have the current user/agent and session to work with.

For example, this allows for creating rules with predicate that checks if "currentUser=someone" or rules with action that gets current user IP address from session.