### PR TITLE
Update session object-level access control logic and add SessionService

### DIFF
--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -83,6 +83,7 @@ FOAM_FILES([
   { name: "foam/nanos/boot/DAOConfigSummaryView", flags: ['web'] },
   { name: "foam/nanos/session/Session" },
   { name: "foam/nanos/session/SessionTimer" },
+  { name: "foam/nanos/session/SessionService" },
   { name: "foam/nanos/menu/AbstractMenu" },
   { name: "foam/nanos/menu/DAOMenu" },
   { name: "foam/nanos/menu/DAOMenu2" },

--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -150,7 +150,7 @@ foam.CLASS({
         }
       ],
       javaCode: `
-        if ( SafetyUtil.equals(getRemoteHost(), remoteHost) ) {
+        if ( SafetyUtil.isEmpty(getRemoteHost()) || SafetyUtil.equals(getRemoteHost(), remoteHost) ) {
           return true;
         }
 

--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -9,14 +9,8 @@ foam.CLASS({
   name: 'Session',
 
   implements: [
-    'foam.nanos.auth.Authorizable',
     'foam.nanos.auth.CreatedAware',
     'foam.nanos.auth.CreatedByAware'
-  ],
-
-  imports: [
-    'auth',
-    'localUserDAO'
   ],
 
   javaImports: [
@@ -161,38 +155,6 @@ foam.CLASS({
         }
 
         return false;
-      `
-    },
-    {
-      name: 'authorizeOnCreate',
-      javaCode: `
-        if ( ! ((AuthService) getAuth()).check(x, "session.create.*") ) {
-          throw new AuthorizationException();
-        }
-      `
-    },
-    {
-      name: 'authorizeOnRead',
-      javaCode: `
-        if ( ! ((AuthService) getAuth()).check(x, "session.read.*") ) {
-          throw new AuthorizationException();
-        }
-      `
-    },
-    {
-      name: 'authorizeOnUpdate',
-      javaCode: `
-        if ( ! ((AuthService) getAuth()).check(x, "session.update.*") ) {
-          throw new AuthorizationException();
-        }
-      `
-    },
-    {
-      name: 'authorizeOnDelete',
-      javaCode: `
-        if ( ! ((AuthService) getAuth()).check(x, "session.delete.*") ) {
-          throw new AuthorizationException();
-        }
       `
     },
     {

--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -163,104 +163,25 @@ foam.CLASS({
         return false;
       `
     },
+    // The authorization methods always throw. This won't happen for superadmin
+    // though because SystemAuthService will return true before these methods
+    // are hit. We do this so that superadmins are the only users who are
+    // permitted to work with sessions.
     {
       name: 'authorizeOnCreate',
-      javaCode: `
-        AuthService auth = (AuthService) getAuth();
-
-        if (
-          ! isSessionUser(x) &&
-          ! hasSPIDPermission(x, "create") &&
-          ! ((AuthService) getAuth()).check(x, createPermission("create"))
-        ) {
-          throw new AuthorizationException("You don't have permission to create that session.");
-        }
-      `
+      javaCode: 'throw new AuthorizationException();'
     },
     {
       name: 'authorizeOnRead',
-      javaCode: `
-        if (
-          ! isSessionUser(x) &&
-          ! hasSPIDPermission(x, "read") &&
-          ! ((AuthService) getAuth()).check(x, createPermission("read"))
-        ) {
-          throw new AuthorizationException("You don't have permission to read that session.");
-        }
-      `
+      javaCode: 'throw new AuthorizationException();'
     },
     {
       name: 'authorizeOnUpdate',
-      javaCode: `
-        Session oldSession = (Session) oldObj;
-        AuthService auth = (AuthService) getAuth();
-
-        if (
-          ! isSessionUser(x) &&
-          ! oldSession.isSessionUser(x) &&
-          ! hasSPIDPermission(x, "update") &&
-          ! oldSession.hasSPIDPermission(x, "update") &&
-          ! auth.check(x, createPermission("update")) &&
-          ! auth.check(x, oldSession.createPermission("update"))
-        ) {
-          throw new AuthorizationException("You don't have permission to update that session.");
-        }
-      `
+      javaCode: 'throw new AuthorizationException();'
     },
     {
       name: 'authorizeOnDelete',
-      javaCode: `
-        if (
-          ! isSessionUser(x) &&
-          ! hasSPIDPermission(x, "delete") &&
-          ! ((AuthService) getAuth()).check(x, createPermission("delete"))
-        ) {
-          throw new AuthorizationException("You don't have permission to delete that session.");
-        }
-      `
-    },
-    {
-      name: 'isSessionUser',
-      args: [
-        { name: 'x', type: 'Context' }
-      ],
-      type: 'Boolean',
-      javaCode: `
-        User user = (User) x.get("user");
-        return user != null && this.getUserId() == user.getId();
-      `
-    },
-    {
-      name: 'hasSPIDPermission',
-      args: [
-        { name: 'x', type: 'Context' },
-        { name: 'operation', type: 'String' }
-      ],
-      type: 'Boolean',
-      javaCode: `
-        if ( getUserId() == 0 ) return false;
-
-        AuthService auth         = (AuthService) getAuth();
-        DAO         localUserDAO = (DAO) getLocalUserDAO();
-        User        sessionUser  = (User) localUserDAO.inX(x).find(getUserId());
-
-        if ( sessionUser == null ) throw new RuntimeException(String.format("User with id '%d' not found.", Long.toString(getUserId())));
-
-        String spid = sessionUser.getSpid();
-        return ! SafetyUtil.isEmpty(spid) && auth.check(x, String.format("session.%s.%s", operation, spid));
-      `
-    },
-    {
-      name: 'createPermission',
-      args: [
-        { name: 'operation', type: 'String' }
-      ],
-      type: 'String',
-      javaCode: `
-        String id = getId();
-        if ( SafetyUtil.isEmpty(id) ) id = "*";
-        return "session." + operation + "." + id;
-      `
+      javaCode: 'throw new AuthorizationException();'
     },
     {
       name: 'applyTo',

--- a/src/foam/nanos/session/SessionService.js
+++ b/src/foam/nanos/session/SessionService.js
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2019 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.INTERFACE({
+  package: 'foam.nanos.session',
+  name: 'SessionService',
+
+  documentation: `
+    A service that can be used to create and destroy sessions for users. The
+    idea behind this service was to create an alternative to letting users
+    access sessionDAO directly to manage sessions. This service has a much
+    simpler interface and reveals less information.
+  `,
+
+  methods: [
+    {
+      name: 'createSession',
+      documentation: 'Creates a new session for the given user. Returns the access token for the new session.',
+      type: 'String',
+      args: [
+        { name: 'x',      type: 'Context' },
+        { name: 'userId', type: 'Long' }
+      ]
+    },
+    {
+      name: 'createSessionWithTTL',
+      documentation: 'Creates a new session for the given user with the specified time to live. Returns the access token for the new session.',
+      type: 'String',
+      args: [
+        { name: 'x',      type: 'Context' },
+        { name: 'userId', type: 'Long' },
+        { name: 'ttl',    type: 'Long' }
+      ]
+    },
+    {
+      name: 'destroySession',
+      documentation: 'Destroys the session with the given access token.',
+      type: 'Void',
+      args: [
+        { name: 'x',           type: 'Context' },
+        { name: 'accessToken', type: 'String' }
+      ]
+    }
+  ],
+});

--- a/src/foam/nanos/session/SessionService.js
+++ b/src/foam/nanos/session/SessionService.js
@@ -9,10 +9,10 @@ foam.INTERFACE({
   name: 'SessionService',
 
   documentation: `
-    A service that can be used to create and destroy sessions for users. The
-    idea behind this service was to create an alternative to letting users
-    access sessionDAO directly to manage sessions. This service has a much
-    simpler interface and reveals less information.
+    A service that can be used to create sessions for users. The idea behind
+    this service was to create an alternative to letting users access sessionDAO
+    directly to manage sessions. This service has a much simpler interface and
+    reveals less information.
   `,
 
   methods: [
@@ -33,15 +33,6 @@ foam.INTERFACE({
         { name: 'x',      type: 'Context' },
         { name: 'userId', type: 'Long' },
         { name: 'ttl',    type: 'Long' }
-      ]
-    },
-    {
-      name: 'destroySession',
-      documentation: 'Destroys the session with the given access token.',
-      type: 'Void',
-      args: [
-        { name: 'x',           type: 'Context' },
-        { name: 'accessToken', type: 'String' }
       ]
     }
   ],

--- a/src/foam/nanos/session/SimpleSessionService.js
+++ b/src/foam/nanos/session/SimpleSessionService.js
@@ -10,8 +10,8 @@ foam.CLASS({
 
   documentation: `
     A simple implementation of the SessionService interface. Uses SPID-based
-    access control checks. Allows SPID administrators to create and destroy
-    sessions for users in the SPID they administrate.
+    access control checks. Allows SPID administrators to create sessions for
+    users in the SPID they administrate.
   `,
 
   implements: ['foam.nanos.session.SessionService'],
@@ -61,29 +61,6 @@ foam.CLASS({
 
         // TODO: Change to access token property when we support that.
         return session.getId();
-      `
-    },
-    {
-      name: 'destroySession',
-      javaCode: `
-        DAO localSessionDAO = (DAO) getLocalSessionDAO();
-
-        // TODO: Change to query by access token property instead of id when we
-        // support that.
-        Session session = (Session) localSessionDAO.find(accessToken);
-
-        if ( session == null ) {
-          throw new RuntimeException("Session not found.");
-        }
-
-        if (
-          session.getUserId() == 0 ||
-          ! hasSPIDPermission(x, "delete", session.getUserId())
-        ) {
-          throw new AuthorizationException("You don't have permission to destroy that session.");
-        }
-
-        localSessionDAO.remove(session);
       `
     },
     {

--- a/src/foam/nanos/session/SimpleSessionService.js
+++ b/src/foam/nanos/session/SimpleSessionService.js
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2019 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.nanos.session',
+  name: 'SimpleSessionService',
+
+  documentation: `
+    A simple implementation of the SessionService interface. Uses SPID-based
+    access control checks. Allows SPID administrators to create and destroy
+    sessions for users in the SPID they administrate.
+  `,
+
+  implements: ['foam.nanos.session.SessionService'],
+
+  imports: [
+    'auth',
+    'localSessionDAO',
+    'localUserDAO'
+  ],
+
+  javaImports: [
+    'foam.dao.DAO',
+    'foam.nanos.auth.AuthService',
+    'foam.nanos.auth.AuthorizationException',
+    'foam.nanos.auth.User',
+    'foam.util.SafetyUtil'
+  ],
+
+  methods: [
+    // Interface methods
+    {
+      name: 'createSession',
+      javaCode: `
+        return createSessionWithTTL(x, userId, 0);
+      `
+    },
+    {
+      name: 'createSessionWithTTL',
+      javaCode: `
+        if ( userId < 1 ) {
+          throw new IllegalArgumentException("User id must be a positive integer.");
+        }
+
+        if ( ! hasSPIDPermission(x, "create", userId) ) {
+          throw new AuthorizationException("You don't have permission to create a session for that user.");
+        }
+
+        Session session = new Session.Builder(x)
+          .setUserId(userId)
+          .build();
+        
+        if ( ttl > 0 ) {
+          session.setTtl(ttl);
+        }
+
+        session = (Session) ((DAO) getLocalSessionDAO()).put(session);
+
+        // TODO: Change to access token property when we support that.
+        return session.getId();
+      `
+    },
+    {
+      name: 'destroySession',
+      javaCode: `
+        DAO localSessionDAO = (DAO) getLocalSessionDAO();
+
+        // TODO: Change to query by access token property instead of id when we
+        // support that.
+        Session session = (Session) localSessionDAO.find(accessToken);
+
+        if ( session == null ) {
+          throw new RuntimeException("Session not found.");
+        }
+
+        if (
+          session.getUserId() == 0 ||
+          ! hasSPIDPermission(x, "delete", session.getUserId())
+        ) {
+          throw new AuthorizationException("You don't have permission to destroy that session.");
+        }
+
+        localSessionDAO.remove(session);
+      `
+    },
+    {
+      name: 'hasSPIDPermission',
+      args: [
+        { name: 'x', type: 'Context' },
+        { name: 'operation', type: 'String' },
+        { name: 'userId', type: 'Long' }
+      ],
+      type: 'Boolean',
+      javaCode: `
+        AuthService auth         = (AuthService) getAuth();
+        DAO         localUserDAO = (DAO) getLocalUserDAO();
+        User        sessionUser  = (User) localUserDAO.inX(x).find(userId);
+
+        if ( sessionUser == null ) throw new RuntimeException(String.format("User with id '%d' not found.", Long.toString(userId)));
+
+        String spid = sessionUser.getSpid();
+        if ( SafetyUtil.isEmpty(spid) ) spid = "*";
+        return auth.check(x, String.format("session.%s.%s", operation, spid));
+      `
+    }
+  ]
+});

--- a/src/services
+++ b/src/services
@@ -247,10 +247,12 @@ p({
     return new foam.dao.EasyDAO.Builder(x)
       .setOf(foam.nanos.session.Session.getOwnClassInfo())
       .setPm(true)
+      .setAuthorize(false)
       .setInnerDAO(((foam.dao.DAO) x.get(\"localSessionDAO\")))
       .build();
   """,
-  "client": "{\"of\":\"foam.nanos.session.Session\"}"
+  "client": "{\"of\":\"foam.nanos.session.Session\"}",
+  "authNotes": "Users must have the 'service.sessionDAO' permission to access this service. Due to the highly sensitive nature of sessions, only superadmins should have permission to access this service."
 })
 
 p({

--- a/src/services
+++ b/src/services
@@ -599,3 +599,10 @@ p({
     "class": "foam.nanos.geocode.GoogleMapsCredentials"
   }
 })
+
+p({
+  "class": "foam.nanos.boot.NSpec",
+  "name": "sessionService",
+  "serve": true,
+  "serviceClass": "foam.nanos.session.SimpleSessionService"
+})

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -230,6 +230,8 @@ var classes = [
   'foam.nanos.http.HttpParameters',
   'foam.nanos.http.DefaultHttpParameters',
   'foam.nanos.session.Session',
+  'foam.nanos.session.SessionService',
+  'foam.nanos.session.SimpleSessionService',
   'foam.nanos.pool.AbstractFixedThreadPool',
   'foam.nanos.om.OMLogger',
   'foam.nanos.pm.NullPM',
@@ -490,6 +492,7 @@ var skeletons = [
   'foam.nanos.notification.email.EmailService',
   'foam.nanos.notification.email.POP3Email',
   'foam.nanos.notification.push.PushService',
+  'foam.nanos.session.SessionService',
   'foam.nanos.test.EchoService',
   'foam.strategy.StrategizerService'
 ];


### PR DESCRIPTION
This commit makes it so that a user must pass one of three checks in
order to operate on a session. The checks are as follows:

  1. The user is the "session user", meaning the user's id matches the
     value of the userId property on the session instance.
  2. The user has a permission of the form "session.<operation>.<spid>"
     where operation is "create", "read", "update", or "delete". This
     permission allows them to operate on all sessions where the user
     in the session has a SPID that matches the SPID in the permission.
  3. The user has a permission of the form "session.<operation>.<id>"
     where operation is the same as above and id is the id of a session,
     which is a GUID.

The first rule allows users to modify their own session in so far as the
property-level access control checks allow them to. The second rule
allows "weak" admins - which are administrators of service providers - to
manage the sessions of users under their service. The third check allows
"super" admins to be able to do anything. Note that the second check
won't always pass for super admins because it will fail if the userId of
the session is not set.