### PR TITLE
Set default for invalid dates in javascript

### DIFF
--- a/src/foam/core/types.js
+++ b/src/foam/core/types.js
@@ -100,7 +100,9 @@ foam.CLASS({
         if ( typeof d === 'string' ) {
           var ret = new Date(d);
 
-          if ( isNaN(ret.getTime()) ) throw 'Invalid Date: ' + d;
+          if ( isNaN(ret.getTime()) ) {
+            ret = new Date(Number.MAX_SAFE_INTEGER || Number.MAX_VALUE);
+          }
 
           return ret;
         }

--- a/src/foam/core/types.js
+++ b/src/foam/core/types.js
@@ -101,7 +101,8 @@ foam.CLASS({
           var ret = new Date(d);
 
           if ( isNaN(ret.getTime()) ) {
-            ret = new Date(Number.MAX_SAFE_INTEGER || Number.MAX_VALUE);
+            ret = new Date((Number.MAX_SAFE_INTEGER || Number.MAX_VALUE) * 0.9);
+            console.warn("Invalid date: " + d + "; assuming "+ret.toISOString()+".");
           }
 
           return ret;


### PR DESCRIPTION
When an invalid date is provided for a Date property on the Javascript side, the current error handling throws an exception and breaks the UI. This PR changes the behaviour to set a default date of `258854-02-07T05:41:06.892Z` (close to the maximum Javascript can support, `MAX_SAFE_INTEGER * 0.9`). Depending on the browser's implementation this date may be different, but it should always be a date after 2038-01-19.