### PR TITLE
Session update authorization fix

### DIFF
--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -199,10 +199,12 @@ foam.CLASS({
     {
       name: 'authorizeOnUpdate',
       javaCode: `
-        AuthService auth = (AuthService) x.get("auth");
+        AuthService auth       = (AuthService) x.get("auth");
+        Session     oldSession = (Session) oldObj;
 
         if (
           ! checkOwnership(x) &&
+          ! oldSession.checkOwnership(x) &&
           ! auth.check(x, createPermission("update"))
         ) {
           throw new AuthorizationException("You don't have permission to update sessions other than your own.");

--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -186,29 +186,53 @@ foam.CLASS({
     {
       name: 'authorizeOnCreate',
       javaCode: `
-      AuthService auth = (AuthService) x.get("auth");
-      if ( ! checkOwnership(x) && ! auth.check(x, createPermission("create")) ) throw new AuthorizationException("You don't have permission to create this session.");
+        AuthService auth = (AuthService) x.get("auth");
+
+        if (
+          ! checkOwnership(x) &&
+          ! auth.check(x, createPermission("create"))
+        ) {
+          throw new AuthorizationException("You don't have permission to create sessions other than your own.");
+        }
       `
     },
     {
       name: 'authorizeOnUpdate',
       javaCode: `
-      AuthService auth = (AuthService) x.get("auth");
-      if ( ! checkOwnership(x) && ! auth.check(x, createPermission("update")) ) throw new AuthorizationException("You don't have permission to update sessions other than your own.");
+        AuthService auth = (AuthService) x.get("auth");
+
+        if (
+          ! checkOwnership(x) &&
+          ! auth.check(x, createPermission("update"))
+        ) {
+          throw new AuthorizationException("You don't have permission to update sessions other than your own.");
+        }
       `
     },
     {
       name: 'authorizeOnDelete',
       javaCode: `
-      AuthService auth = (AuthService) x.get("auth");
-      if ( ! checkOwnership(x) && ! auth.check(x, "*") ) throw new AuthorizationException("You don't have permission to delete sessions other than your own.");
+        AuthService auth = (AuthService) x.get("auth");
+
+        if (
+          ! checkOwnership(x) &&
+          ! auth.check(x, "*")
+        ) {
+          throw new AuthorizationException("You don't have permission to delete sessions other than your own.");
+        }
       `
     },
     {
       name: 'authorizeOnRead',
       javaCode: `
-      AuthService auth = (AuthService) x.get("auth");
-      if ( ! checkOwnership(x) && ! auth.check(x, createPermission("read")) ) throw new AuthorizationException("You don't have permission to view sessions other than your own.");
+        AuthService auth = (AuthService) x.get("auth");
+
+        if (
+          ! checkOwnership(x) &&
+          ! auth.check(x, createPermission("read"))
+        ) {
+          throw new AuthorizationException("You don't have permission to view sessions other than your own.");
+        }
       `
     },
     {

--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -190,6 +190,13 @@ foam.CLASS({
 
         if (
           ! checkOwnership(x) &&
+
+          // TODO: This permission scheme doesn't make sense for create. We're
+          // not going to assign permissions like
+          // 'session.create.0b2ac741-010e-4af9-bc43-dd86c88bbe6a' to people. It
+          // would make more sense to allow certain users or groups to create
+          // sessions for other users in a limited scope. For example, within
+          // the same spid.
           ! auth.check(x, createPermission("create"))
         ) {
           throw new AuthorizationException("You don't have permission to create sessions other than your own.");


### PR DESCRIPTION
Fixes a session update security vulnerability. Since we weren't checking the userId on the old session, people would have been able to update someone else's session and set themselves as the user for that session.