### PR TITLE
Handled apiColumns

### DIFF
--- a/src/foam/nanos/dig/DIG.js
+++ b/src/foam/nanos/dig/DIG.js
@@ -54,6 +54,19 @@ foam.CLASS({
     'cmd',
     'format',
     {
+      class: 'StringArray',
+      name: 'fields',
+      factory: null,
+      expression: function(daoKey) {
+         var dao = this.__context__[daoKey];
+         var apiColumns;
+
+         if ( dao ) apiColumns = dao.of.getAxiomByName('apiColumns');
+
+         return apiColumns ? apiColumns.columns : ( dao ? dao.of.getAxiomsByClass(foam.core.Property).map(p => p.name) : [] );
+      }
+    },
+    {
       class: 'String',
       name: 'dao',
       hidden: true,

--- a/src/foam/u2/Element.js
+++ b/src/foam/u2/Element.js
@@ -2648,6 +2648,18 @@ foam.CLASS({
   ]
 });
 
+foam.CLASS({
+  package: 'foam.u2',
+  name: 'ApiColumns',
+
+  documentation: 'Axiom for storing certain Columns information for Api in Class. Unlike most Axioms, doesn\'t modify the Class, but is just used to store information.',
+
+  properties: [
+    [ 'name', 'apiColumns' ],
+    'columns'
+  ]
+});
+
 
 foam.CLASS({
   package: 'foam.u2',
@@ -2689,6 +2701,12 @@ foam.CLASS({
       name: 'searchColumns',
       postSet: function(_, cs) {
         this.axioms_.push(foam.u2.SearchColumns.create({columns: cs}));
+      }
+    },
+    {
+      name: 'apiColumns',
+      postSet: function(_, cs) {
+        this.axioms_.push(foam.u2.ApiColumns.create({columns: cs}));
       }
     }
   ]


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/CPF-2243

Just as we have tableColumns in a model, we also need digColumns in a model.

The digColumns would specify the default columns which would be returned from a find, create, or update of an entity. If extra columns were requested in a find call, then they would be returned as long as the user had permissions to access those fields.