### PR TITLE
Log errors with logger rather than standard out.

### DIFF
--- a/src/foam/nanos/notification/email/EmailTemplateApplyEmailPropertyService.js
+++ b/src/foam/nanos/notification/email/EmailTemplateApplyEmailPropertyService.js
@@ -37,7 +37,7 @@ foam.CLASS({
       try {
         emailMessage = emailTemplateObj.apply(x, group, emailMessage, templateArgs);
       } catch (Exception e) {
-        logger.error(new NoSuchFieldException("@EmailTemplateApplyEmailPropertyService: emailTemplate.apply has failed. emailTemplate = {id:" + templateName + ", group:" + group + "}" + e));
+        ((Logger) x.get("logger")).error(new NoSuchFieldException("@EmailTemplateApplyEmailPropertyService: emailTemplate.apply has failed. emailTemplate = {id:" + templateName + ", group:" + group + "}" + e));
       }
 
       return emailMessage;

--- a/src/foam/nanos/notification/email/EmailTemplateApplyEmailPropertyService.js
+++ b/src/foam/nanos/notification/email/EmailTemplateApplyEmailPropertyService.js
@@ -37,7 +37,7 @@ foam.CLASS({
       try {
         emailMessage = emailTemplateObj.apply(x, group, emailMessage, templateArgs);
       } catch (Exception e) {
-        throw new NoSuchFieldException("@EmailTemplateApplyEmailPropertyService: emailTemplate.apply has failed. emailTemplate = {id:" + templateName + ", group:" + group + "}" + e);
+        logger.error(new NoSuchFieldException("@EmailTemplateApplyEmailPropertyService: emailTemplate.apply has failed. emailTemplate = {id:" + templateName + ", group:" + group + "}" + e));
       }
 
       return emailMessage;

--- a/src/foam/util/Emails/EmailsUtility.java
+++ b/src/foam/util/Emails/EmailsUtility.java
@@ -59,7 +59,7 @@ public class EmailsUtility {
     try {
       cts.apply(x, group, emailMessage, templateArgs);
     } catch (Exception e) {
-      e.printStackTrace();
+      logger.error(e);
       return;
     }
 


### PR DESCRIPTION
Also, trap the NoSuchFieldException and log an error.

In development, scripts fail if email templates are not configured. 