### PR TITLE
Don't hide entire ReciprocalSearch when searchColumns is empty

### DIFF
--- a/src/foam/u2/view/ReciprocalSearch.js
+++ b/src/foam/u2/view/ReciprocalSearch.js
@@ -150,8 +150,6 @@ foam.CLASS({
       this.
         addClass(self.myClass()).
         add(this.slot(function(filters) {
-          self.show(filters.length);
-
           this.searchManager.filteredDAO$.sub(self.updateSelectedCount);
           self.updateSelectedCount(0, 0, 0, this.searchManager.filteredDAO$);
 


### PR DESCRIPTION
Just hide the indiviual search controls. That way the general search box
is still available.

This also fixes an issue where a gap would be shown where the ReciprocalSearch would have been if it hadn't been hidden.