### PR TITLE
[CPF-2694] Remove URL sessionId from ProfilePictureView and DigFileUploadView

### DIFF
--- a/src/foam/nanos/auth/ProfilePictureView.js
+++ b/src/foam/nanos/auth/ProfilePictureView.js
@@ -144,7 +144,6 @@ foam.CLASS({
               src: this.ProfilePictureImage$.map(function(ProfilePictureImage) {
                 if ( ProfilePictureImage && ProfilePictureImage.data ) {
                   var blob = ProfilePictureImage.data;
-                  var sessionId = localStorage['defaultSession'];
                   if ( self.BlobBlob.isInstance(blob) )
                     return URL.createObjectURL(blob.blob);
 

--- a/src/foam/nanos/auth/ProfilePictureView.js
+++ b/src/foam/nanos/auth/ProfilePictureView.js
@@ -149,9 +149,6 @@ foam.CLASS({
                     return URL.createObjectURL(blob.blob);
 
                   var url = '/service/httpFileService/' + ProfilePictureImage.id;
-                  // attach session id if available
-                  if ( sessionId )
-                    url += '?sessionId=' + sessionId;
                   return url;
                 }
 

--- a/src/foam/nanos/dig/DigFileUploadView.js
+++ b/src/foam/nanos/dig/DigFileUploadView.js
@@ -140,7 +140,6 @@ foam.CLASS({
                       href: this.data$.map(function(data) {
                         if ( data ) {
                           var blob = data.data;
-                          var sessionId = localStorage['defaultSession'];
 
                           if ( self.BlobBlob.isInstance(blob) ) {
                             return URL.createObjectURL(blob.blob);

--- a/src/foam/nanos/dig/DigFileUploadView.js
+++ b/src/foam/nanos/dig/DigFileUploadView.js
@@ -146,11 +146,8 @@ foam.CLASS({
                             return URL.createObjectURL(blob.blob);
                           } else {
                             var url = '/service/httpFileService/' + data.id;
-                            // attach session id if available
-                            if ( sessionId )
-                              url += '?sessionId=' + sessionId;
+                            return url;
                           }
-                          return url;
                         }
                       }),
                       target: '_self'


### PR DESCRIPTION
These views can pass a sessionId in a querystring to `/service/httpFileService`. This service uses SessionWebAgent which now gives the sessionId cookie precedence (#2578). 
