### PR TITLE
PieDAOChartView Colouring

### DIFF
--- a/src/org/chartjs/PieDAOChartView.js
+++ b/src/org/chartjs/PieDAOChartView.js
@@ -78,7 +78,7 @@ foam.CLASS({
               // Pass keys and data in their correct order to method passed to be
               // processed
               backgroundColors = self.palette(keys, data);
-            } else {
+            } else if ( backgroundColors.length === 0 ) {
               // Fallback if all else fails. Should never be the case.
               data.forEach(function(_, index) {
                 backgroundColors.push('lightgray');

--- a/src/org/chartjs/PieDAOChartView.js
+++ b/src/org/chartjs/PieDAOChartView.js
@@ -77,7 +77,6 @@ foam.CLASS({
 
             config.data = {
               datasets: [{
-                label: 'Colors',
                 data: data,
                 backgroundColor: backgroundColors
               }],

--- a/src/org/chartjs/PieDAOChartView.js
+++ b/src/org/chartjs/PieDAOChartView.js
@@ -61,7 +61,7 @@ foam.CLASS({
             var backgroundColors = [];
             keys.forEach(key => {
               data.push(sink.groups[key].value);
-              if ( ! Array.isArray(self.palette) && typeof self.palette === 'object' ) {
+              if ( foam.Object.isInstance(self.palette) ) {
                 // Color has a key associated with it
                 var color = self.palette[key];
                 var unsupportedKeyColor = self.palette['default'] ? self.palette['default'] : 'lightgray';

--- a/src/org/chartjs/PieDAOChartView.js
+++ b/src/org/chartjs/PieDAOChartView.js
@@ -41,7 +41,14 @@ foam.CLASS({
           return palette[context.dataIndex % palette.length];
         }
       }
+    },
+    // Note: This is a workaround for a chartjs issue. Once it is resolved,
+    //       revert back to previous implementation
+    {
+      name: 'palette',
+      value: ['#E3170D', '#AF4035', '#CC1100', '#FFE4E1', '#FF6347', '#FF6600']
     }
+    // END WORKAROUND
   ],
 
   listeners: [
@@ -58,10 +65,21 @@ foam.CLASS({
             // a stack overflow.
             self.config.data = { datasets: [] };
             var config = foam.Object.clone(self.config);
+
+            // Note: this is a workaround for a chartjs issue. Once it is resolved,
+            //       revert back to previous implementation
+            var data = Object.keys(sink.groups).map(key => sink.groups[key].value);
+            var backgroundColors = [];
+            data.forEach(function(_ ,index) {
+              backgroundColors.push(self.palette[index % self.palette.length]);
+            });
+            // END WORKAROUND
+
             config.data = {
               datasets: [{
-                data: Object.keys(sink.groups).map(key => sink.groups[key].value),
-                backgroundColor: self.backgroundColor
+                label: 'Colors',
+                data: data,
+                backgroundColor: backgroundColors
               }],
               labels: Object.keys(sink.groups)
             };

--- a/src/org/chartjs/PieDAOChartView.js
+++ b/src/org/chartjs/PieDAOChartView.js
@@ -33,7 +33,11 @@ foam.CLASS({
     },
     {
       name: 'palette',
-      value: ['#E3170D', '#AF4035', '#CC1100', '#FFE4E1', '#FF6347', '#FF6600']
+      value: ['#E3170D', '#AF4035', '#CC1100', '#FFE4E1', '#FF6347', '#FF6600'],
+      documentation: `
+        Takes array/map/function. Function must take two params (keys, data) and
+        returns an array of colors.
+      `
     }
   ],
 


### PR DESCRIPTION
Refactors `backgroundColor` property to `palette` which takes an array/map/function.

If array:
- Cycles through the array and loops depending on number of data

If map:
- Colours section of the pie according to the provided key colour in the map
- If `default` is given in map, keys which have not been accounted for will use that colour
- If no `default` is given, 'lightgray' will be used

If function: 
- must be a function that takes two parameters (keys, data).
- must be a function that returns an array of colours.

This refactor should add flexibility in how we would represent data in the pie chart. Some possible representations include:
- Cycle through a colour palette (so not everything will be represented by the same colour)
- Each key would be represented by a specific colour (USD -> blue, CAD -> red)
- Colour of section would also reflect the range in which the data sits in. (red for data <= 33%, yellow for data between 34% - 66%, green for data > 66%)
 