### PR TITLE
Deduplicate a potentially expensive expression & improve docs

### DIFF
--- a/src/foam/dao/index/TreeLookupFindPlan.java
+++ b/src/foam/dao/index/TreeLookupFindPlan.java
@@ -20,16 +20,20 @@ public class TreeLookupFindPlan implements FindPlan {
   }
 
   /**
-   * The cost will claculate by the node size
+   * The cost is calculated based on the size of the tree.
    */
   public long cost() {
     return ((Double) Math.log(Long.valueOf(size_).doubleValue())).longValue();
   }
 
   public FObject find(Object state, Object key) {
-    if ( state != null && state instanceof TreeNode ) {
-      // Sometimes the object is not exist, it will return a null value.
-      return ( (TreeNode) state ).get(( (TreeNode) state ), key, prop_) == null ? null : (FObject) ( (TreeNode) state ).get(( (TreeNode) state ), key, prop_).value;
+    if ( state instanceof TreeNode ) {
+      TreeNode stateNode = (TreeNode) state;
+      TreeNode valueNode = stateNode.get(stateNode, key, prop_);
+
+      // If the object being searched for isn't in the tree, then valueNode will
+      // be null.
+      return valueNode == null ? null : (FObject) valueNode.value;
     }
 
     return null;

--- a/src/foam/dao/index/ValuePlan.java
+++ b/src/foam/dao/index/ValuePlan.java
@@ -24,6 +24,6 @@ public class ValuePlan implements FindPlan, SelectPlan {
   }
 
   public void select(Object state, Sink sink, long skip, long limit, Comparator order, Predicate predicate) {
-      sink.put(state, null);
+    sink.put(state, null);
   }
 }


### PR DESCRIPTION
The expression `( (TreeNode) state ).get(( (TreeNode) state ), key, prop_)` was duplicated in the code, so if the compiler doesn't perform common subexpression substitution, then that expression would be needlessly evaluated twice.