### PR TITLE
dateview bug

### DIFF
--- a/src/foam/core/types.js
+++ b/src/foam/core/types.js
@@ -98,6 +98,14 @@ foam.CLASS({
       value: function (_, d) {
         if ( typeof d === 'number' ) return new Date(d);
         if ( typeof d === 'string' ) {
+          
+          // TODO: Currently some DateViews are allowing users to enter 6-digit years 
+          // which needs to be fixed via setAttribute('max', '9999-12-31') on DateViews
+          // However, there are already existing journal entries that contain Dates
+          // with 6-digit years and they are not showing up in tables because the invalid
+          // date error below is being thrown. 
+          // This is a temporary fix to migrate journal entries with bad dates to use proper date format
+          if ( d.indexOf('-') > 4 ) d = '9999' + d.substring(d.indexOf('-'));
           var ret = new Date(d);
 
           if ( isNaN(ret.getTime()) ) throw 'Invalid Date: ' + d;

--- a/src/foam/core/types.js
+++ b/src/foam/core/types.js
@@ -98,14 +98,20 @@ foam.CLASS({
       value: function (_, d) {
         if ( typeof d === 'number' ) return new Date(d);
         if ( typeof d === 'string' ) {
-          
-          // TODO: Currently some DateViews are allowing users to enter 6-digit years 
-          // which needs to be fixed via setAttribute('max', '9999-12-31') on DateViews
-          // However, there are already existing journal entries that contain Dates
-          // with 6-digit years and they are not showing up in tables because the invalid
-          // date error below is being thrown. 
-          // This is a temporary fix to migrate journal entries with bad dates to use proper date format
-          if ( d.indexOf('-') > 4 ) d = '9999' + d.substring(d.indexOf('-'));
+
+          // Currently we are allowing users to input >4-digit years 
+          // in our DateViews, but the ISO string is not formatted correctly
+          // A valid ISO string for >4-digit year must be padded to 6 digits
+          // in the year field and prepended by '+'
+          // this fixes the problem of the invalid string causing error to be
+          // thrown below.
+          year = d.substring(0, d.indexOf('-'));
+          if ( year.length > 4 ) {
+            year.padStart(6, '0');
+            year = '+' + year;
+          }
+          d = year + d.substring(d.indexOf('-'));
+
           var ret = new Date(d);
 
           if ( isNaN(ret.getTime()) ) throw 'Invalid Date: ' + d;

--- a/src/foam/nanos/auth/HtmlDoc.js
+++ b/src/foam/nanos/auth/HtmlDoc.js
@@ -30,9 +30,6 @@ foam.CLASS({
       class: 'Date',
       name: 'issuedDate',
       label: 'Effective Date',
-      tableCellFormatter: function(date) {
-        this.add(date ? date.toISOString().substring(0, 10) : '');
-      }
     },
     {
       class: 'String',

--- a/src/foam/u2/DateView.js
+++ b/src/foam/u2/DateView.js
@@ -49,7 +49,11 @@ foam.CLASS({
     function initE() {
       this.SUPER();
       this.setAttribute('type', 'date');
-      this.setAttribute('max', '9999-12-31');
+      // this.setAttribute('max', '9999-12-31'); 
+      // Possible cause of Invalid Date Exceptions 
+      // for old journal entries before this was added to the DateView
+      // commenting out until the old journal entries can be migrated to 
+      // 4-digit years or there is a better solution
       this.setAttribute('placeholder', 'yyyy/mm/dd');
       this.on('blur', this.onBlur);
     },

--- a/src/foam/u2/DateView.js
+++ b/src/foam/u2/DateView.js
@@ -49,11 +49,7 @@ foam.CLASS({
     function initE() {
       this.SUPER();
       this.setAttribute('type', 'date');
-      // this.setAttribute('max', '9999-12-31'); 
-      // Possible cause of Invalid Date Exceptions 
-      // for old journal entries before this was added to the DateView
-      // commenting out until the old journal entries can be migrated to 
-      // 4-digit years or there is a better solution
+      this.setAttribute('max', '9999-12-31'); 
       this.setAttribute('placeholder', 'yyyy/mm/dd');
       this.on('blur', this.onBlur);
     },

--- a/src/foam/u2/view/TableCellFormatter.js
+++ b/src/foam/u2/view/TableCellFormatter.js
@@ -194,8 +194,11 @@ foam.CLASS({
       class: 'foam.u2.view.TableCellFormatter',
       name: 'tableCellFormatter',
       value: function(date) {
-        // allow the browser to deal with this since we are technically using the user's preference
-        if ( date ) this.add(date.toLocaleDateString());
+        if ( date ) {
+          date = ((date.toISOString()).split('T')[0]).replace(/^\+/, '').replace(/^0+/, '');
+          date = date.split('-');
+          this.add(date[0] + '-' + date[1] + '-' + date[2]).style({ 'align' : 'right'});
+        }
       }
     }
   ]
@@ -212,8 +215,11 @@ foam.CLASS({
       class: 'foam.u2.view.TableCellFormatter',
       name: 'tableCellFormatter',
       value: function(date) {
-        // allow the browser to deal with this since we are technically using the user's preference
-        if ( date ) this.add(date.toLocaleString());
+        if ( date ) {
+          date = ((date.toISOString()).split('T')[0]).replace(/^\+/, '').replace(/^0+/, '');
+          date = date.split('-');
+          this.add(date[0] + '-' + date[1] + '-' + date[2]).style({ 'align' : 'right'});
+        }
       }
     }
   ]

--- a/src/foam/u2/view/TableCellFormatter.js
+++ b/src/foam/u2/view/TableCellFormatter.js
@@ -197,7 +197,7 @@ foam.CLASS({
         if ( date ) {
           date = ((date.toISOString()).split('T')[0]).replace(/^\+/, '').replace(/^0+/, '');
           date = date.split('-');
-          this.add(date[0] + '-' + date[1] + '-' + date[2]).style({ 'align' : 'right'});
+          this.add(date[0] + '-' + date[1] + '-' + date[2]);
         }
       }
     }
@@ -218,7 +218,7 @@ foam.CLASS({
         if ( date ) {
           date = ((date.toISOString()).split('T')[0]).replace(/^\+/, '').replace(/^0+/, '');
           date = date.split('-');
-          this.add(date[0] + '-' + date[1] + '-' + date[2]).style({ 'align' : 'right'});
+          this.add(date[0] + '-' + date[1] + '-' + date[2]);
         }
       }
     }


### PR DESCRIPTION
remove custom tableCellFormatters that were taking the first 10 chars of isoString and use the generic tableCellFormatter for Date and DateTime that supports up to 6-digit years 
in this pr
https://github.com/nanoPayinc/NANOPAY/pull/7767