### PR TITLE
[CPF-1957] Add relationship check to table row count

### DIFF
--- a/src/foam/u2/DetailView.js
+++ b/src/foam/u2/DetailView.js
@@ -215,12 +215,26 @@ foam.CLASS({
                 hasTabs = true;
                 var label = p.label;
                 let tab = self.Tab.create({ label: label });
-                var dao = p.cls_ == foam.dao.ManyToManyRelationshipProperty
-                  ? p.get(self.data).getJunctionDAO()
-                  : p.get(self.data);
-                dao.select(expr.COUNT()).then(function(c) {
-                  tab.label = label + ' (' + c.value + ')';
-                });
+
+                var dao = p.get(self.data);
+
+                if (p.cls_ == foam.dao.ManyToManyRelationshipProperty) {
+                  var many2many = dao;
+                  dao = dao.getJunctionDAO();
+
+                  var matchCondition = foam.mlang.predicate.Eq.create();
+                  matchCondition.arg1 = many2many.sourceProperty;
+                  matchCondition.arg2 = many2many.sourceId;
+
+                  dao.where(matchCondition).select(expr.COUNT()).then(function(c) {
+                    tab.label = label + ' (' + c.value + ')';
+                  });
+                } else {
+                  dao.select(expr.COUNT()).then(function(c) {
+                    tab.label = label + ' (' + c.value + ')';
+                  });
+                }
+
                 p = p.clone();
                 p.label = '';
                 tab.start('table').tag(self.DetailPropertyView, { prop: p });

--- a/src/foam/u2/DetailView.js
+++ b/src/foam/u2/DetailView.js
@@ -220,20 +220,13 @@ foam.CLASS({
 
                 if (p.cls_ == foam.dao.ManyToManyRelationshipProperty) {
                   var many2many = dao;
-                  dao = dao.getJunctionDAO();
+                  dao = dao.getDAO();
 
-                  var matchCondition = foam.mlang.predicate.Eq.create();
-                  matchCondition.arg1 = many2many.sourceProperty;
-                  matchCondition.arg2 = many2many.sourceId;
-
-                  dao.where(matchCondition).select(expr.COUNT()).then(function(c) {
-                    tab.label = label + ' (' + c.value + ')';
-                  });
-                } else {
-                  dao.select(expr.COUNT()).then(function(c) {
-                    tab.label = label + ' (' + c.value + ')';
-                  });
                 }
+
+                dao.select(expr.COUNT()).then(function(c) {
+                  tab.label = label + ' (' + c.value + ')';
+                });
 
                 p = p.clone();
                 p.label = '';

--- a/src/foam/u2/DetailView.js
+++ b/src/foam/u2/DetailView.js
@@ -215,15 +215,9 @@ foam.CLASS({
                 hasTabs = true;
                 var label = p.label;
                 let tab = self.Tab.create({ label: label });
-
-                var dao = p.get(self.data);
-
-                if (p.cls_ == foam.dao.ManyToManyRelationshipProperty) {
-                  var many2many = dao;
-                  dao = dao.getDAO();
-
-                }
-
+                var dao = p.cls_ == foam.dao.ManyToManyRelationshipProperty
+                  ? p.get(self.data).getDAO()
+                  : p.get(self.data);
                 dao.select(expr.COUNT()).then(function(c) {
                   tab.label = label + ' (' + c.value + ')';
                 });


### PR DESCRIPTION
This commit fixes incorrect row counts on the table header of `foam.u2.DetailView` affecting properties that are many-to-many relationships.