### PR TITLE
Fix ExprProperty adaptValue

### DIFF
--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -205,7 +205,7 @@ foam.CLASS({
       if ( o.class && this.__context__.lookup(o.class, true) ) {
         return this.adaptValue(this.__context__.lookup(o.class).create(o, this));
       }
-      if ( typeof o.id === 'string' && foam.isRegistered(o.id) ) {
+      if ( foam.core.FObject.isSubClass(o) ) {
         return foam.mlang.Constant.create({ value: o });
       }
 

--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -205,6 +205,9 @@ foam.CLASS({
       if ( o.class && this.__context__.lookup(o.class, true) ) {
         return this.adaptValue(this.__context__.lookup(o.class).create(o, this));
       }
+      if ( typeof o.id === 'string' && foam.isRegistered(o.id) ) {
+        return foam.mlang.Constant.create({ value: o });
+      }
 
       console.error('Invalid expression value: ', o);
     }


### PR DESCRIPTION
Allow adapting foam model class to expression property to support `EQ(Thing.OF, OtherThing)` where OtherThing is a model class.

Credit to: @TW80000.