### PR TITLE
Fix property update history

### DIFF
--- a/src/foam/core/AbstractPropertyInfo.java
+++ b/src/foam/core/AbstractPropertyInfo.java
@@ -60,7 +60,7 @@ public abstract class AbstractPropertyInfo
 
   @Override
   public void diff(FObject o1, FObject o2, Map diff, PropertyInfo prop) {
-    if ( prop.f(o1) == null || ! prop.f(o1).equals(prop.f(o2)) ) {
+    if ( prop.compare(o1, o2) != 0 ) {
       diff.put(prop.getName(), prop.f(o2));
     }
   }

--- a/src/foam/u2/Element.js
+++ b/src/foam/u2/Element.js
@@ -2512,6 +2512,17 @@ foam.CLASS({
 
 foam.CLASS({
   package: 'foam.u2',
+  name: 'ObjectViewRefinement',
+  refines: 'foam.core.Object',
+  requires: [ 'foam.u2.view.AnyView' ],
+  properties: [
+    [ 'view', { class: 'foam.u2.view.AnyView' } ]
+  ]
+});
+
+
+foam.CLASS({
+  package: 'foam.u2',
   name: 'ControllerViewTrait',
 
   documentation: 'Trait for adding a ControllerMode controllerMode Property.',

--- a/test/src/core/types.js
+++ b/test/src/core/types.js
@@ -109,9 +109,11 @@ describe('Date', function() {
     p.date = dateStr;
     expect(p.date).toEqual(new Date(dateStr));
   });
-  it('throws on invalid date strings', function() {
+  // Assigning invalid date is no longer throw.
+  // Please see foam.core.Date for detail.
+  it('not throws on invalid date strings', function() {
     var dateStr = "d ";
-    expect(function() { p.date = dateStr; }).toThrow();
+    expect(function() { p.date = dateStr; }).not.toThrow();
   });
   it('compares', function() {
     p.date = 55555;


### PR DESCRIPTION
## Changes

- Fix property diff comparison so that only the changing properties are saved to the history DAO
- Set default Object view to AnyView

<img width="1043" alt="Screen Shot 2019-10-06 at 8 41 01 AM" src="https://user-images.githubusercontent.com/441658/66269367-90095a00-e815-11e9-94a0-06793736bb87.png">
