### PR TITLE
Improve session cookie security

### DIFF
--- a/src/foam/nanos/http/AuthWebAgent.java
+++ b/src/foam/nanos/http/AuthWebAgent.java
@@ -67,18 +67,7 @@ public class AuthWebAgent
     // the app is configured that way.
     AppConfig appConfig = (AppConfig) x.get("appConfig");
     sessionCookie.setSecure(appConfig.getForceHttps());
-
-    int ttlInSeconds = session.getTtl() < 0
-      // Session should last forever. Since cookies don't support lasting
-      // forever, the best we can do is set a max age that's significantly
-      // long-lasting. Here we use the greatest possible representable integer,
-      // which is equivalent to just over 68 years.
-      ? Integer.MAX_VALUE
-
-      // If the time to live is zero or positive, then convert to seconds,
-      // rounding up to the nearest second.
-      : (int) Math.ceil(session.getTtl() / 1000.0);
-
+    int ttlInSeconds = (int) Math.ceil(session.getTtl() / 1000.0);
     sessionCookie.setMaxAge(ttlInSeconds);
     resp.addCookie(sessionCookie);
   }

--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -73,8 +73,17 @@ foam.CLASS({
       class: 'Duration',
       name: 'ttl',
       label: 'TTL',
-      documentation: 'The "time to live" of the session. The amount of time in milliseconds that the session should be kept alive after its last use before being destroyed. A value of less than zero signifies that the session should never be destroyed unless the user explicitly logs out.',
-      value: 28800000 // 1000 * 60 * 60 * 8 = number of milliseconds in 8 hours
+      documentation: 'The "time to live" of the session. The amount of time in milliseconds that the session should be kept alive after its last use before being destroyed. Must be a positive value or zero.',
+      value: 28800000, // 1000 * 60 * 60 * 8 = number of milliseconds in 8 hours
+      validationPredicates: [
+        {
+          args: ['ttl'],
+          predicateFactory: function(e) {
+            return e.GTE(foam.nanos.session.Session.TTL, 0);
+          },
+          errorString: 'TTL must be 0 or greater.'
+        }
+      ]
     },
     {
       class: 'Long',

--- a/src/foam/nanos/session/cron/ExpireSessionsCron.java
+++ b/src/foam/nanos/session/cron/ExpireSessionsCron.java
@@ -25,7 +25,7 @@ public class ExpireSessionsCron implements ContextAgent {
     List<Session> expiredSessions = ((ArraySink) localSessionDAO.where(GT(Session.TTL, 0)).select(new ArraySink())).getArray();
 
     for ( Session session : expiredSessions ) {
-      if ( session.getLastUsed() != null && session.getLastUsed().getTime() + session.getTtl() <= (new Date()).getTime() ) {
+      if ( session.getLastUsed() != null && session.getLastUsed().getTime() + Math.max(session.getTtl(), 0L) <= (new Date()).getTime() ) {
         logger.debug("Destroyed expired session : " + (String) session.getId());
         localSessionDAO.remove(session);
       }

--- a/src/foam/nanos/session/cron/ExpireSessionsCron.java
+++ b/src/foam/nanos/session/cron/ExpireSessionsCron.java
@@ -37,7 +37,7 @@ public class ExpireSessionsCron implements ContextAgent {
         session.setLastUsed(now);
       }
 
-      if ( session.getLastUsed().getTime() + Math.max(session.getTtl(), 0L) <= now.getTime() ) {
+      if ( session.getLastUsed().getTime() + session.getTtl() <= now.getTime() ) {
         logger.debug("Destroyed expired session : " + (String) session.getId());
         localSessionDAO.remove(session);
       }

--- a/src/services
+++ b/src/services
@@ -257,6 +257,7 @@ p({
       .setJournalName("sessions")
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
       .setAuthorize(false)
+      .setDecorator(new foam.dao.ValidatingDAO(x, null))
       .build();
   """
 })


### PR DESCRIPTION
## Changes

* Set `Secure` flag on session cookie when app is configured to use HTTPS only
* Set `HttpOnly` flag on session cookie to prevent access to it via client-side scripts
* Set `MaxAge` flag on session cookie based on TTL of the session
* Removed the ability to mark a session's TTL as infinite
* Added an `ignoreRemoteHostChanges` flag to `Session`
* Fixed a bug where sessions weren't being deleted after a server restart under certain conditions
  * Behaviour specified by @jlhughes here: https://github.com/foam-framework/foam2/pull/2542#issuecomment-525576239