### PR TITLE
Another FloatParser fix

### DIFF
--- a/src/foam/lib/json/FloatParser.java
+++ b/src/foam/lib/json/FloatParser.java
@@ -37,9 +37,14 @@ public class FloatParser implements Parser {
           n.append(c);
       } else if ( c == '.' ) { // TODO: localization
         if ( decimalFound ) return null;
+
+        // Java throws a NumberFormatException if exponent is before decimal.
+        // Exponent with no decimal is acceptable.
+        if ( exponentFound ) return null;
+
         decimalFound = true;
         n.append(c);
-      } else if ( c == 'E' ) {
+      } else if ( c == 'E' || c == 'e' ) {
         if ( exponentFound ) return null;
         exponentFound = true;
         n.append(c);


### PR DESCRIPTION
- Handle exponent appearing before decimal.
- Handle 'e' in addition to 'E'