### PR TITLE
#CPF-1651 : action in label doesn't effect the checkbox

### DIFF
--- a/src/foam/u2/CheckBox.js
+++ b/src/foam/u2/CheckBox.js
@@ -55,9 +55,11 @@ foam.CLASS({
           .callIfElse(this.labelFormatter,
                       this.labelFormatter,
                       function() { this.add(self.label$); })
-          .on('click', function() {
-            this.data = ! this.data;
-          }.bind(this))
+          .start()
+            .on('click', function() {
+              this.data = ! this.data;
+            }.bind(this))
+          .end()
         .end();
       }
     },


### PR DESCRIPTION
The **issue** arose when a labelFormatter was used that contained a link to open a new window.

The click on the link, toggled the checkbox. 

(**solution**)This PR separates the checkbox from the label, so an action taken on the label is seperate from the action on the checkbox.