### PR TITLE
[CPF-2831] Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ nano.log*
 /cronjobs
 .vscode/
 android/nanos_example_client/.settings/
+android/nanos_example_client/src/main/gen/
 logs/logs
 src/cronjobs
 src/notifications


### PR DESCRIPTION
The build.gradle inside `android/nanos_example_client` is causing IltelliJ to create this folder, which somebody could commit to the repo by accident.