### PR TITLE
Table style update

### DIFF
--- a/src/foam/comics/DAOControllerView.js
+++ b/src/foam/comics/DAOControllerView.js
@@ -60,11 +60,8 @@ foam.CLASS({
     ^container {
       display: grid;
       grid-template-columns: fit-content(100%) auto;
+      grid-gap: 10px;
       overflow-x: scroll;
-    }
-
-    ^container > * + * {
-      margin-left: 10px;
     }
 
     ^ .actions {

--- a/src/foam/nanos/controller/AppStyles.js
+++ b/src/foam/nanos/controller/AppStyles.js
@@ -20,53 +20,6 @@ foam.CLASS({
       background: /*%GREY5%*/ #f5f7fa;
       margin: 0;
     }
-    table.foam-u2-view-TableView {
-      border-collapse: collapse;
-      border-style: hidden;
-    }
-    .foam-u2-view-TableView thead > tr > th {
-      color: #2b2b2b;
-      border-spacing: 0;
-      text-align: left;
-      padding-left: 15px;
-      height: 40px;
-      font-family: Roboto, 'Helvetica Neue', helvetica, sans-serif;
-      font-size: 14px;
-      font-style: normal;
-      font-stretch: normal;
-      font-weight: 900;
-      line-height: 1.5;
-      letter-spacing: 0.4px;
-    }
-    .foam-u2-view-TableView-row > th > td {
-      font-size: 12px;
-      letter-spacing: 0.2px;
-      text-align: left;
-      color: /*%BLACK%*/ #1e1f21;
-      padding-left: 15px;
-      height: 60px;
-    }
-    .foam-u2-view-TableView th {
-      font-family: Roboto, 'Helvetica Neue', helvetica, sans-serif;
-      padding-left: 15px;
-      font-size: 14px;
-      line-height: 1;
-      letter-spacing: 0.4px;
-      color: /*%BLACK%*/ #1e1f21;
-    }
-    .foam-u2-view-TableView td {
-      font-family: Roboto, 'Helvetica Neue', helvetica, sans-serif;
-      font-size: 12px;
-      line-height: 1.33;
-      letter-spacing: 0.2px;
-      padding-left: 15px;
-      font-size: 12px;
-      color: /*%BLACK%*/ #1e1f21;
-    }
-    .foam-u2-view-TableView-row {
-      height: 60px;
-      background: white;
-    }
     .New {
       width: 35px;
       height: 20px;

--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -284,7 +284,7 @@
         this.page2DAO_ = this.initialPage2DAO_;
         this.page3DAO_ = this.initialPage3DAO_;
         this.table_.childNodes
-          .filter((x) => x.nodeName === 'TBODY')
+          .slice(1)
           .forEach((x) => x.remove());
         this.table_.add(this.table_.rowsFrom(this.page1DAO_$proxy));
         this.addTbodies();
@@ -315,7 +315,7 @@
         this[daoName] = this.data.skip(this.currentUpperBound - this.pageSize).limit(this.pageSize);
         var rows = this.table_.rowsFrom(this[daoName + '$proxy']);
         this.table_.add(rows);
-        var x = this.table_.childNodes.filter((x) => x.nodeName === 'TBODY');
+        var x = this.table_.childNodes.slice(1);
         this.bottomBufferTable_ = x[x.length - 1];
       }
     },
@@ -341,7 +341,7 @@
         this[daoName] = this.data.skip(this.currentLowerBound).limit(this.pageSize);
         var rows = this.table_.rowsFrom(this[daoName + '$proxy']);
         this.table_.insertBefore(this.table_.slotE_(rows), this.visibleTable_);
-        var x = this.table_.childNodes.filter((x) => x.nodeName === 'TBODY');
+        var x = this.table_.childNodes.slice(1);
         this.topBufferTable_ = x[0];
       }
     },
@@ -415,7 +415,7 @@
       code: function() {
         this.table_.add(this.table_.rowsFrom(this.page2DAO_$proxy));
         this.table_.add(this.table_.rowsFrom(this.page3DAO_$proxy));
-        var tbodies = this.table_.childNodes.filter((x) => x.nodeName === 'TBODY');
+        var tbodies = this.table_.childNodes.slice(1);
         this.topBufferTable_ = tbodies[0];
         this.visibleTable_ = tbodies[1];
         this.bottomBufferTable_ = tbodies[2];

--- a/src/foam/u2/view/TableView.js
+++ b/src/foam/u2/view/TableView.js
@@ -11,69 +11,60 @@ foam.CLASS({
 
   css: `
     ^ {
+      width: 1450px;
       border-spacing: 14px 8px;
+      border-collapse: collapse;
     }
 
-    ^ th {
-      text-align: left;
-      white-space: nowrap;
-      font-family: Roboto, 'Helvetica Neue', helvetica, sans-serif;
-      padding-left: 15px;
-      font-size: 14px;
-      line-height: 1;
-      letter-spacing: 0.4px;
-      color: /*%BLACK%*/ #1e1f21;
+    ^tr {
+      background: white;
+      border-bottom: 1px solid /*%GREY4%*/ #e7eaec;
+      display: flex;
+      height: 48px;
+    }
+
+    ^tbody > ^tr:hover {
       background: /*%GREY5%*/ #f5f7fa;
-      box-sizing: border-box;
-    }
-
-    ^ th:not(:last-child) > img {
-      margin-left: 8px;
-    }
-
-    ^ td {
-      white-space: nowrap;
-      font-family: Roboto, 'Helvetica Neue', helvetica, sans-serif;
-      line-height: 1.33;
-      letter-spacing: 0.2px;
-      padding-left: 15px;
-      font-size: 14px;
-      color: /*%BLACK%*/ #1e1f21;
-    }
-
-    ^row:hover {
-      background: #eee;
       cursor: pointer;
     }
 
-    ^ tbody > tr {
-      height: 48px;
-      background: white;
+    ^thead {
+      border: 1px solid /*%GREY4%*/ #e7eaec;
+      border-radius: 5px;
+      box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.08);
+      overflow: hidden;
+      position: sticky;
+      top: 0;
     }
 
-    ^ tbody > tr > td {
-      border-top: solid 1px #e2e2e3;
-      border-bottom: solid 1px #e2e2e3;
+    ^td,
+    ^th {
+      align-items: center;
+      box-sizing: border-box;
+      color: /*%BLACK%*/ #1e1f21;
+      display: flex;
+      font-family: Roboto, 'Helvetica Neue', helvetica, sans-serif;
+      font-size: 14px;
+      line-height: 1.5;
+      overflow: hidden;
+      padding-left: 16px;
+      text-align: left;
+      white-space: nowrap;
     }
 
-    ^ tbody > tr > td:first-child {
-      border-top-left-radius: 5px;
-      border-left: solid 1px #e2e2e3;
+    ^th {
+      font-weight: 900;
     }
 
-    ^ tbody > tr > td:last-child {
-      border-top-right-radius: 5px;
-      border-right: solid 1px #e2e2e3;
+    ^th:not(:last-child) > img {
+      margin-left: 8px;
     }
 
+    /**
+     * OTHER
+     */
     ^selected {
-      background: #eee;
-    }
-
-    ^vertDots {
-      font-size: 20px;
-      font-weight: bold;
-      padding-right: 21px;
+      background: /*%PRIMARY5%*/ #e5f1fc;
     }
 
     ^noselect {
@@ -87,10 +78,6 @@ foam.CLASS({
 
     ^ .disabled {
       color: #aaa;
-    }
-
-    ^context-menu-cell {
-      margin-right: 12px;
     }
   `,
 });

--- a/src/foam/u2/view/TreeView.js
+++ b/src/foam/u2/view/TreeView.js
@@ -53,7 +53,7 @@ foam.CLASS({
       min-width: 120px;
       padding: 4px;
       font-weight: 500;
-      color: #2b2b2b;
+      color: /*%BLACK%*/ #1e1f21;
     }
 
     ^selected > ^label {

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -206,16 +206,19 @@ foam.CLASS({
       this.
         addClass(this.myClass()).
         addClass(this.myClass(this.of.id.replace(/\./g, '-'))).
-        setNodeName('table').
-        start('thead').
+        start().
+          addClass(this.myClass('thead')).
           show(this.showHeader$).
           add(this.slot(function(columns_) {
-            return this.E('tr').
+            return this.E().
+              addClass(view.myClass('tr')).
+
               // If multi-select is enabled, then we show a checkbox in the
               // header that allows you to select all or select none.
               callIf(view.multiSelectEnabled, function() {
                 var slot = view.SimpleSlot.create();
-                this.start('th').
+                this.start().
+                  addClass(view.myClass('th')).
                   tag(view.CheckBox, {}, slot).
                   style({ width: '42px' }).
                 end();
@@ -246,10 +249,15 @@ foam.CLASS({
 
               // Render the table headers for the property columns.
               forEach(columns_, function(column) {
-                this.start('th').
+                this.start().
+                  addClass(view.myClass('th')).
                   addClass(view.myClass('th-' + column.name)).
-                  callIf(column.tableWidth, function() {
-                    this.style({ width: column.tableWidth + 'px' });
+                  call(function() {
+                    if ( column.tableWidth ) {
+                      this.style({ flex: `0 0 ${column.tableWidth}px` });
+                    } else {
+                      this.style({ flex: '1 0 0' });
+                    }
                   }).
                   on('click', function(e) {
                     view.sortBy(column);
@@ -269,7 +277,9 @@ foam.CLASS({
               // menu. If the column-editing feature is enabled, add that to the
               // th we create here.
               call(function() {
-                this.start('th').
+                this.start().
+                  addClass(view.myClass('th')).
+                  style({ flex: '0 0 60px' }).
                   callIf(view.editColumnsEnabled, function() {
                     this.addClass(view.myClass('th-editColumns')).
                     on('click', function(e) {
@@ -279,7 +289,6 @@ foam.CLASS({
                     addClass(view.myClass('vertDots')).
                     addClass(view.myClass('noselect'));
                   }).
-                  style({ width: '60px' }).
                   tag('div', null, view.dropdownOrigin$).
                 end();
               });
@@ -317,9 +326,11 @@ foam.CLASS({
             : modelActions;
 
           return this.
-            E('tbody').
+            E().
+            addClass(this.myClass('tbody')).
             select(proxy, function(obj) {
-              return this.E('tr').
+              return this.E().
+                addClass(view.myClass('tr')).
                 on('mouseover', function() { view.hoverSelection = obj; }).
                 callIf(view.dblclick && ! view.disableUserSelection, function() {
                   this.on('dblclick', function() {
@@ -351,7 +362,8 @@ foam.CLASS({
                 callIf(view.multiSelectEnabled, function() {
                   var slot = view.SimpleSlot.create();
                   this
-                    .start('td')
+                    .start()
+                      .addClass(view.myClass('td'))
                       .tag(view.CheckBox, { data: view.idsOfObjectsTheUserHasInteractedWith_[obj.id] ? !!view.selectedObjects[obj.id] : view.allCheckBoxesEnabled_ }, slot)
                     .end();
 
@@ -409,7 +421,8 @@ foam.CLASS({
 
                 forEach(columns_, function(column) {
                   this.
-                    start('td').
+                    start().
+                      addClass(view.myClass('td')).
                       callOn(column.tableCellFormatter, 'format', [
                         column.f ? column.f(obj) : null, obj, column
                       ]).
@@ -421,11 +434,19 @@ foam.CLASS({
                           }
                         } catch (err) {}
                       }).
+                      call(function() {
+                        if ( column.tableWidth ) {
+                          this.style({ flex: `0 0 ${column.tableWidth}px` });
+                        } else {
+                          this.style({ flex: '1 0 0' });
+                        }
+                      }).
                     end();
                 }).
-                start('td').
+                start().
+                  addClass(view.myClass('td')).
                   attrs({ name: 'contextMenuCell' }).
-                  addClass(view.myClass('context-menu-cell')).
+                  style({ flex: '0 0 60px' }).
                   tag(view.OverlayActionListView, {
                     data: actions,
                     obj: obj


### PR DESCRIPTION
## Changes

* The `TableView` is implemented using `div` elements now instead of the traditional `table`, `tbody`, `thead`, `tr`, `th`, and `td` elements. This frees us from a number of CSS limitations and bugs. The reason I did this was because I came across a bug in the CSS specification/browser implementation of it when setting table elements to `position: sticky`, where the border of the header wouldn't be sticky. There are other annoying quirks around the table elements in HTML that I've come across before, so it's simplest just to use `div`s instead and avoid the issues altogether.f
  * The DOM is a bit uglier now and the HTML isn't as semantic, but it's a tradeoff to get the application behaviour we want, which I would consider worthwhile
* Updated tables to match the designs
* Changed a handful of hard-coded colours to reference the Theme
* Fixed a tiny visual bug where the table and heading wouldn't be aligned when you toggle the filters in the DAO controller

## Screenshots

### Showing the table
<img width="1331" alt="Screen Shot 2019-07-04 at 4 03 43 PM" src="https://user-images.githubusercontent.com/4259165/60686189-596a1f00-9e75-11e9-9457-ba31bd215ff8.png">

### Showing hover and selected colour
<img width="1319" alt="Screen Shot 2019-07-04 at 4 03 55 PM" src="https://user-images.githubusercontent.com/4259165/60686188-596a1f00-9e75-11e9-944f-406ceace9548.png">