### PR TITLE
[CPF-2781] Add MenuDefinedViewList

### DIFF
--- a/src/foam/nanos/menu/MenuDefinedViewList.js
+++ b/src/foam/nanos/menu/MenuDefinedViewList.js
@@ -1,0 +1,35 @@
+foam.CLASS({
+  package: 'foam.nanos.menu',
+  name: 'MenuDefinedViewList',
+  extends: 'foam.u2.View',
+
+  properties: [
+    {
+      name: 'containerView',
+      class: 'foam.u2.ViewSpec'
+    },
+    {
+      name: 'childViews',
+      class: 'FObjectArray',
+      of: 'foam.u2.View'
+    }
+  ],
+
+  methods: [
+    function initE() {
+      var self = this;
+      var view = this;
+
+      view = view
+        .start(self.containerView);
+      
+      for ( var i = 0; i < self.childViews.length; i++ ) {
+        view = view
+          .start(self.childViews[i]).end();
+      }
+
+      view = view
+        .end();
+    }
+  ]
+});


### PR DESCRIPTION
This allows separation of views that are often used together in a simple layout (i.e. rows or columns) without creating additional views to combine them.

For example, in a Capability info page there's a back button at the top, but it may be desirable to display just the capability info by itself. To navigate to the capability info view with a back button the views can be combined as follows:
```
self.stack.push({
  class: 'foam.nanos.menu.MenuDefinedViewList',
  containerView: 'foam.u2.layout.Rows',
  childViews: [
    {
      class: 'foam.nanos.crunch.ui.CapabilityPageMenu'
    },
    {
      class: 'foam.nanos.crunch.ui.CapabilityInfoView'
    }
  ]
});
```

This is added to the foam.nanos.menu since it may be useful elsewhere, including inside a menuDAO entry.