### PR TITLE
[CPF-2948] Add validation predicates to foam.core.Date

### DIFF
--- a/src/files2.js
+++ b/src/files2.js
@@ -552,5 +552,8 @@ FOAM_FILES([
   { name: "foam/build/ClassLoader" },
   { name: "foam/build/ClassLoaderImpl" },
   { name: "foam/build/PromisedClassLoader" },
-  { name: "foam/build/ClassLoaderContext" }
+  { name: "foam/build/ClassLoaderContext" },
+
+  { name: "foam/core/CoreTypesValidationTest" },
+  { name: "foam/core/CoreTypesValidationTestModel" }
 ]);

--- a/src/foam/core/CoreTypesValidationTest.js
+++ b/src/foam/core/CoreTypesValidationTest.js
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2019 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core',
+  name: 'CoreTypesValidationTestModel',
+  properties: [
+    { name: 'id', class: 'String' },
+    {
+      name: 'testDate', class: 'DateTime'
+    }
+  ]
+});
+
+foam.CLASS({
+  package: 'foam.core',
+  name: 'CoreTypesValidationTest',
+  extends: 'foam.nanos.test.Test',
+
+  javaImports: [
+    'foam.dao.DAO',
+    'foam.dao.MDAO',
+    'foam.dao.ValidatingDAO',
+    'java.util.Date'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+
+      javaCode: `
+      CoreTypesValidationTestModel testModel =
+        new CoreTypesValidationTestModel.Builder(getX())
+          .setTestDate(new Date(8640000000000001L))
+          .build();
+
+      boolean throwsIllegalState = false;
+      
+      DAO m = new MDAO(testModel.getClassInfo());
+      DAO v = new ValidatingDAO(getX(), m);
+      try {
+        v.put(testModel);
+      } catch (IllegalStateException e) {
+        throwsIllegalState = true;
+      } 
+
+      test(throwsIllegalState,
+        "Invalid date property should not pass ValidatingDAO"
+      );
+      `
+    }
+  ]
+});

--- a/src/foam/core/CoreTypesValidationTest.js
+++ b/src/foam/core/CoreTypesValidationTest.js
@@ -32,24 +32,68 @@ foam.CLASS({
       name: 'runTest',
 
       javaCode: `
-      CoreTypesValidationTestModel testModel =
+      CoreTypesValidationTestModel testModelInvalidHigh =
         new CoreTypesValidationTestModel.Builder(getX())
           .setTestDate(new Date(8640000000000001L))
+          .build();
+      CoreTypesValidationTestModel testModelValidHigh =
+        new CoreTypesValidationTestModel.Builder(getX())
+          .setTestDate(new Date(8640000000000000L))
+          .build();
+      CoreTypesValidationTestModel testModelInvalidLow =
+        new CoreTypesValidationTestModel.Builder(getX())
+          .setTestDate(new Date(-8640000000000001L))
+          .build();
+      CoreTypesValidationTestModel testModelValidLow =
+        new CoreTypesValidationTestModel.Builder(getX())
+          .setTestDate(new Date(-8640000000000000L))
           .build();
 
       boolean throwsIllegalState = false;
       
-      DAO m = new MDAO(testModel.getClassInfo());
+      DAO m = new MDAO(
+        CoreTypesValidationTestModel.getOwnClassInfo());
       DAO v = new ValidatingDAO(getX(), m);
+
       try {
-        v.put(testModel);
+        v.put(testModelInvalidHigh);
       } catch (IllegalStateException e) {
         throwsIllegalState = true;
-      } 
-
+      }
       test(throwsIllegalState,
-        "Invalid date property should not pass ValidatingDAO"
+        "Invalid date property (too high) should not pass ValidatingDAO"
       );
+      throwsIllegalState = false;
+
+      try {
+        v.put(testModelInvalidLow);
+      } catch (IllegalStateException e) {
+        throwsIllegalState = true;
+      }
+      test(throwsIllegalState,
+        "Invalid date property (too low) should not pass ValidatingDAO"
+      );
+      throwsIllegalState = false;
+
+      try {
+        v.put(testModelValidHigh);
+      } catch (IllegalStateException e) {
+        throwsIllegalState = true;
+      }
+      test(( ! throwsIllegalState ),
+        "Valid date property (upper bound) should pass ValidatingDAO"
+      );
+      throwsIllegalState = false;
+
+      try {
+        v.put(testModelValidLow);
+      } catch (IllegalStateException e) {
+        throwsIllegalState = true;
+      }
+      test(( ! throwsIllegalState ),
+        "Valid date property (lower bound) should pass ValidatingDAO"
+      );
+      throwsIllegalState = false;
       `
     }
   ]

