### PR TITLE
[CPF-2929] Add sourceURL to foam-bin.js output

### DIFF
--- a/src/foam.js
+++ b/src/foam.js
@@ -20,6 +20,11 @@
   var isWorker = typeof importScripts !== 'undefined';
   var isServer = ( ! isWorker ) && typeof window === 'undefined';
 
+  // Imports used by the loadServer() loader
+  if ( isServer && typeof global !== 'undefined' ) {
+    global.imports = {}; global.imports.path = require('path');
+  }
+
   var flags    = this.FOAM_FLAGS = this.FOAM_FLAGS || {};
   flags.web    = ! isServer,
   flags.node   = isServer;
@@ -61,6 +66,12 @@
     if ( typeof global !== 'undefined' && ! global.FOAM_ROOT ) global.FOAM_ROOT = path;
 
     return function (filename) {
+      if ( typeof global !== 'undefined' ) {
+        // Set document.currentScript.src, as expected by EndBoot.js
+        let normalPath = global.imports.path.relative(
+          '.', global.imports.path.normalize(path + filename + '.js'));
+        global.document = { currentScript: { src: normalPath } };
+      }
       require(path + filename + '.js');
     }
   }

--- a/src/foam/build/Builder.js
+++ b/src/foam/build/Builder.js
@@ -464,7 +464,7 @@ console.log("Done.");
             if ( typeof s.source !== 'undefined' ) {
               dataTmp += `\n//# sourceURL=/`+s.source;
             }
-            // NB: eval() is necessary for `//# sourceURL` to work
+            // eval() is necessary for `//# sourceURL` to work
             data += 'eval(' + JSON.stringify(dataTmp) + ');\n';
           },
           eof: function() { then(data); }

--- a/src/foam/build/Builder.js
+++ b/src/foam/build/Builder.js
@@ -458,8 +458,14 @@ console.log("Done.");
 
             if ( func == 'UNKNOWN' ) throw new Error("What's the right foam.FOO function for a " + s.cls_.id);
 
-
-            data += `foam.${func}(${serializer.stringify(filterAxiomsByFlags(s))});\n`;
+            // Print FOAM model definition
+            dataTmp = `foam.${func}(${serializer.stringify(filterAxiomsByFlags(s))});\n`
+            // Print sourceURL annotation for browser inpector
+            if ( typeof s.source !== 'undefined' ) {
+              dataTmp += `\n//# sourceURL=/`+s.source;
+            }
+            // NB: eval() is necessary for `//# sourceURL` to work
+            data += 'eval(' + JSON.stringify(dataTmp) + ');\n';
           },
           eof: function() { then(data); }
         });

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -123,6 +123,7 @@ FOAM_FILES([
   { name: "foam/nanos/test/TestBorder" },
   { name: "foam/nanos/cron/Cron" },
   { name: "foam/nanos/cron/test/IntervalScheduleTest" },
+  { name: "foam/nanos/cron/test/TimeOfDayScheduleTest" },
   { name: "foam/nanos/export/ExportDriverRegistry"},
   { name: "foam/nanos/export/ExportDriver" },
   { name: "foam/nanos/export/JSONDriver"},


### PR DESCRIPTION
Caveats:
- sourceURL requires code to be put in an eval() function. This adds escapes and makes the output source slightly larger, but as far as I can tell has not affected the performance of page loads or runtime.
- line numbers are inaccurate when javaCode and css are stripped out.
- full path does not display (but filename does) in Chrome if a file has more than one model. This is likely because the same sourceFile is specified multiple times and the contents of each model does not match the contents of the entire file.