### PR TITLE
Fix bug where editEnabled: false would still allow editing

### DIFF
--- a/src/foam/comics/DAOControllerView.js
+++ b/src/foam/comics/DAOControllerView.js
@@ -234,6 +234,7 @@ foam.CLASS({
       this.stack.push({
         class: this.updateView.class,
         detailView: this.data.detailView,
+        editEnabled: this.data.editEnabled,
         key: id
       }, this);
     },

--- a/src/foam/comics/DAOUpdateControllerView.js
+++ b/src/foam/comics/DAOUpdateControllerView.js
@@ -95,6 +95,10 @@ foam.CLASS({
       }
     },
     {
+      class: 'Boolean',
+      name: 'editEnabled'
+    },
+    {
       class: 'FObjectProperty',
       of: 'foam.u2.Element',
       name: 'container_'
@@ -169,8 +173,8 @@ foam.CLASS({
     },
     {
       name: 'edit',
-      isAvailable: function(controllerMode) {
-        return controllerMode === this.ControllerMode.VIEW;
+      isAvailable: function(controllerMode, editEnabled) {
+        return editEnabled && controllerMode === this.ControllerMode.VIEW;
       },
       code: function() {
         this.controllerMode = this.ControllerMode.EDIT;


### PR DESCRIPTION
The bug was happening because the `editEnabled` property wasn't being passed to `DAOUpdateControllerView`.

Ticket: https://nanopay.atlassian.net/browse/CPF-2995