### PR TITLE
fix server/client timeZone differentiation

### DIFF
--- a/src/foam/u2/DateView.js
+++ b/src/foam/u2/DateView.js
@@ -63,12 +63,12 @@ foam.CLASS({
     },
 
     function inputToData(input) {
-      return new Date(input);
+      return new Date(input+' (UTC)');
     },
 
     function dataToInput(data) {
       if ( ! data ) return data;
-
+    
       // Using our own formatter to keep the date in the format (yyyy-mm-dd) while maintaining the locale date
       const year = data.getUTCFullYear();
       const month = (data.getUTCMonth() + 1).toString().padStart(2, '0');


### PR DESCRIPTION
Yikes after a lot of investigating and hating of js dates, it turns out this is all that was needed for correct saving of date with client/server timezone differences.

The issue was the string input was the correct date but the 'new Date(input)' was being saved in the local timeZone - causing the date to be saved incorrectly.

specifying UTC on saving the new Date object - then stores the correct date.

FYI: To illustrate my frustration, the image below displays console cmds I inputted within seconds, while on a breakpoint.

![image](https://user-images.githubusercontent.com/10802216/63589548-736fd600-c577-11e9-965e-723cdf4c5e3a.png)

why are the first 2 dates different by hours??
