### PR TITLE
Do a lookup rather than foam.json.parse for InnerClass model adapts

### DIFF
--- a/src/foam/core/InnerClass.js
+++ b/src/foam/core/InnerClass.js
@@ -65,7 +65,7 @@ foam.CLASS({
       return foam.core.Model.isInstance(m) ? m :
           foam.core.EnumModel.isInstance(m) ? m :
           foam.core.InnerClass.isInstance(m) ? this.modelAdapt_(m.model) :
-          m.class ? this.modelAdapt_(foam.json.parse(m)) :
+          m.class ? foam.lookup(m.class).create(m) :
           foam.core.Model.create(m);
     },
 


### PR DESCRIPTION
This fixes an issue when running from a built js file. The builder adds `class` to every object it outputs which triggers this codepath and has side effects like turning viewspecs into actual instances.