### PR TITLE
Session logic consolidation

### DIFF
--- a/src/foam/box/SessionServerBox.java
+++ b/src/foam/box/SessionServerBox.java
@@ -9,20 +9,26 @@ package foam.box;
 import foam.core.X;
 import foam.dao.DAO;
 import foam.nanos.app.AppConfig;
-import foam.nanos.auth.AuthService;
-import foam.nanos.auth.*;
 import foam.nanos.auth.AuthenticationException;
 import foam.nanos.auth.AuthorizationException;
+import foam.nanos.auth.Group;
+import foam.nanos.boot.Boot;
 import foam.nanos.boot.NSpec;
-import foam.nanos.logger.*;
-import foam.nanos.logger.PrefixLogger;
+import foam.nanos.logger.Logger;
 import foam.nanos.session.Session;
 import foam.util.SafetyUtil;
-import java.util.Date;
-import javax.naming.NoPermissionException;
-import javax.servlet.http.HttpServletRequest;
 import org.eclipse.jetty.server.Request;
 
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * This Box decorator adds session support to boxes.
+ *
+ * Its core purpose is to create a new context using parts of the context it was
+ * created with and parts of a user's session context to pass on to its delegate
+ * box. This class also enforces authorization and authentication controls for
+ * the NSpec in the context.
+ */
 public class SessionServerBox
   extends ProxyBox
 {
@@ -46,27 +52,14 @@ public class SessionServerBox
 
     try {
       HttpServletRequest req        = getX().get(HttpServletRequest.class);
-      AuthService        auth       = (AuthService) getX().get("auth");
-      DAO                sessionDAO = (DAO)         getX().get("localSessionDAO");
+      DAO                sessionDAO = (DAO) getX().get("localSessionDAO");
       Session            session    = sessionID == null ? null : (Session) sessionDAO.find(sessionID);
 
       if ( session == null ) {
-        session = new Session();
+        session = new Session((X) getX().get(Boot.ROOT));
         session.setId(sessionID == null ? "anonymous" : sessionID);
-        session.setRemoteHost(req.getRemoteHost());
+        if ( req != null ) session.setRemoteHost(req.getRemoteHost());
 
-        // Set the user to null to avoid the system user from leaking into
-        // newly created sessions. If we don't do this, then a user has admin
-        // privileges before they log in, which is obviously a big security
-        // issue.
-        // We also need to null out the AuthService cache, otherwise the system
-        // context's cache will be reused across every session.
-        X sessionContext = getX()
-          .put("user", null)
-          .put("group", null)
-          .put(CachingAuthService.CACHE_KEY, null)
-          .put(Session.class, session);
-        session.setContext(sessionContext);
         if ( sessionID != null ) {
           session = (Session) sessionDAO.put(session);
         }
@@ -90,17 +83,6 @@ public class SessionServerBox
         }
       }
 
-      User user = (User) session.getContext().get("user");
-      X    x    = session.getContext()
-        .put(
-          "logger",
-          new PrefixLogger(
-              new Object[] { user == null ? "" : user.getId() + " - " + user.label(), "[Service]", spec.getName() },
-              (Logger) session.getContext().get("logger")))
-        .put(HttpServletRequest.class, req);
-
-      session.touch();
-
       // If this service has been configured to require authentication, then
       // throw an error if there's no user in the context.
       if ( authenticate_ && session.getUserId() == 0 ) {
@@ -108,11 +90,13 @@ public class SessionServerBox
         return;
       }
 
-      // If there is no user in the session (which happens when a user is
-      // signing up, for example) then set the URL in the app configuration to
-      // the URL that the request is coming from.
+      X effectiveContext = session.applyTo(getX());
+
+      session.touch();
+
+      // TODO: Shouldn't this go somewhere else?
       if ( req != null && ! SafetyUtil.isEmpty(req.getRequestURI()) ) {
-        AppConfig appConfig = (AppConfig) x.get("appConfig");
+        AppConfig appConfig = (AppConfig) effectiveContext.get("appConfig");
         appConfig = (AppConfig) appConfig.fclone();
         String configUrl = ((Request) req).getRootURL().toString();
 
@@ -127,33 +111,19 @@ public class SessionServerBox
         }
 
         appConfig.setUrl(configUrl);
-        x = x.put("appConfig", appConfig);
-        session.getContext().put("appConfig", appConfig);
+        effectiveContext = effectiveContext.put("appConfig", appConfig);
       }
 
