### PR TITLE
[CPF-2909] Use java code for addressParser service

### DIFF
--- a/src/services
+++ b/src/services
@@ -587,9 +587,9 @@ p({
   "name":"addressParser",
   "lazy":false,
   "serve":false,
-  "service":{
-    "class":"foam.nanos.geocode.GoogleMapsAddressParser",
-  }
+  "serviceScript": """
+    new foam.nanos.geocode.GoogleMapsAddressParser.Builder().build();
+  """,
 })
 p({
   "class":"foam.nanos.boot.NSpec",

--- a/src/services
+++ b/src/services
@@ -588,7 +588,7 @@ p({
   "lazy":false,
   "serve":false,
   "serviceScript": """
-    new foam.nanos.geocode.GoogleMapsAddressParser.Builder().build();
+    return new foam.nanos.geocode.GoogleMapsAddressParser.Builder(x).build();
   """,
 })
 p({


### PR DESCRIPTION
@zahnno should review this first because I don't know where to test the service.

This PR fixes CPF-2909 and CPF-2854.

As an interesting side-note, this bug brought to light inconsistencies between the old development build and the foam-bin.js build. In this particular case, foam-bin.js build would try to load an object from a Context.__cache__ (using `lookup()`) before it has been registered, causing an error; the old development build also tried to do this but using a different caller (unsure which) that did not try to use the undefined object that was reported by lookup.