### PR TITLE
revert invalidx changes

### DIFF
--- a/src/foam/core/InvalidX.java
+++ b/src/foam/core/InvalidX.java
@@ -6,37 +6,27 @@
 
 package foam.core;
 
-import foam.nanos.logger.Logger;
-
 public class InvalidX
-  extends ProxyX
+  extends AbstractX
 {
-  private X delegate_;
-  private String nspecName_;
-  private Logger logger_;
+  private RuntimeException exception_;
 
-  public InvalidX(X delegate, String nspecName, Logger logger) {
-    super(delegate);
-    delegate_ = delegate;
-    nspecName_ = nspecName;
-    logger_ = logger;
+  public InvalidX(RuntimeException exception) {
+    exception_ = exception;
   }
 
   @Override
   public Object get(X x, Object key) {
-    logger_.warning("Unsafe access to " + nspecName_ + ". Please use .inX() instead.");
-    return super.get(x, key);
+    throw exception_;
   }
 
   @Override
   public X put(Object key, Object value) {
-    logger_.warning("Unsafe access to " + nspecName_ + ". Please use .inX() instead.");
-    return super.put(key, value);
+    throw exception_;
   }
 
   @Override
   public X putFactory(Object key, XFactory factory) {
-    logger_.warning("Unsafe access to " + nspecName_ + ". Please use .inX() instead.");
-    return super.putFactory(key, factory);
+    throw exception_;
   }
 }

--- a/src/foam/nanos/boot/NSpecFactory.java
+++ b/src/foam/nanos/boot/NSpecFactory.java
@@ -47,9 +47,8 @@ public class NSpecFactory
       if ( logger != null ) logger.info("Creating Service", spec_.getName());
       ns_ = spec_.createService(x_.getX().put(NSpec.class, spec_));
       Object ns = ns_;
-      X serviceX = ns instanceof foam.dao.DAO ? new InvalidX(x_.getX(), spec_.getName(), logger) : x_.getX();
       while ( ns != null ) {
-        if (ns instanceof ContextAware) ((ContextAware) ns).setX(serviceX);
+        if (ns instanceof ContextAware) ((ContextAware) ns).setX(x_.getX());
         if (ns instanceof NSpecAware) ((NSpecAware) ns).setNSpec(spec_);
         if (ns instanceof NanoService) ((NanoService) ns).start();
         if (ns instanceof ProxyDAO) {


### PR DESCRIPTION
Problem: getx always returns invalidx for daos created in invalidx even when the caller means to use the system context.
Instead of setting context to invalidx to catch unsafe calls to x, set a unsafeXDao decorator when creating dao services during boot, which will warn only when non-context oriented dao operations are made