### PR TITLE
Fix alignment of DAOControllerView cross-browser

### DIFF
--- a/src/foam/comics/DAOControllerView.js
+++ b/src/foam/comics/DAOControllerView.js
@@ -37,7 +37,11 @@ foam.CLASS({
 
   css: `
     ^ {
-      width: fit-content;
+      /* The following three lines are a cross-browser
+         equivalent to width: fit-content; in Chrome */
+      width: intrinsic;
+      width: -moz-max-content;
+      width: -webkit-max-content;
       margin: 24px auto 0 auto;
     }
 


### PR DESCRIPTION
Alignment of DAOControllerView was incorrect due to Firefox not recognizing the `fit-content` property. This PR ensures alignment is correct in Chrome, Firefox, and Safari.