### PR TITLE
fix safari RO css issue

### DIFF
--- a/src/foam/u2/CurrencyView.js
+++ b/src/foam/u2/CurrencyView.js
@@ -11,7 +11,7 @@ foam.CLASS({
 
   documentation: 'View for formatting cents into dollars.',
 
-  css: '^:read-only { border: none; background: rgba(0,0,0,0); }',
+  css: '^:read-only:not(^:disabled) { border: none; background: rgba(0,0,0,0); }',
 
   properties: [
     ['precision', 2]

--- a/src/foam/u2/DateView.js
+++ b/src/foam/u2/DateView.js
@@ -24,7 +24,7 @@ foam.CLASS({
 
   documentation: 'View for editing Date values.',
 
-  css: '^:read-only { border: none; background: rgba(0,0,0,0); }',
+  css: '^:read-only:not(^:disabled) { border: none; background: rgba(0,0,0,0); }',
 
   axioms: [
     { class: 'foam.u2.TextInputCSS' }

--- a/src/foam/u2/FloatView.js
+++ b/src/foam/u2/FloatView.js
@@ -22,12 +22,7 @@ foam.CLASS({
 
   documentation: 'View for editing Float Properties.',
 
-  css: `
-    ^:read-only {
-      border: none;
-      background: rgba(0,0,0,0);
-    }
-  `,
+  css: `^:read-only:not(^:disabled) { border: none; background: rgba(0,0,0,0); }`,
 
   properties: [
     ['type', 'number'],

--- a/src/foam/u2/IntView.js
+++ b/src/foam/u2/IntView.js
@@ -20,7 +20,7 @@ foam.CLASS({
   name: 'IntView',
   extends: 'foam.u2.TextField',
 
-  css: '^:read-only { border: none; background: rgba(0,0,0,0); }',
+  css: '^:read-only:not(^:disabled) { border: none; background: rgba(0,0,0,0); }',
 
   properties: [
     [ 'type', 'number' ],

--- a/src/foam/u2/TextField.js
+++ b/src/foam/u2/TextField.js
@@ -29,10 +29,8 @@ foam.CLASS({
       -webkit-appearance: textfield !important;
     }
 
-    ^:read-only {
-      border: none;
-      background: rgba(0,0,0,0);
-    }
+    ^:read-only:not(^:disabled) 
+    { border: none; background: rgba(0,0,0,0); }
   `,
 
   properties: [

--- a/src/foam/u2/tag/Input.js
+++ b/src/foam/u2/tag/Input.js
@@ -21,7 +21,7 @@ foam.CLASS({
   extends: 'foam.u2.View',
 
   css: `
-    ^:read-only { border: none; background: rgba(0,0,0,0); }
+    ^:read-only:not(^:disabled) { border: none; background: rgba(0,0,0,0); }
     /* Still show outline when focused as read-only to help accessibility *
     ^:read-only:focus { outline: 1px solid rgb(238, 238, 238); }
   `,


### PR DESCRIPTION
issue: Safari will apply both RO && DISABLE css Pseudo selectors rules when element has DISABLE attribute.

solution: we change `read-only` to  `read-only:not(^:disabled)`