### PR TITLE
CPF-3149 Prevent broken slots due to Javascript errors

### DIFF
--- a/src/foam/core/Slot.js
+++ b/src/foam/core/Slot.js
@@ -93,10 +93,13 @@ foam.CLASS({
 
         if ( ! foam.util.is(s1.get(), s2.get()) ) {
           feedback1 = true;
-          s2.set(s1.get());
-          if ( ! foam.util.is(s1.get(), s2.get()) )
-            s1.set(s2.get());
-          feedback1 = false;
+          try {
+            s2.set(s1.get());
+            if ( ! foam.util.is(s1.get(), s2.get()) )
+              s1.set(s2.get());
+          } finally {
+            feedback1 = false;
+          }
         }
       };
 
@@ -105,10 +108,13 @@ foam.CLASS({
 
         if ( ! foam.util.is(s1.get(), s2.get()) ) {
           feedback2 = true;
-          s1.set(s2.get());
-          if ( ! foam.util.is(s1.get(), s2.get()) )
-            s2.set(s1.get());
-          feedback2 = false;
+          try {
+            s1.set(s2.get());
+            if ( ! foam.util.is(s1.get(), s2.get()) )
+              s2.set(s1.get());
+          } finally {
+            feedback2 = false;
+          }
         }
       };
 


### PR DESCRIPTION
It is possible for exceptions related to setting a property (setter, adapt, etc) to be thrown at the time that a subslot updates a parent slot. This causes the two slots to be broken in one direction, resulting in confusing behaviour.