### PR TITLE
#comment fix spelling of 'class' and add unAuthorizedTargetDAO to foa…

### DIFF
--- a/src/foam/core/types.js
+++ b/src/foam/core/types.js
@@ -614,6 +614,13 @@ foam.CLASS({
       }
     },
     {
+      class: 'String',
+      name: 'unauthorizedTargetDAOKey',
+      documentation: `
+        Can be provided to use unauthorized local DAOs when the context user is the SYSTEM USER.
+      `
+    },
+    {
       name: 'adapt',
       value: function(oldValue, newValue, prop) {
         return prop.of.isInstance(newValue) ?

--- a/src/foam/dao/Relationship.js
+++ b/src/foam/dao/Relationship.js
@@ -103,7 +103,7 @@ foam.CLASS({
       }
     },
     {
-      name: 'String',
+      class: 'String',
       name: 'unauthorizedTargetDAOKey',
     },
     {


### PR DESCRIPTION
…m.core.Reference to fix unknownProperty warning