-      if ( user != null ) {
-        Group group = (Group) x.get("group");
-
-        try {
-          spec.checkAuthorization(session.getContext());
-        } catch (AuthorizationException e) {
-          logger.warning("Missing permission", group != null ? group.getId() : "NO GROUP" , "service." + spec.getName());
-          msg.replyWithException(e);
-          return;
-        }
-
-        // padding this because if group is null this can cause an NPE
-        // technically the user shouldn't be created without a group
-        if ( group == null ) {
-          logger.warning(String.format("The context with id = %s does not have the group set in the context.", session.getId()));
-        } else {
-          AppConfig appConfig = group.getAppConfig(x);
-          x = x.put("appConfig", appConfig);
-          session.getContext().put("appConfig", appConfig);
-        }
+      try {
+        spec.checkAuthorization(effectiveContext);
+      } catch (AuthorizationException e) {
+        Group group = (Group) effectiveContext.get("group");
+        logger.warning("Missing permission", group != null ? group.getId() : "NO GROUP" , "service." + spec.getName());
+        msg.replyWithException(e);
+        return;
       }
 
-      msg.getLocalAttributes().put("x", x);
+      msg.getLocalAttributes().put("x", effectiveContext);
     } catch (Throwable t) {
       logger.error("Error throw in SessionServerBox: " + t, " ,service: " + spec.getName());
       t.printStackTrace();

--- a/src/foam/nanos/auth/AgentUserAuthService.java
+++ b/src/foam/nanos/auth/AgentUserAuthService.java
@@ -61,18 +61,6 @@ public class AgentUserAuthService
       return null;
     }
 
-    /*
-      Finds the UserUserJunction object to see if user can act as the passed in user.
-      Source (agent) users are permitted to act as target (entity) users, not vice versa.
-    */
-    UserUserJunction permissionJunction = (UserUserJunction) agentJunctionDAO_.find(AND(
-      EQ(UserUserJunction.SOURCE_ID, agent.getId()),
-      EQ(UserUserJunction.TARGET_ID, user.getId())
-    ));
-
-    // Junction object contains a group which has a unique set of permissions specific to the relationship.
-    Group actingWithinGroup = (Group) groupDAO_.find(permissionJunction.getGroup());
-
     // Clone and freeze both user and agent.
     user = (User) user.fclone();
     user.freeze();
@@ -84,9 +72,8 @@ public class AgentUserAuthService
     Session session = x.get(Session.class);
     session.setUserId(user.getId());
     session.setAgentId(agent.getId());
-    session.setContext(session.getContext().put("user", user));
-    session.setContext(session.getContext().put("agent", agent));
-    session.setContext(session.getContext().put("group", actingWithinGroup));
+    session = (Session) sessionDAO_.put(session);
+    session.setContext(session.applyTo(session.getContext()));
     return user;
   }
 

