### PR TITLE
Temporarily disable performance monitoring

### DIFF
--- a/src/foam/nanos/pm/DAOPMLogger.java
+++ b/src/foam/nanos/pm/DAOPMLogger.java
@@ -32,6 +32,18 @@ public class DAOPMLogger
 
   @Override
   public void log(PM pm) {
+    /*
+     * Performance monitoring is disabled for now since it's causing significant
+     * memory usage. The underlying issue is that since we store everything in
+     * MDAOs, which are in-memory databases, eventually we run out of memory.
+     * pmDAO just happens to be one that gets put to relatively often, so the
+     * space it takes up is highly visible when profiling the application.
+     *
+     * This is only a temporary solution to the performance problems.
+     */
+    return;
+
+    /*
     if ( ! pm.getClassType().getId().equals("foam.dao.PMDAO") ) {
       if ( pm.getClassType().getId().indexOf("PM") != -1 ) return;
       if ( pm.getName().indexOf("PM")              != -1 ) return;
@@ -83,5 +95,6 @@ public class DAOPMLogger
         }
       }
     }
+    */
   }
 }


### PR DESCRIPTION
Disables performance monitoring for now since it's causing unbounded memory consumption.

The underlying issue is that since we store everything in `MDAO`s, which are in-memory databases, eventually we run out of memory. `pmDAO` is put to every minute by cron jobs, even if the server is sitting idle. This leads to more and more space in memory being consumed by `pmDAO` until the server eventually runs out of available memory, after which almost all CPU time is spent doing garbage collection to free up space, slowing the server down practically to a halt.

This is a temporary "solution" while we figure out how we're going to fix this problem properly.