### PR TITLE
Expose the old value and whether or not the old value was set in javaPostSet

### DIFF
--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -300,7 +300,8 @@ foam.CLASS({
       };
 
       // set value
-      setter += `Object oldVal = ${this.name}_;\n`;
+      setter += `boolean oldIsSet = ${this.name}IsSet_;\n`;
+      setter += `${this.javaType} oldVal = ${this.name}_;\n`;
       setter += `${this.name}_ = val;\n`;
       setter += `${this.name}IsSet_ = true;\n`;
 

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -300,6 +300,7 @@ foam.CLASS({
       };
 
       // set value
+      setter += `Object oldVal = ${this.name}_;\n`;
       setter += `${this.name}_ = val;\n`;
       setter += `${this.name}IsSet_ = true;\n`;
 


### PR DESCRIPTION
We need the old isSet because we don't have the distinction between undefined and null like we do in JS to know if the value was previously set or not.