### PR TITLE
Set table columns and widths for a number of properties on Session

### DIFF
--- a/src/foam/nanos/session/Session.js
+++ b/src/foam/nanos/session/Session.js
@@ -24,6 +24,16 @@ foam.CLASS({
     'java.util.Date'
   ],
 
+  tableColumns: [
+    'userId',
+    'agentId',
+    'created',
+    'lastUsed',
+    'ttl',
+    'uses',
+    'remoteHost'
+  ],
+
   properties: [
     {
       class: 'String',
@@ -77,6 +87,7 @@ foam.CLASS({
       label: 'TTL',
       documentation: 'The "time to live" of the session. The amount of time in milliseconds that the session should be kept alive after its last use before being destroyed. Must be a positive value or zero.',
       value: 28800000, // 1000 * 60 * 60 * 8 = number of milliseconds in 8 hours
+      tableWidth: 70,
       validationPredicates: [
         {
           args: ['ttl'],
@@ -90,12 +101,14 @@ foam.CLASS({
     {
       class: 'Long',
       name: 'uses',
+      tableWidth: 70,
       storageTransient: true
     },
     {
       class: 'String',
       name: 'remoteHost',
-      visibility: 'RO'
+      visibility: 'RO',
+      tableWidth: 120
     },
     {
       documentation: 'Intended to be used with long TTL sessions, further restricting to a known set of IPs.',


### PR DESCRIPTION
## Screenshot

<img width="1038" alt="Screen Shot 2019-09-26 at 1 46 43 PM" src="https://user-images.githubusercontent.com/4259165/65712099-488c0c80-e064-11e9-9c56-98c4f75f7cae.png">

I removed `id` as a column since it's not very helpful imo. Can add back if you want me to.