### PR TITLE
DotF predicate

### DIFF
--- a/src/foam/mlang/MLang.java
+++ b/src/foam/mlang/MLang.java
@@ -214,4 +214,11 @@ public class MLang
       .setAuthorizer(authorizer)
       .build();
   }
+
+  public static Predicate DOT_F(Object o1, Object o2) {
+    return new DotF.Builder(null)
+      .setArg1(MLang.prepare(o1))
+      .setArg2(MLang.prepare(o2))
+      .build();
+  }
 }

--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -3154,7 +3154,7 @@ foam.CLASS({
   implements: [ 'foam.core.Serializable' ],
 
   documentation: `A binary predicate that evaluates arg1 as a predicate with
-    arg2 as its argument.',
+    arg2 as its argument.`,
 
   properties: [
     {

--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -3148,6 +3148,41 @@ foam.CLASS({
 
 
 foam.CLASS({
+  package: 'foam.mlang.predicate',
+  name: 'DotF',
+  extends: 'foam.mlang.predicate.AbstractPredicate',
+  implements: [ 'foam.core.Serializable' ],
+
+  documentation: `A binary predicate that evaluates arg1 as a predicate with
+    arg2 as its argument.',
+
+  properties: [
+    {
+      class: 'foam.mlang.ExprProperty',
+      name: 'arg1'
+    },
+    {
+      class: 'foam.mlang.ExprProperty',
+      name: 'arg2'
+    }
+  ],
+
+  methods: [
+    {
+      name: 'f',
+      javaCode: `
+        Object predicate = getArg1().f(obj);
+        if ( predicate instanceof Predicate ) {
+          return ((Predicate) predicate).f(getArg2().f(obj));
+        }
+        return false;
+      `
+    }
+  ]
+});
+
+
+foam.CLASS({
   package: 'foam.mlang',
   name: 'PredicatedExpr',
   extends: 'foam.mlang.AbstractExpr',

--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -3150,22 +3150,11 @@ foam.CLASS({
 foam.CLASS({
   package: 'foam.mlang.predicate',
   name: 'DotF',
-  extends: 'foam.mlang.predicate.AbstractPredicate',
+  extends: 'foam.mlang.predicate.Binary',
   implements: [ 'foam.core.Serializable' ],
 
   documentation: `A binary predicate that evaluates arg1 as a predicate with
     arg2 as its argument.`,
-
-  properties: [
-    {
-      class: 'foam.mlang.ExprProperty',
-      name: 'arg1'
-    },
-    {
-      class: 'foam.mlang.ExprProperty',
-      name: 'arg2'
-    }
-  ],
 
   methods: [
     {

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -49,6 +49,7 @@ var classes = [
   'foam.mlang.predicate.Keyword',
   'foam.mlang.predicate.IsInstanceOf',
   'foam.mlang.predicate.IsClassOf',
+  'foam.mlang.predicate.DotF',
   'foam.mlang.sink.Count',
   'foam.mlang.sink.GroupBy',
   'foam.mlang.F',


### PR DESCRIPTION
DotF predicate evaluates arg1 as a predicate with arg2 as its argument.

Suppose there is a rule with predicate: `EQ(User.ID, 1)`, the below query would evaluate the predicate against the given `user` object and check if the user id=1 then put the rule in the result.

    // the result should contain the rule
    ruleDAO.where(
      DOT_F(Rule.PREDICATE, user)
    )