### PR TITLE
Set User and Group Id to visibility FINAL

### DIFF
--- a/src/foam/nanos/auth/Group.js
+++ b/src/foam/nanos/auth/Group.js
@@ -25,7 +25,8 @@ foam.CLASS({
     {
       class: 'String',
       name: 'id',
-      documentation: 'Unique name of the Group.'
+      documentation: 'Unique name of the Group.',
+      visibility: 'FINAL',
     },
     {
       class: 'Boolean',

--- a/src/foam/nanos/auth/User.js
+++ b/src/foam/nanos/auth/User.js
@@ -84,7 +84,7 @@ foam.CLASS({
       class: 'Long',
       name: 'id',
       documentation: 'The ID for the User.',
-      final: true,
+      visibility: 'FINAL',
       tableWidth: 50
     },
     {


### PR DESCRIPTION
User and Group ID should not change after creation.  
Changing the User or Group ID acts as Copy operation - which on second thought isn't a bad thing. 