### PR TITLE
Speed up authorization checks for superadmins

### DIFF
--- a/src/foam/nanos/auth/SystemAuthService.js
+++ b/src/foam/nanos/auth/SystemAuthService.js
@@ -13,7 +13,7 @@ foam.CLASS({
       name: 'check',
       javaCode: `
         foam.nanos.auth.User user = (foam.nanos.auth.User) x.get("user");
-        return ( user != null && user.getId() == 1 ) || getDelegate().check(x, permission);
+        return user != null && ( user.getId() == 1 || user.getGroup().equals("admin") || user.getGroup().equals("system") ) || getDelegate().check(x, permission);
       `
     }
   ]


### PR DESCRIPTION
Results in an 88.24% shorter mean duration and 93.75% shorter median
duration of calls to AuthService.check for users that meet the
conditions.

This AuthService decorator was working already, but there are other
users that could also be benefiting from the speed increase.