### PR TITLE
Change Rule.id to string and remove Rule.name

### DIFF
--- a/src/foam/nanos/ruler/Rule.js
+++ b/src/foam/nanos/ruler/Rule.js
@@ -21,7 +21,6 @@
 
   tableColumns: [
     'id',
-    'name',
     'ruleGroup',
     'enabled',
     'priority',
@@ -31,7 +30,6 @@
 
   searchColumns: [
     'id',
-    'name',
     'ruleGroup',
     'enabled',
     'priority',
@@ -54,17 +52,9 @@
 
   properties: [
     {
-      class: 'Long',
-      name: 'id',
-      documentation: 'Sequence number.',
-      visibility: 'RO',
-      tableWidth: 50
-    },
-    {
       class: 'String',
-      name: 'name',
-      section: 'basicInfo',
-      documentation: 'Rule name for human readability.',
+      name: 'id',
+      visibility: 'RO',
       tableWidth: 200
     },
     {
@@ -311,7 +301,7 @@
       name: 'javaExtras',
       buildJavaClass: function(cls) {
         cls.extras.push(`
-        public static Rule findById(Collection<Rule> listRule, Long passedId) {
+        public static Rule findById(Collection<Rule> listRule, String passedId) {
           return listRule.stream().filter(rule -> passedId.equals(rule.getId())).findFirst().orElse(null);
         }
         `);

--- a/src/foam/nanos/ruler/RuleEngine.java
+++ b/src/foam/nanos/ruler/RuleEngine.java
@@ -23,8 +23,8 @@ public class RuleEngine extends ContextAwareSupport {
   private DAO delegate_ = null;
   private DAO ruleHistoryDAO_ = null;
   private AtomicBoolean stops_ = new AtomicBoolean(false);
-  private Map<Long, Object> results_ = new HashMap<>();
-  private Map<Long, RuleHistory> savedRuleHistory_ = new HashMap<>();
+  private Map<String, Object> results_ = new HashMap<>();
+  private Map<String, RuleHistory> savedRuleHistory_ = new HashMap<>();
   private Rule currentRule_ = null;
   private X userX_;
 
@@ -138,7 +138,7 @@ public class RuleEngine extends ContextAwareSupport {
     results_.put(currentRule_.getId(), result);
   }
 
-  public Object getResult(long ruleId) {
+  public Object getResult(String ruleId) {
     return results_.get(ruleId);
   }
 

--- a/src/foam/nanos/ruler/test/RulerDAOTest.java
+++ b/src/foam/nanos/ruler/test/RulerDAOTest.java
@@ -91,8 +91,7 @@ public class RulerDAOTest extends Test {
 
     //the rule with the highest priority in "users:email filter" group and stops execution of the rest.
     rule7 = new Rule();
-    rule7.setId(7);
-    rule7.setName("userDAO email filter");
+    rule7.setId("rule7. userDAO email filter");
     rule7.setRuleGroup("users:email filter");
     rule7.setDaoKey("localUserDAO");
     rule7.setOperation(Operations.CREATE);
@@ -123,8 +122,7 @@ public class RulerDAOTest extends Test {
   public void createRule(X x) {
     // first rule stops execution of rules with a lower priority within the same group
     rule1 = new Rule();
-    rule1.setId(1);
-    rule1.setName("userDAO email filter");
+    rule1.setId("rule1. userDAO email filter");
     rule1.setRuleGroup("users:email filter");
     rule1.setDaoKey("localUserDAO");
     rule1.setOperation(Operations.CREATE);
@@ -136,8 +134,7 @@ public class RulerDAOTest extends Test {
 
     //the rule has a higher priority than the first rule, changes user's email from nanos@nanos.net to foam@nanos.net
     rule2 = new Rule();
-    rule2.setId(2);
-    rule2.setName("userDAO email filter");
+    rule2.setId("rule2. userDAO email filter");
     rule2.setRuleGroup("users:email filter");
     rule2.setDaoKey("localUserDAO");
     rule2.setOperation(Operations.CREATE);
@@ -161,8 +158,7 @@ public class RulerDAOTest extends Test {
 
     //the rule has lower priority than the first one => should never be executed
     rule3 = new Rule();
-    rule3.setId(3);
-    rule3.setName("userDAO email filter");
+    rule3.setId("rule3. userDAO email filter");
     rule3.setRuleGroup("users:email filter");
     rule3.setDaoKey("localUserDAO");
     rule3.setOperation(Operations.CREATE);
@@ -176,8 +172,7 @@ public class RulerDAOTest extends Test {
 
     //the rule has lower priority than the first one but has different group so should be executed
     rule4 = new Rule();
-    rule4.setId(4);
-    rule4.setName("userDAO lastName filter");
+    rule4.setId("rule4. userDAO lastName filter");
     rule4.setRuleGroup("users:change lastName");
     rule4.setDaoKey("localUserDAO");
     rule4.setOperation(Operations.CREATE);
@@ -196,8 +191,7 @@ public class RulerDAOTest extends Test {
 
     //the rule has lower priority than the first one but has different group so should be executed
     rule5 = new Rule();
-    rule5.setId(5);
-    rule5.setName("userDAO lastName filter");
+    rule5.setId("rule5. userDAO lastName filter");
     rule5.setRuleGroup("users:change lastName");
     rule5.setDaoKey("localUserDAO");
     rule5.setOperation(Operations.UPDATE);
@@ -208,7 +202,7 @@ public class RulerDAOTest extends Test {
       User user = (User) obj;
       user.setLastName("Unknown");
       Rule executeRule = new Rule();
-      executeRule.setId(666L);
+      executeRule.setId("executeRule");
       executeRule.setRuleGroup("fake test group");
       executeRule.setDaoKey("fakeDaoKey");
       agency.submit(x, new ContextAwareAgent() {
@@ -234,8 +228,7 @@ public class RulerDAOTest extends Test {
 
     //the rule only applied to user2
     rule6 = new Rule();
-    rule6.setId(6);
-    rule6.setName("user2 update");
+    rule6.setId("rule6. user2 update");
     rule6.setRuleGroup("user2 update");
     rule6.setDaoKey("localUserDAO");
     rule6.setOperation(Operations.UPDATE);
@@ -256,8 +249,7 @@ public class RulerDAOTest extends Test {
 
     //the rule with erroneous predicate
     rule8 = new Rule();
-    rule8.setId(8);
-    rule8.setName("Erroneous rule predicate");
+    rule8.setId("rule8. Erroneous rule predicate");
     rule8.setRuleGroup("user created");
     rule8.setDaoKey("localUserDAO");
     rule8.setOperation(Operations.CREATE);
@@ -269,8 +261,7 @@ public class RulerDAOTest extends Test {
 
     //the rule with FObject predicate
     rule9 = new Rule();
-    rule9.setId(9);
-    rule9.setName("FObject rule predicate");
+    rule9.setId("rule9. FObject rule predicate");
     rule9.setRuleGroup("user updated");
     rule9.setDaoKey("localUserDAO");
     rule9.setOperation(Operations.UPDATE);

--- a/src/services
+++ b/src/services
@@ -457,7 +457,7 @@ p({
   "serviceScript": """
     ed = new foam.dao.EasyDAO.Builder(x)
       .setPm(true)
-      .setSeqNo(true)
+      .setGuid(true)
       .setOf(foam.nanos.ruler.Rule.getOwnClassInfo())
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
       .setJournalName("rules")


### PR DESCRIPTION
When adding new rules in journal file chances that people using the same rule id range are quite likely.

To reduce the likelihood of conflicting rule id, change rule id to string and decorate it with GUID decorator and remove rule name property as the string-based rule id can serve the same purpose.

DO_NOT_MERGE until we have a strategy for migrating production journals. 