### PR TITLE
DO_NOT_MERGE: Fix SafetyUtil.compare

### DIFF
--- a/src/foam/util/SafetyUtil.java
+++ b/src/foam/util/SafetyUtil.java
@@ -18,6 +18,20 @@ public class SafetyUtil {
     if ( o2 == null ) return  1;
     if ( o1 == null ) return -1;
 
+    // Number subtypes (Long, Integer, etc.) are type-specific comparable and
+    // can only be compareTo the same type eg., Long can only compareTo Long.
+    //
+    // Converting o1 and o2 to double then comparing allows FOAM property types
+    // that are java.lang.Number compatible such as Long, Int, Short, Byte,
+    // Float and Double to be able to compareTo one another.
+    //
+    // Ex. The generated `isDefaultValue` of a Long property compares its value
+    // to 0, which is an integer.
+    //
+    // This also allows predicates such as EQ, GT, LT and friends comparison
+    // without explicit casting.
+    //
+    // Ex. EQ(User.ID, 1L) is the same as EQ(User.ID, 1).
     if ( o1 instanceof Number && o2 instanceof Number ) {
       double d1 = ((Number) o1).doubleValue();
       double d2 = ((Number) o2).doubleValue();

--- a/src/foam/util/SafetyUtil.java
+++ b/src/foam/util/SafetyUtil.java
@@ -27,6 +27,10 @@ public class SafetyUtil {
       if ( d1  < d2 ) return -1;
     }
 
+    if ( ! (o1 instanceof Comparable && o2 instanceof Comparable) ) return 0;
+    if ( ! (o2 instanceof Comparable) ) return 1;
+    if ( ! (o1 instanceof Comparable) ) return -1;
+
     return ((Comparable) o1).compareTo(o2);
   }
 


### PR DESCRIPTION
Some properties on a model might not be always Comparable e.g., Rule.action.

Add non-Comparable checks in SafetyUtil.compare to account for comparing these might-be-non-Comparable properties.