--- a/src/foam/nanos/auth/CachingAuthService.java
+++ b/src/foam/nanos/auth/CachingAuthService.java
@@ -31,7 +31,7 @@ class SessionContextCacheFactory
   }
 
   public Object create(X x) {
-    Session session = (Session) x.get(Session.class);
+    Session session = x.get(Session.class);
     if ( session == null ) return null;
     if ( sessionX_ == null ) sessionX_ = session.getContext();
     if ( sessionX_ != session.getContext() ) return null;

--- a/src/foam/nanos/auth/UserAndGroupAuthService.js
+++ b/src/foam/nanos/auth/UserAndGroupAuthService.js
@@ -160,8 +160,8 @@ foam.CLASS({
 
         Session session = x.get(Session.class);
         session.setUserId(user.getId());
-        session.setContext(session.getContext().put("user", user).put("group", group));
         ((DAO) getLocalSessionDAO()).put(session);
+        session.setContext(session.applyTo(session.getContext()));
 
         return user;
       `

--- a/src/foam/nanos/auth/UserAndGroupAuthService.js
+++ b/src/foam/nanos/auth/UserAndGroupAuthService.js
@@ -161,6 +161,7 @@ foam.CLASS({
         Session session = x.get(Session.class);
         session.setUserId(user.getId());
         session.setContext(session.getContext().put("user", user).put("group", group));
+        ((DAO) getLocalSessionDAO()).put(session);
 
         return user;
       `

--- a/src/foam/nanos/auth/UserAndGroupAuthService.js
+++ b/src/foam/nanos/auth/UserAndGroupAuthService.js
@@ -391,7 +391,7 @@ foam.CLASS({
         if ( user != null ) {
           if ( agent != null ) {
             DAO agentJunctionDAO = (DAO) x.get("agentJunctionDAO");
-            UserUserJunction junction = (UserUserJunction) agentJunctionDAO.inX(x).find(
+            UserUserJunction junction = (UserUserJunction) agentJunctionDAO.find(
               AND(
                 EQ(UserUserJunction.SOURCE_ID, agent.getId()),
                 EQ(UserUserJunction.TARGET_ID, user.getId())
@@ -407,7 +407,7 @@ foam.CLASS({
 
           // Third highest precedence: If a user is logged in but not acting as
           // another user, return their group.
-          return user.findGroup(x);
+          return (Group) ((DAO) getLocalGroupDAO()).inX(x).find(user.getGroup());
         }
 
         // If none of the cases above match, return null.

--- a/src/foam/nanos/http/AuthWebAgent.java
+++ b/src/foam/nanos/http/AuthWebAgent.java
@@ -276,6 +276,7 @@ public class AuthWebAgent
     HttpServletRequest req     = x.get(HttpServletRequest.class);
     Session            session = new Session((X) x.get(Boot.ROOT));
     session.setRemoteHost(req.getRemoteHost());
+    session.setContext(session.applyTo(x));
     return session;
   }
 

--- a/src/foam/nanos/http/NanoRouter.java
+++ b/src/foam/nanos/http/NanoRouter.java
@@ -18,6 +18,7 @@ import foam.nanos.NanoService;
 import foam.nanos.boot.NSpec;
 import foam.nanos.boot.NSpecAware;
 import foam.nanos.logger.Logger;
+import foam.nanos.logger.PrefixLogger;
 import foam.nanos.pm.PM;
 import foam.nanos.pm.PMWebAgent;
 
@@ -105,6 +106,7 @@ public class NanoRouter
               }
             }
           })
+          .put("logger", new PrefixLogger(new Object[] { "[Service]", spec.getName() }, (Logger) getX().get("logger")))
           .put(NSpec.class, spec);
         serv.execute(requestContext);
       }

--- a/src/foam/nanos/http/NanoRouter.java
+++ b/src/foam/nanos/http/NanoRouter.java
@@ -92,20 +92,21 @@ public class NanoRouter
         System.err.println("No service found for: " + serviceKey);
         resp.sendError(resp.SC_NOT_FOUND, "No service found for: "+serviceKey);
       } else {
-        X y = getX().put(HttpServletRequest.class, req)
-            .put(HttpServletResponse.class, resp)
-            .putFactory(PrintWriter.class, new XFactory() {
-              @Override
-              public Object create(X x) {
-                try {
-                  return resp.getWriter();
-                } catch (IOException e) {
-                  return null;
-                }
+        X requestContext = getX()
+          .put(HttpServletRequest.class, req)
+          .put(HttpServletResponse.class, resp)
+          .putFactory(PrintWriter.class, new XFactory() {
+            @Override
+            public Object create(X x) {
+              try {
+                return resp.getWriter();
+              } catch (IOException e) {
+                return null;
               }
-            })
-            .put(NSpec.class, spec);
-        serv.execute(y);
+            }
+          })
+          .put(NSpec.class, spec);
+        serv.execute(requestContext);
       }
     } catch (Throwable t) {
       System.err.println("Error serving " + serviceKey + " " + path);

--- a/src/services
+++ b/src/services
@@ -172,7 +172,6 @@ p({
   "class":"foam.nanos.boot.NSpec",
   "name":"userDAO",
   "serve":true,
-  "authenticate": false, 
   "serviceScript":"""
     return new foam.dao.EasyDAO.Builder(x)
       .setPm(true)


### PR DESCRIPTION
* Adds an `applyTo` method to `Session` that serves as a central way of appropriately updating a context based on a session. A number of places throughout the repository are updated to call this method to update the session context instead of doing so manually to ensure consistent behaviour across the board. This method also allows us to move some of the logic out of `SessionServerBox` and into the method, making `SessionServerBox` simpler.
* Updates the logger for sessions so that it shows both the agent and the user when a user is acting as another user. This will make things easier to audit.
* Sets `authenticate: true` on the `userDAO` service.
* Saves sessions when user id is set so it will persist across server restarts.