### PR TITLE
Handle nested properties in foam.Function.withArgs

### DIFF
--- a/src/foam/core/stdlib.js
+++ b/src/foam/core/stdlib.js
@@ -433,7 +433,8 @@ foam.LIB({
       var argNames = foam.Function.argNames(fn);
       var args = [];
       for ( var i = 0 ; i < argNames.length ; i++ ) {
-        var a = source[argNames[i]];
+        var a = argNames[i].indexOf('$') == -1 ? source[argNames[i]] :
+          source.slot(argNames[i]).get();
         if ( typeof a === 'function' ) a = a.bind(source);
         args.push(a);
       }

--- a/src/foam/core/stdlib.js
+++ b/src/foam/core/stdlib.js
@@ -427,13 +427,42 @@ foam.LIB({
      * Outputs:
      * Name is adam
      * Hello adam
+     * 
+     * This also supports nested properties for FObjects using the $ syntax.
+     * 
+     * Ex.
+     * foam.CLASS({
+     *   name: 'Foo',
+     *   properties: ['str']
+     * });
+     * foam.CLASS({
+     *   name: 'Bar',
+     *   properties: [
+     *     {
+     *       class: 'FObjectProperty',
+     *       of: 'Foo',
+     *       name: 'foo'
+     *     }
+     *   ]
+     * });
+     * 
+     * var bar = Bar.create({
+     *   foo: Foo.create({str: 'Hello!'})
+     * });
+     * foam.Function.withArgs(function(foo$str) {
+     *   console.log(foo$str);
+     * }, bar);
      *
+     * Outputs:
+     * Hello!
      **/
     function withArgs(fn, source, opt_self) {
       var argNames = foam.Function.argNames(fn);
       var args = [];
       for ( var i = 0 ; i < argNames.length ; i++ ) {
-        var a = argNames[i].indexOf('$') == -1 ? source[argNames[i]] :
+        var a = foam.core.FObject.isInstance(source) &&
+                argNames[i].indexOf('$') == -1 ?
+          source[argNames[i]] :
           source.slot(argNames[i]).get();
         if ( typeof a === 'function' ) a = a.bind(source);
         args.push(a);

--- a/src/foam/core/stdlib.js
+++ b/src/foam/core/stdlib.js
@@ -461,9 +461,9 @@ foam.LIB({
       var args = [];
       for ( var i = 0 ; i < argNames.length ; i++ ) {
         var a = foam.core.FObject.isInstance(source) &&
-                argNames[i].indexOf('$') == -1 ?
-          source[argNames[i]] :
-          source.slot(argNames[i]).get();
+                argNames[i].indexOf('$') != -1 ?
+          source.slot(argNames[i]).get() :
+          source[argNames[i]];
         if ( typeof a === 'function' ) a = a.bind(source);
         args.push(a);
       }


### PR DESCRIPTION
```
var fn = function(foo$bar) {
  console.log(foo$bar);
};
foam.Function.withArgs(fn, obj)
```
Should be the equivalent of calling `fn(obj.foo.bar);` and this PR handles doing that by using the FObject's slot method when a $ is found in the argname. FObject's slot method knows how to handle nested args.