--- a/src/foam/core/Validation.js
+++ b/src/foam/core/Validation.js
@@ -350,11 +350,19 @@ foam.CLASS({
           {
             args: [self.name],
             predicateFactory: function(e) {
-              return e.LTE(
-                self,
-                // Maximum date supported by FOAM
-                // (bounded by JavaScript's limit)
-                new Date(8640000000000000)
+              return e.AND(
+                e.LTE(
+                  self,
+                  // Maximum date supported by FOAM
+                  // (bounded by JavaScript's limit)
+                  new Date(8640000000000000)
+                ),
+                e.GTE(
+                  self,
+                  // Minimum date supported by FOAM
+                  // (bounded by JavaScript's limit)
+                  new Date(-8640000000000000)
+                )
               )
             },
             errorString: 'Invalid date value'

--- a/src/foam/core/Validation.js
+++ b/src/foam/core/Validation.js
@@ -334,3 +334,33 @@ foam.CLASS({
     }
   ]
 });
+
+foam.CLASS({
+  package: 'foam.core',
+  name: 'DatePropertyValidationRefinement',
+  refines: 'foam.core.Date',
+  properties: [
+    {
+      class: 'FObjectArray',
+      of: 'foam.core.ValidationPredicate',
+      name: 'validationPredicates',
+      factory: function() {
+        var self = this;
+        return [
+          {
+            args: [self.name],
+            predicateFactory: function(e) {
+              return e.LTE(
+                self,
+                // Maximum date supported by FOAM
+                // (bounded by JavaScript's limit)
+                new Date(8640000000000000)
+              )
+            },
+            errorString: 'Invalid date value'
+          }
+        ]
+      }
+    }
+  ]
+});

--- a/src/foam/core/tests.jrl
+++ b/src/foam/core/tests.jrl
@@ -1,1 +1,2 @@
 p({"class":"foam.core.FObjectTest","id":"FObject Test","description":"Test FObject features"})
+p({"class":"foam.core.CoreTypesValidationTest","id":"Core Types Validation Test"})

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -68,6 +68,10 @@ ${Object.keys(o).map(function(k) {
           o = o.replace(/\\/g, '\\\\')
           return `java.util.regex.Pattern.compile("${o}")`
         },
+        Date: function(d) {
+          var n = d.getTime();
+          return `new java.util.Date(` + n + (n > Math.pow(2, 31) ? 'L' : '') + `)`
+        }
       })
     },
     {

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -70,7 +70,8 @@ ${Object.keys(o).map(function(k) {
         },
         Date: function(d) {
           var n = d.getTime();
-          return `new java.util.Date(` + n + (n > Math.pow(2, 31) ? 'L' : '') + `)`
+          return `new java.util.Date(` + n +
+            (n > Math.pow(2, 31) || n < -Math.pow(2,31) ? 'L' : '') + `)`
         }
       })
     },

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -17,6 +17,8 @@ var classes = [
   'foam.core.AbstractFObject',
   'foam.core.Validatable',
   'foam.core.Agency',
+  'foam.core.CoreTypesValidationTest',
+  'foam.core.CoreTypesValidationTestModel',
   'foam.glang.EndOfTimeSpan',
   'foam.glang.EndOfDay',
   'foam.glang.EndOfWeek',


### PR DESCRIPTION
FOAM relies on the `Date` object in Javascript as the value for properties of type `foam.core.Date`. According to the EMCAScript spec and my own testing, Date supports a range from `-8640000000000000` to `+8640000000000000`. If an input value exceeds this range, an error will be thrown, causing the UI to break.

Currently it is possible to store dates into journals that cannot be handled by the Javascript Date object. This PR adds validation predicates to `foam.core.Date`, making Javascript's limitation the lower and upper bounds.

Addition: The timestamp literals above correspond to the date range of `-271821-04-20` to `+275760-09-13` with zeroed time values.