### PR TITLE
[CPF-2828] Add nanos.js and support.js to LiveScriptBundler watchers

### DIFF
--- a/src/foam/nanos/http/LiveScriptBundler.java
+++ b/src/foam/nanos/http/LiveScriptBundler.java
@@ -128,7 +128,11 @@ public class LiveScriptBundler implements WebAgent, ContextAware
 
           // Find any file named files.js
           String filename = path.getFileName().toString();
-          if ( filename.equals("files.js") ) {
+          if (
+            filename.equals("files.js") ||
+            filename.equals("nanos.js") ||
+            filename.equals("support.js")
+          ) {
             // Locate the closest `src` folder if one exists
             for ( int i = path.getNameCount()-1; i >= 0; i-- ) {
               String dirname = path.getName(i).getFileName().toString();


### PR DESCRIPTION
This PR fixes a problem where changing files defined in `nanos.js` and `support.js` (like `ProfilePictureView`) does not re-build Javascript via LiveScriptBundler until the next time a file specified in a `files.js` is modified.