### PR TITLE
Add Duration property type and use in Script and Session

### DIFF
--- a/src/foam/core/types.js
+++ b/src/foam/core/types.js
@@ -249,6 +249,25 @@ foam.CLASS({
 
 foam.CLASS({
   package: 'foam.core',
+  name: 'Duration',
+  extends: 'Long',
+
+  documentation: `
+    A length of time in milliseconds. Further refined in TableCellFormatter.js
+    to make values human-readable when displayed in tables.
+  `,
+
+  properties: [
+    {
+      name: 'units',
+      value: 'ms'
+    }
+  ]
+});
+
+
+foam.CLASS({
+  package: 'foam.core',
   name: 'Object',
   extends: 'Property',
   documentation: '',

--- a/src/foam/nanos/script/Script.js
+++ b/src/foam/nanos/script/Script.js
@@ -87,27 +87,10 @@ foam.CLASS({
       tableWidth: 140
     },
     {
-      class: 'Long',
+      class: 'Duration',
       name: 'lastDuration',
       documentation: 'Date and time the script took to complete.',
       visibility: 'RO',
-      units: 'ms',
-      tableCellFormatter: function(value) {
-        var hours = Math.floor(value / 3600000);
-        var minutes = Math.floor(value / 60000);
-        var seconds = Math.floor(value / 1000);
-        var milliseconds = value % 1000;
-
-        if ( hours ) {
-          this.add(`${hours}h ${minutes}m ${seconds}s ${milliseconds}ms`);
-        } else if ( minutes ) {
-          this.add(`${minutes}m ${seconds}s ${milliseconds}ms`);
-        } else if ( seconds ) {
-          this.add(`${seconds}s ${milliseconds}ms`);
-        } else {
-          this.add(`${milliseconds}ms`);
-        }
-      },
       tableWidth: 125
     },
     /*

--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -58,8 +58,9 @@ foam.CLASS({
       storageTransient: true
     },
     {
-      class: 'Long',
+      class: 'Duration',
       name: 'ttl',
+      label: 'TTL',
       documentation: 'The "time to live" of the session. The amount of time in milliseconds that the session should be kept alive after its last use before being destroyed. A value of 0 or less signifies that the session should never be destroyed unless the user explicitly logs out.',
       value: 28800000 // 1000 * 60 * 60 * 8 = number of milliseconds in 8 hours
     },

--- a/src/foam/u2/view/TableCellFormatter.js
+++ b/src/foam/u2/view/TableCellFormatter.js
@@ -218,3 +218,32 @@ foam.CLASS({
     }
   ]
 });
+
+
+foam.CLASS({
+  package: 'foam.u2.view',
+  name: 'DurationTableCellFormatterRefinement',
+  refines: 'foam.core.Duration',
+
+  properties: [
+    {
+      class: 'foam.u2.view.TableCellFormatter',
+      name: 'tableCellFormatter',
+      value: function(value) {
+        var hours = Math.floor(value / 3600000);
+        value -= hours * 3600000;
+        var minutes = Math.floor(value / 60000);
+        value -= minutes * 60000;
+        var seconds = Math.floor(value / 1000);
+        value -= seconds * 1000;
+        var milliseconds = value % 1000;
+
+        var formatted = [[hours, 'h'], [minutes, 'm'], [seconds, 's'], [milliseconds, 'ms']].reduce((acc, cur) => {
+          return cur[0] > 0 ? acc.concat([cur[0] + cur[1]]) : acc;
+        }, []).join(' ');
+
+        this.add(formatted || '0ms');
+      }
+    }
+  ]
+});


### PR DESCRIPTION
The `Duration` property extends `Long` and is used when you want to store a value in milliseconds that represents an amount of elapsed time. A `tableCellFormatter` is included for the new property that displays the value in a human-readable format. For example, it will display '8h' instead of '28800000'. It also omits units for which the value is empty, so it will display '8h 1ms' instead of '28800001' or '8h 0m 0s 1ms'.

Fixed a bug in the `tableCellFormatter` function for `Script.lastDuration` that wasn't subtracting from the value when splitting the duration up into components.