### PR TITLE
[CPF-2616] Add MenuDefinedViewList

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -385,6 +385,7 @@ FOAM_FILES([
   { name: "foam/swift/refines/Remote", flags: ['swift'] },
 
   { name: "foam/nanos/menu/DAOMenu2" },
+  { name: "foam/nanos/menu/MenuDefinedViewList" },
 
   { name: "foam/box/LogBox" },
   { name: "foam/box/MultiDelegateBox" },

--- a/src/foam/nanos/menu/MenuDefinedViewList.js
+++ b/src/foam/nanos/menu/MenuDefinedViewList.js
@@ -1,0 +1,36 @@
+foam.CLASS({
+  package: 'foam.nanos.menu',
+  name: 'MenuDefinedViewList',
+  extends: 'foam.u2.View',
+
+  properties: [
+    {
+      name: 'containerView',
+      class: 'foam.u2.ViewSpec'
+    },
+    {
+      name: 'childViews',
+      class: 'FObjectArray',
+      of: 'foam.u2.View'
+    }
+  ],
+
+  methods: [
+    function initE() {
+      var self = this;
+      var view = this;
+
+      view = view
+        .start(self.containerView);
+      
+      for ( var i = 0; i < self.childViews.length; i++ ) {
+        view = view
+          .start(self.childViews[i]).end();
+      }
+
+      view = view
+        .end();
+    }
+  ]
+});
+


### PR DESCRIPTION
Currently it is difficult to specify children of a view for a menu item or navigation action. This can be useful to decouple navigation items from pages without the need to create a new model for every pairing.

Example use:
```javascript
self.stack.push({
  class: 'foam.nanos.menu.MenuDefinedViewList',
  containerView: 'foam.u2.layout.Rows',
  childViews: [
    {   
      class: 'foam.nanos.crunch.ui.CapabilityPageMenu'
    },  
    {   
      class: 'foam.nanos.crunch.ui.CapabilityInfoView'
    }   
  ]   
}); 
```