### PR TITLE
Hide 1:* relationships if no ID is set.

### DIFF
--- a/src/foam/dao/Relationship.js
+++ b/src/foam/dao/Relationship.js
@@ -677,6 +677,12 @@ foam.CLASS({
   extends: 'foam.dao.DAOProperty',
   properties: [
     {
+      name: 'visibilityExpression',
+      value: function(id) {
+        return !! id ? foam.u2.Visibility.RW : foam.u2.Visibility.HIDDEN;
+      }
+    },
+    {
       name: 'flags',
       value: ['swift', 'js'],
     },


### PR DESCRIPTION
This effectively hides them when creating an object.