### PR TITLE
Fix menu text selection when mouse moved

### DIFF
--- a/src/foam/nanos/u2/navigation/TopNavigation.js
+++ b/src/foam/nanos/u2/navigation/TopNavigation.js
@@ -62,6 +62,8 @@ foam.CLASS({
     ^ .foam-nanos-menu-MenuBar li {
       display: inline-block;
       cursor: pointer;
+      -webkit-user-select: none;
+      user-select: none;
     }
     ^ .menuItem {
       display: inline-block;


### PR DESCRIPTION
Both attributes must be set for the fix to work for Chrome, Firefox and Safari:

      -webkit-user-select: none;
      user-select: none;