### PR TITLE
[CPF-2854] Make foam.core.JSON more robust for missing classes

### DIFF
--- a/src/foam/core/JSON.js
+++ b/src/foam/core/JSON.js
@@ -727,12 +727,15 @@ foam.LIB({
 
           if ( cls ) {
             var c = typeof cls === 'string' ? ( opt_ctx || foam ).lookup(cls) : cls;
-            // TODO(markdittmer): Turn into static method: "parseJSON" once
-            // https://github.com/foam-framework/foam2/issues/613 is fixed.
             if ( c === undefined ) {
-              console.warn("In foam.core.JSON.parse(Object): json.class or opt_class undefined! Returning empty object.");
+              console.warn(
+                "In foam.core.JSON.parse(Object): class lookup result undefined! Returning empty object." +
+                " (" + cls + ")"
+              );
               return {};
             }
+            // TODO(markdittmer): Turn into static method: "parseJSON" once
+            // https://github.com/foam-framework/foam2/issues/613 is fixed.
             if ( c.PARSE_JSON ) return c.PARSE_JSON(json, opt_class, opt_ctx);
 
             for ( var key in json ) {

--- a/src/foam/core/JSON.js
+++ b/src/foam/core/JSON.js
@@ -729,6 +729,10 @@ foam.LIB({
             var c = typeof cls === 'string' ? ( opt_ctx || foam ).lookup(cls) : cls;
             // TODO(markdittmer): Turn into static method: "parseJSON" once
             // https://github.com/foam-framework/foam2/issues/613 is fixed.
+            if ( c === undefined ) {
+              console.warn("In foam.core.JSON.parse(Object): json.class or opt_class undefined! Returning empty object.");
+              return {};
+            }
             if ( c.PARSE_JSON ) return c.PARSE_JSON(json, opt_class, opt_ctx);
 
             for ( var key in json ) {

--- a/src/foam/core/JSON.js
+++ b/src/foam/core/JSON.js
@@ -729,10 +729,9 @@ foam.LIB({
             var c = typeof cls === 'string' ? ( opt_ctx || foam ).lookup(cls) : cls;
             if ( c === undefined ) {
               console.warn(
-                "In foam.core.JSON.parse(Object): class lookup result undefined! Returning empty object." +
-                " (" + cls + ")"
+                "In foam.core.JSON.parse(Object): JSON parser tried to deserialize class '"
+                  + cls + "' and failed. Is this class available to the client?"
               );
-              return {};
             }
             // TODO(markdittmer): Turn into static method: "parseJSON" once
             // https://github.com/foam-framework/foam2/issues/613 is fixed.


### PR DESCRIPTION
This PR adds a check in case `( opt_ctx || foam ).lookup(cls)` reports an undefined value, making foam more robust in the case that such an error occurs.