### PR TITLE
Fix failing test

### DIFF
--- a/src/foam/core/Validation.js
+++ b/src/foam/core/Validation.js
@@ -76,7 +76,14 @@ foam.CLASS({
     {
       class: 'FObjectArray',
       of: 'foam.core.ValidationPredicate',
-      name: 'validationPredicates'
+      name: 'validationPredicates',
+      // We override 'compare' here because we need to avoid infinite recursion
+      // that occurs when a validation predicate for a given property contains a
+      // reference to the property itself.
+      // This is an incorrect implementation of compare since it will always
+      // return a match, even if the validation predicates are different. It
+      // would be preferable to find a way to deal with circular references.
+      compare: function() { return 0; }
     },
     {
       name: 'validateObj',


### PR DESCRIPTION
When we refined `foam.core.Date` to add validation predicates, the build started to fail because one of the AutoIndex tests started failing. It was failing because of a stack overflow exception. The stack overflow was happening because in the AutoIndex code, a property is cloned and compared to the `arg1` of a predicate using `foam.util.equals`. The implementation of `compareTo` for FObjects loops over all properties and compares each of them. So since we're comparing two instances of `foam.core.Date`, it's looping over the properties on that model, one of which is `validationPredicates`. The value of `validationPredicates` is an array of predicates, and they contain references to the date property itself, which means that as the compare methods are being recursively called on FObjects and their properties, they eventually reach the reference to the property itself and that's where the circular reference happens. Obviously, it continues recursively calling compare methods in this manner until a stack overflow occurs.

The fix proposed here is not ideal, but it is simple. By simply always returning a match when we compare the `validationPredicates` properties, we avoid the recursive checks down the predicates and thus avoid the circular reference issue.

A better fix would be to implement compare in such a way that it avoids infinite recursion but still makes a proper comparison between predicates.