### PR TITLE
Remove "Browse" from DAO Controller title

### DIFF
--- a/src/foam/comics/BrowserView.js
+++ b/src/foam/comics/BrowserView.js
@@ -39,7 +39,7 @@ foam.CLASS({
     {
       name: 'title',
       expression: function(data$of) {
-        return 'Browse ' + data$of.model_.plural;
+        return data$of.model_.plural;
       }
     },
     {

--- a/src/foam/comics/DAOController.js
+++ b/src/foam/comics/DAOController.js
@@ -139,7 +139,7 @@ foam.CLASS({
       class: 'String',
       name: 'title',
       expression: function(data$of) {
-        return 'Browse ' + data$of.model_.plural;
+        return data$of.model_.plural;
       }
     },
     {


### PR DESCRIPTION
Eg: Instead of "Browse Users" it'll just say "Users".

I don't think "Browse" was adding anything useful to the page. It's just an extra word you need to ignore in every title.