### PR TITLE
Google maps address parser

### DIFF
--- a/src/foam/nanos/geocode/GoogleMapsAddressParser.js
+++ b/src/foam/nanos/geocode/GoogleMapsAddressParser.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2019 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 foam.CLASS({
   package: 'foam.nanos.geocode',
   name: 'GoogleMapsParser',
@@ -162,7 +168,7 @@ foam.CLASS({
           }
         }
 
-        if ( addressList == null ) addressRequest = address;
+        if ( addressList == null ) { addressRequest = address; }
         else {
           for ( String s : addressList ) {
             addressRequest += s;

--- a/src/foam/nanos/geocode/GoogleMapsAddressParser.js
+++ b/src/foam/nanos/geocode/GoogleMapsAddressParser.js
@@ -1,0 +1,258 @@
+foam.CLASS({
+  package: 'foam.nanos.geocode',
+  name: 'GoogleMapsAddressParser',
+
+  documentation: `
+    Responsible for converting an address string to the FOAM address data structure.
+    Returns a FOAM address taken from google maps best matching result.
+
+    Google maps autocomplete api has a hard time finding secondary units (Suite, Apt, Flr etc..).
+    Some addresses return a response or a list of predictions but it's a rare occurance.
+    We're handling this situation by parsing the address string to remove secondary units and their value,
+    making the call then appending the secondary unit under the suite property of a FOAM address object.
+  `,
+
+  javaImports: [
+    'foam.lib.json.JSONParser',
+    'foam.nanos.auth.Address',
+    'foam.nanos.geocode.GoogleMapsAddressComponent',
+    'foam.nanos.geocode.GoogleMapsGeocodeResponse',
+    'foam.nanos.geocode.GoogleMapsGeocodeResult',
+    'foam.nanos.geocode.GoogleMapsPlacesPredictions',
+    'foam.nanos.geocode.GoogleMapsPlacesResponse',
+    'foam.util.SafetyUtil',
+    'java.io.BufferedReader',
+    'java.io.InputStreamReader',
+    'java.net.HttpURLConnection',
+    'java.net.URL',
+    'java.util.Arrays',
+    'java.util.LinkedList',
+    'java.util.List',
+    'org.apache.commons.io.IOUtils'
+  ],
+
+  properties: [
+    {
+      class: 'String',
+      name: 'apiKey',
+      documentation: `
+        Google API Key.
+        API key owner: Patrick Zanowski
+      `
+    }
+  ],
+
+  constants: {
+    API_HOST_AUTOCOMPLETE: 'https://maps.googleapis.com/maps/api/place/autocomplete/json?input=',
+    API_HOST_PLACES: 'https://maps.googleapis.com/maps/api/geocode/json?place_id=',
+  },
+
+  methods: [
+    {
+      name: 'buildHttpRequest',
+      args: [
+        {
+          name: 'builder',
+          type: 'java.lang.StringBuilder'
+        }
+      ],
+      type: 'java.lang.StringBuilder',
+      javaCode: `
+      String line = null;
+      HttpURLConnection httpConnection = null;
+      BufferedReader reader = null;
+
+      try {
+        URL url = new URL(builder.toString().replace(" ", "+"));
+        httpConnection = (HttpURLConnection) url.openConnection();
+        httpConnection.setConnectTimeout(5 * 1000);
+        httpConnection.setRequestMethod("GET");
+        httpConnection.connect();
+
+        builder.setLength(0);
+        reader = new BufferedReader(new InputStreamReader(httpConnection.getInputStream()));
+        while ( (line = reader.readLine()) != null ) {
+          builder.append(line);
+        }
+
+        return builder;
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      } finally {
+        IOUtils.closeQuietly(reader);
+        IOUtils.close(httpConnection);
+      }
+      `
+    },
+    {
+      name: 'buildURLString',
+      args: [
+        {
+          class: 'String',
+          name: 'paramValue'
+        },
+        {
+          class: 'String',
+          name: 'mapsUri'
+        }
+      ],
+      type: 'java.lang.StringBuilder',
+      javaCode: `
+        StringBuilder sb = new StringBuilder();
+        StringBuilder builder = sb.append(mapsUri);
+        builder.append(paramValue).append("&key=").append(getApiKey());
+        
+        return builder;
+      `
+    },
+    {
+      name: 'parseAddress',
+      args: [
+        {
+          name: 'x',
+          type: 'Context'
+        },
+        {
+          name: 'address',
+          type: 'String'
+        },
+        {
+          name: 'foamAddress',
+          type: 'foam.nanos.auth.Address'
+        }
+      ],
+      type: 'foam.nanos.auth.Address',
+      javaCode: `
+        if ( foamAddress != null ) {
+          address = foamAddress.getAddress() + foamAddress.getCity() + foamAddress.getRegionId() + foamAddress.getCountryId();
+        }
+
+        String[] affix = { "apt", "unit", "suite", "#", "bsmt", "fl", "frnt", "key", "lowr", "dept", "lbby", "rm", "room", "ste", "dept", "space", "spc", "lot" };
+
+        if ( SafetyUtil.isEmpty(address) ) {
+          throw new RuntimeException("No address provided.");
+        }
+
+        if ( SafetyUtil.isEmpty(getApiKey()) ) {
+          throw new RuntimeException("No API Key was provided.");
+        }
+
+        // Remove the suite affix from address to find location using maps api.
+        String suite = null;
+        List<String> addressList = null;
+        String addressRequest = "";
+
+        // FIX ME: This string parser can probably be improved.
+        for ( String separator : affix ) {
+          String[] splitAddress = address.replace("#", "").split("(?<=" + separator + " [0-9]{0,9}+)|(?=" + separator + " [0-9]{0,9}+)");
+          if ( splitAddress.length > 1 ) {
+            int suiteIndex = splitAddress[0].length() <= splitAddress[1].length() ? 0 : 1;
+            suite = splitAddress[suiteIndex];
+            addressList = new LinkedList<>(Arrays.asList(splitAddress));
+            addressList.remove(addressList.get(suiteIndex));
+            break;
+          }
+        }
+
+        if ( addressList == null ) addressRequest = address;
+        else {
+          for ( String s : addressList ) {
+            addressRequest += s;
+          }
+        }
+
+        StringBuilder sb = buildURLString(addressRequest, (String) API_HOST_AUTOCOMPLETE);
+        StringBuilder builder = buildHttpRequest(sb);
+
+        GoogleMapsPlacesResponse response = (GoogleMapsPlacesResponse) getX().create(JSONParser.class)
+            .parseString(builder.toString(), GoogleMapsPlacesResponse.class);
+
+        if ( response == null ) {
+          throw new RuntimeException("Invalid response");
+        }
+        
+        if ( ! "OK".equals(response.getStatus()) ) {
+          throw new RuntimeException(! SafetyUtil.isEmpty(response.getError_message()) ? response.getError_message() : "Invalid response");
+        }
+
+        // Grab detailed information on predicted address using place_id.
+        GoogleMapsPlacesPredictions[] predictions = response.getPredictions();
+        String placeId = predictions[0].getPlace_id();
+
+        StringBuilder s = buildURLString(placeId, (String) API_HOST_PLACES);
+        StringBuilder placesBuilder = buildHttpRequest(s);
+
+        GoogleMapsGeocodeResponse result = (GoogleMapsGeocodeResponse) getX().create(JSONParser.class)
+        .parseString(placesBuilder.toString(), GoogleMapsGeocodeResponse.class);
+
+        if ( result == null ) {
+          throw new RuntimeException("Invalid response");
+        }
+        
+        if ( ! "OK".equals(result.getStatus()) ) {
+          throw new RuntimeException(! SafetyUtil.isEmpty(result.getError_message()) ? result.getError_message() : "Invalid response");
+        }
+
+        GoogleMapsGeocodeResult[] mapResults = result.getResults();
+        GoogleMapsAddressComponent[] addressComponents = mapResults[0].getAddress_components();
+        Address completeAddress = constructAddress(addressComponents, suite);
+
+        return completeAddress;
+      `
+    },
+    {
+      name: 'constructAddress',
+      args: [
+        {
+          name: 'addressComponents',
+          type: 'foam.nanos.geocode.GoogleMapsAddressComponent[]'
+        },
+        {
+          class: 'String',
+          name: 'suite'
+        }
+      ],
+      type: 'foam.nanos.auth.Address',
+      javaCode: `
+        Address newAddress = new Address();
+        newAddress.setStreetNumber(getAddressComponent("street_number", addressComponents, false));
+        newAddress.setStreetName((String) getAddressComponent("route", addressComponents, false));
+        newAddress.setCity((String) getAddressComponent("locality", addressComponents, false));
+        newAddress.setRegionId((String) getAddressComponent("administrative_area_level_1", addressComponents, true));
+        newAddress.setCountryId((String) getAddressComponent("country", addressComponents, true));
+        newAddress.setPostalCode((String) getAddressComponent("postal_code", addressComponents, false));
+        String formattedSuite = ! SafetyUtil.isEmpty(suite) ? suite.substring(0, 1).toUpperCase() + suite.substring(1)
+            .replaceAll("([^\\\\d-]?)(-?[\\\\d\\\\.]+)([^\\\\d]?)", "$1 $2 $3").replaceAll(" +", " ").trim() : null;
+        newAddress.setSuite(formattedSuite);
+        return newAddress;
+      `
+    },
+    {
+      name: 'getAddressComponent',
+      args: [
+        {
+          class: 'String',
+          name: 'type'
+        },
+        {
+          name: 'addressComponents',
+          type: 'foam.nanos.geocode.GoogleMapsAddressComponent[]'
+        },
+        {
+          class: 'Boolean',
+          name: 'shortName'
+        }
+      ],
+      type: 'String',
+      javaCode: `
+        for ( GoogleMapsAddressComponent addressComponent : addressComponents ) {
+          String[] addressType = addressComponent.getTypes();
+          if ( Arrays.asList(addressType).contains(type)) {
+            return shortName ? addressComponent.getShort_name() : addressComponent.getLong_name();
+          }
+        }
+        return null;
+      `
+    }
+  ]
+});

--- a/src/foam/nanos/geocode/GoogleMapsAddressParser.js
+++ b/src/foam/nanos/geocode/GoogleMapsAddressParser.js
@@ -24,10 +24,11 @@ foam.CLASS({
     'foam.lib.json.JSONParser',
     'foam.nanos.auth.Address',
     'foam.nanos.geocode.GoogleMapsAddressComponent',
+    'foam.nanos.geocode.GoogleMapsCredentials',
     'foam.nanos.geocode.GoogleMapsGeocodeResponse',
     'foam.nanos.geocode.GoogleMapsGeocodeResult',
     'foam.nanos.geocode.GoogleMapsPlacesPredictions',
-    'foam.nanos.geocode.auth.GoogleMapsPlacesResponse',
+    'foam.nanos.geocode.GoogleMapsPlacesResponse',
     'foam.util.SafetyUtil',
     'java.io.BufferedReader',
     'java.io.InputStreamReader',
@@ -37,16 +38,6 @@ foam.CLASS({
     'java.util.LinkedList',
     'java.util.List',
     'org.apache.commons.io.IOUtils'
-  ],
-
-  properties: [
-    {
-      class: 'String',
-      name: 'apiKey',
-      documentation: `
-        Google Maps API Key.
-      `
-    }
   ],
 
   constants: {
@@ -277,6 +268,19 @@ foam.CLASS({
           }
         }
         return null;
+      `
+    },
+    {
+      name: 'getApiKey',
+      type: 'String',
+      javaCode: `
+        GoogleMapsCredentials credentials = (GoogleMapsCredentials) getX().get("googleMapsCredentials");
+        if ( credentials == null || SafetyUtil.isEmpty(credentials.getApiKey()) ) {
+          Logger logger = (Logger) getX().get("logger");
+          logger.error(this.getClass().getSimpleName(), "invalid credentials");
+          throw new RuntimeException("Google maps invalid credentials");
+        }
+        return credentials.getApiKey();
       `
     }
   ]

--- a/src/foam/nanos/geocode/GoogleMapsAddressParser.js
+++ b/src/foam/nanos/geocode/GoogleMapsAddressParser.js
@@ -6,6 +6,8 @@ foam.CLASS({
     Responsible for converting an address string to the FOAM address data structure.
     Returns a FOAM address taken from google maps best matching result.
 
+    Providing a FOAM address will attempt to further populate the address object.
+
     Google maps autocomplete api has a hard time finding secondary units (Suite, Apt, Flr etc..).
     Some addresses return a response or a list of predictions but it's a rare occurance.
     We're handling this situation by parsing the address string to remove secondary units and their value,
@@ -36,8 +38,7 @@ foam.CLASS({
       class: 'String',
       name: 'apiKey',
       documentation: `
-        Google API Key.
-        API key owner: Patrick Zanowski
+        Google Maps API Key.
       `
     }
   ],
@@ -149,7 +150,7 @@ foam.CLASS({
         List<String> addressList = null;
         String addressRequest = "";
 
-        // FIX ME: This string parser can probably be improved.
+        // FIX ME: This string parser can probably be improved to include use cases where suite value has characters included.
         for ( String separator : affix ) {
           String[] splitAddress = address.replace("#", "").split("(?<=" + separator + " [0-9]{0,9}+)|(?=" + separator + " [0-9]{0,9}+)");
           if ( splitAddress.length > 1 ) {

--- a/src/foam/nanos/geocode/GoogleMapsCredentials.js
+++ b/src/foam/nanos/geocode/GoogleMapsCredentials.js
@@ -1,0 +1,13 @@
+foam.CLASS({
+  package: 'foam.nanos.geocode',
+  name: 'GoogleMapsCredientials',
+
+  axioms: [ foam.pattern.Singleton.create() ],
+
+  properties: [
+    {
+      class: 'String',
+      name: 'apiKey'
+    }
+  ]
+});

--- a/src/foam/nanos/geocode/GoogleMapsPlacesPredictions.js
+++ b/src/foam/nanos/geocode/GoogleMapsPlacesPredictions.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2019 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 foam.CLASS({
   package: 'foam.nanos.geocode',
   name: 'GoogleMapsPlacesPredictions',

--- a/src/foam/nanos/geocode/GoogleMapsPlacesPredictions.js
+++ b/src/foam/nanos/geocode/GoogleMapsPlacesPredictions.js
@@ -1,0 +1,19 @@
+foam.CLASS({
+  package: 'foam.nanos.geocode',
+  name: 'GoogleMapsPlacesPredictions',
+
+  documentation: 'Address string formulated by Google Places API.',
+
+  properties: [
+    {
+      class: 'String',
+      name: 'description',
+      documentation: 'Full address returned by Google Places API.'
+    },
+    {
+      class: 'String',
+      name: 'place_id',
+      documentation: 'Google maps place id used to lookup additional information of a location.'
+    }
+  ]
+});

--- a/src/foam/nanos/geocode/GoogleMapsPlacesResponse.js
+++ b/src/foam/nanos/geocode/GoogleMapsPlacesResponse.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2019 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 foam.CLASS({
   package: 'foam.nanos.geocode',
   name: 'GoogleMapsPlacesResponse',

--- a/src/foam/nanos/geocode/GoogleMapsPlacesResponse.js
+++ b/src/foam/nanos/geocode/GoogleMapsPlacesResponse.js
@@ -1,0 +1,25 @@
+foam.CLASS({
+  package: 'foam.nanos.geocode',
+  name: 'GoogleMapsPlacesResponse',
+
+  documentation: `Response model representing response from calling Google's Places API`,
+
+  properties: [
+    {
+      class: 'FObjectArray',
+      of: 'foam.nanos.geocode.GoogleMapsPlacesPredictions',
+      name: 'predictions',
+      documentation: 'Array of geocoded address information and geometry information'
+    },
+    {
+      class: 'String',
+      name: 'status',
+      documentation: 'Contains the status of the request'
+    },
+    {
+      class: 'String',
+      name: 'error_message',
+      documentation: 'Contains an error message'
+    }
+  ]
+});

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -218,6 +218,6 @@ FOAM_FILES([
   { name: "foam/nanos/crunch/RemoveJunctionsOnUserRemoval" },
   //authservice
   { name: "foam/nanos/auth/CapabilityAuthService" },
-
+  { name: "foam/nanos/geocode/GoogleMapsCredentials" },
 
 ]);

--- a/src/services
+++ b/src/services
@@ -317,3 +317,13 @@ p({
     }
   """
 })
+p({
+  "class":"foam.nanos.boot.NSpec",
+  "name":"addressParser",
+  "lazy":false,
+  "serve":false,
+  "service":{
+    "class":foam.nanos.geocode.GoogleMapsAddressParser",
+    "apiKey":"AIzaSyBHdOZNO5sXIkBdalrHYfH2pMA1087Omh8"
+  }
+})

--- a/src/services
+++ b/src/services
@@ -324,6 +324,14 @@ p({
   "serve":false,
   "service":{
     "class":foam.nanos.geocode.GoogleMapsAddressParser",
-    "apiKey":"AIzaSyBHdOZNO5sXIkBdalrHYfH2pMA1087Omh8"
+  }
+})
+p({
+  "class":"foam.nanos.boot.NSpec",
+  "name":"googleMapsCredentials",
+  "lazy":false,
+  "serve":false,
+  "service":{
+    "class": "foam.nanos.geocode.GoogleMapsCredentials"
   }
 })

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -334,6 +334,9 @@ var classes = [
   'foam.nanos.geocode.GoogleMapsGeocodeResult',
   'foam.nanos.geocode.GoogleMapsGeometry',
   'foam.nanos.geocode.GoogleMapsBoundary',
+  'foam.nanos.geocode.GoogleMapsAddressParser',
+  'foam.nanos.geocode.GoogleMapsPlacesPredictions',
+  'foam.nanos.geocode.GoogleMapsPlacesResponse',
 
   'foam.nanos.demo.DemoObject',
   'foam.nanos.demo.relationship.Student',

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -337,6 +337,7 @@ var classes = [
   'foam.nanos.geocode.GoogleMapsAddressParser',
   'foam.nanos.geocode.GoogleMapsPlacesPredictions',
   'foam.nanos.geocode.GoogleMapsPlacesResponse',
+  'foam.nanos.geocode.GoogleMapsCredentials',
 
   'foam.nanos.demo.DemoObject',
   'foam.nanos.demo.relationship.Student',


### PR DESCRIPTION
## Google maps address parser

Responsible for converting an address string to the FOAM address data structure. Returns a FOAM address constructed from google maps best matching result. Providing a FOAM address will attempt to further populate the address object.

Google maps autocomplete api has a hard time finding secondary units (Suite, Apt, Flr etc..). Some addresses return a response or a list of predictions but it's a rare occurance. We're handling this situation by parsing the address string to remove secondary units and their value, making the call then appending the secondary unit under the suite property of a FOAM address object.