### PR TITLE
Fixed Up TreeGraph to work properly with Invalidate

### DIFF
--- a/src/foam/graphics/TreeGraph.js
+++ b/src/foam/graphics/TreeGraph.js
@@ -37,18 +37,14 @@
    ],
 
    methods: [
-     function init() {
+     function initCView() {
        this.SUPER();
 
        if ( this.data ) {
-         this.root = this.Node.create({x:500, y: 50, data: this.data});
-         this.children.push(this.root);
-         this.doLayout();
-       }
-     },
-
-     function initCView() {
-       this.SUPER();
+        this.root = this.Node.create({x:500, y: 50, data: this.data});
+        this.add(this.root);
+        this.doLayout();
+      }
 
        // List for 'click' events to expand/collapse Nodes.
        this.canvas.on('click', function(e) {


### PR DESCRIPTION

Made sure that the node children all had access to the canvas so that they can properly react to Invalidate.

1. In `src/foam/graphics/TreeGraph.js`, moved the logic in init() to initCView() because no canvas property exists in init() after calling the super. By moving it to initCView(), the canvas property exists when creating the nodes and adding the children.

2.  In `src/foam/graphics/TreeGraph.js`, in the node creation block, changed `this.children.push(this.root)` to `this.add(this.root)` because aside from just adding the child to the children array,  the `this.add()` method also calls  `addChild_(c)`, which allows the setting of the canvas in the added child. In addition it calls `this.invalidate()` afterwards.