### PR TITLE
Move DAOBrowserView sub-views into properties

### DIFF
--- a/src/foam/comics/v2/DAOBrowserView.js
+++ b/src/foam/comics/v2/DAOBrowserView.js
@@ -103,6 +103,24 @@ foam.CLASS({
       }
     },
     {
+      class: 'foam.u2.ViewSpec',
+      name: 'summaryView',
+      factory: function() {
+        return {
+          class: 'foam.u2.view.ScrollTableView'
+        };
+      }
+    },
+    {
+      class: 'foam.u2.ViewSpec',
+      name: 'cannedQueriesView',
+      factory: function() {
+        return {
+          class: 'foam.u2.view.TabChoiceView'
+        };
+      }
+    },
+    {
       class: 'foam.mlang.predicate.PredicateProperty',
       name: 'predicate',
       expression: function(config$cannedQueries) {
@@ -157,7 +175,7 @@ foam.CLASS({
                     .start(self.Cols)
                       .callIf(config$cannedQueries.length > 1, function() {
                         this
-                          .start(self.TabChoiceView, {
+                          .start(self.cannedQueriesView, {
                             choices: config$cannedQueries.map(o => [o.predicate, o.label]),
                             data$: self.predicate$
                           })
@@ -179,7 +197,7 @@ foam.CLASS({
                   .end()
                 .endContext()
               .end()
-              .start(self.ScrollTableView, {
+              .start(self.summaryView, {
                 data: self.predicatedDAO$proxy,
                 enableDynamicTableHeight: false,
                 columns: config$defaultColumns


### PR DESCRIPTION
This branch moves the hard-coded ScrollTableView and TabChoiceView from DAOBrowserView into properties to make DAOBrowserView more generic.

Later changes could eventually allow propagation of views specified in DAOMenu2 to these properties.