### PR TITLE
Add default newItem value to ArrayView

### DIFF
--- a/src/foam/u2/view/ArrayView.js
+++ b/src/foam/u2/view/ArrayView.js
@@ -10,6 +10,7 @@ foam.CLASS({
   extends: 'foam.u2.View',
 
   requires: [
+    'foam.core.FObject',
     'foam.u2.layout.Cols',
     'foam.u2.layout.Rows'
   ],
@@ -40,7 +41,7 @@ foam.CLASS({
       },
       code: function() {
         var newItem = this.defaultNewItem;
-        if ( foam.core.FObject.isInstance(newItem) ) {
+        if ( this.FObject.isInstance(newItem) ) {
           newItem = newItem.clone();
         }
         this.data[this.data.length] = newItem;

--- a/src/foam/u2/view/ArrayView.js
+++ b/src/foam/u2/view/ArrayView.js
@@ -24,6 +24,10 @@ foam.CLASS({
       class: 'foam.u2.ViewSpec',
       name: 'valueView',
       value: { class: 'foam.u2.view.AnyView' }
+    },
+    {
+      name: 'defaultNewItem',
+      value: ''
     }
   ],
 
@@ -35,7 +39,11 @@ foam.CLASS({
         return mode === foam.u2.DisplayMode.RW;
       },
       code: function() {
-        this.data[this.data.length] = '';
+        var newItem = this.defaultNewItem;
+        if ( foam.core.FObject.isInstance(newItem) ) {
+          newItem = newItem.clone();
+        }
+        this.data[this.data.length] = newItem;
         this.updateData();
       }
     }

--- a/src/foam/u2/view/FObjectArrayView.js
+++ b/src/foam/u2/view/FObjectArrayView.js
@@ -15,6 +15,12 @@ foam.CLASS({
       name: 'of'
     },
     {
+      name: 'defaultNewItem',
+      expression: function(of) {
+        return of.create();
+      }
+    },
+    {
       name: 'valueView',
       expression: function(of) {
         return {


### PR DESCRIPTION
When creating an item in an ArrayView, an empty string value is added to the end of the array. In the case of an FObjectArrayView for an interface type, this causes an exception to be thrown when updating the parent slot.

This PR adds a `defaultNewItem` property to ArrayView, allowing the view of an FObjectProperty to specify a reasonable value for new items.