### PR TITLE
add prereq logic

### DIFF
--- a/src/foam/nanos/crunch/UserCapabilityJunctionDAO.js
+++ b/src/foam/nanos/crunch/UserCapabilityJunctionDAO.js
@@ -108,7 +108,8 @@ foam.CLASS({
       if ( old != null && old.getStatus() == CapabilityJunctionStatus.GRANTED && ucJunction.getStatus() == CapabilityJunctionStatus.EXPIRED ) 
         return getDelegate().put_(x, ucJunction);
 
-      if ( validateData(x, ucJunction) && checkPrereqs(x, ucJunction) ) {
+      List<CapabilityCapabilityJunction> prereqJunctions = (List<CapabilityCapabilityJunction>) getPrereqs(x, obj);
+      if ( validateData(x, ucJunction) && checkPrereqs(x, ucJunction, prereqJunctions) ) {
         ucJunction.setStatus(CapabilityJunctionStatus.GRANTED);
         saveDataToDAO(x, ucJunction);
         configureJunctionExpiry(x, ucJunction, old);
@@ -202,7 +203,7 @@ foam.CLASS({
       ` 
     },
     {
-      name: 'checkPrereqs',
+      name: 'getPrereqs',
       args: [
         {
           name: 'x',
@@ -213,26 +214,63 @@ foam.CLASS({
           type: 'foam.core.FObject'
         }
       ],
-      type: 'Boolean',
-      documentation: `Check if prerequisites of a capability is fulfilled`,
+      javaType: 'java.util.List<CapabilityCapabilityJunction>',
       javaCode: `
       DAO capabilityDAO = (DAO) x.get("capabilityDAO");
       DAO prerequisiteCapabilityJunctionDAO = (DAO) (x.get("prerequisiteCapabilityJunctionDAO"));
       Capability capability = (Capability) capabilityDAO.find(((UserCapabilityJunction) obj).getTargetId());
 
+      // get a list of the prerequisite junctions where the current capability is the dependent
       List<CapabilityCapabilityJunction> ccJunctions = (List<CapabilityCapabilityJunction>) ((ArraySink) prerequisiteCapabilityJunctionDAO
-      .where(EQ(CapabilityCapabilityJunction.TARGET_ID, (String) capability.getId()))
+      .where(EQ(CapabilityCapabilityJunction.SOURCE_ID, (String) capability.getId()))
       .select(new ArraySink()))
       .getArray();
 
+      // for each of those junctions, assign the user the prerequisite if the user does not already have it
+      for ( CapabilityCapabilityJunction ccJunction : ccJunctions ) {
+        UserCapabilityJunction ucJunction = (UserCapabilityJunction) getDelegate().find(AND(
+          EQ(UserCapabilityJunction.SOURCE_ID, ((UserCapabilityJunction) obj).getSourceId()),
+          EQ(UserCapabilityJunction.TARGET_ID, ((CapabilityCapabilityJunction) ccJunction).getId())));
+        if ( ucJunction == null ) {
+          UserCapabilityJunction junction = new UserCapabilityJunction();
+          junction.setSourceId(((UserCapabilityJunction) obj).getSourceId());
+          junction.setTargetId(((CapabilityCapabilityJunction) ccJunction).getTargetId());
+          ((DAO) x.get("userCapabilityJunctionDAO")).put_(x, junction);
+        }
+      }
+      return ccJunctions;
+      
+      `
+    },
+    {
+      name: 'checkPrereqs',
+      args: [
+        {
+          name: 'x',
+          type: 'Context'
+        },
+        {
+          name: 'obj',
+          type: 'foam.core.FObject'
+        },
+        {
+          name: 'ccJunctions',
+          javaType: 'java.util.List<CapabilityCapabilityJunction>'
+        }
+      ],
+      type: 'Boolean',
+      documentation: `Check if prerequisites of a capability is fulfilled`,
+      javaCode: `
+    
+
+      // for each of those junctions, check if the prerequisite is granted, if not, return false
       for ( CapabilityCapabilityJunction ccJunction : ccJunctions ) {
         Capability cap = (Capability) ((DAO) x.get("capabilityDAO")).find((String) ccJunction.getSourceId());
         if (!cap.getEnabled()) continue;
         UserCapabilityJunction ucJunction = (UserCapabilityJunction) getDelegate().find(AND(
           EQ(UserCapabilityJunction.SOURCE_ID, ((UserCapabilityJunction) obj).getSourceId()),
-          EQ(UserCapabilityJunction.TARGET_ID, (String) ccJunction.getSourceId())
+          EQ(UserCapabilityJunction.TARGET_ID, cap.getId())
         ));
-        
         if ( ucJunction == null || ucJunction.getStatus() != CapabilityJunctionStatus.GRANTED ) return false;
       }
       return true;
@@ -253,11 +291,13 @@ foam.CLASS({
       type: 'Boolean',
       documentation: `call the validate method on data and if not "return true" then set the junction status to pending`,
       javaCode: `
-        try {
-          FObject data = ((UserCapabilityJunction) obj).getData();
-          data.validate(x);
-        } catch(Exception e) {
-          return false;
+        FObject data = ((UserCapabilityJunction) obj).getData();
+        if ( data != null ) {
+          try {
+            data.validate(x);
+          } catch(Exception e) {
+            return false;
+          }
         }
         return true;
       `

--- a/src/foam/nanos/crunch/UserCapabilityJunctionDAO.js
+++ b/src/foam/nanos/crunch/UserCapabilityJunctionDAO.js
@@ -215,14 +215,17 @@ foam.CLASS({
         }
       ],
       javaType: 'java.util.List<CapabilityCapabilityJunction>',
+      documentation: `
+      check the prerequisites of the current capability in the junction. If the user does not have a junction with the 
+      prerequisite capability, set a junction between them.
+      Returns the list of prerequisiteCapabilityJunctions
+      `, 
       javaCode: `
-      DAO capabilityDAO = (DAO) x.get("capabilityDAO");
       DAO prerequisiteCapabilityJunctionDAO = (DAO) (x.get("prerequisiteCapabilityJunctionDAO"));
-      Capability capability = (Capability) capabilityDAO.find(((UserCapabilityJunction) obj).getTargetId());
 
       // get a list of the prerequisite junctions where the current capability is the dependent
       List<CapabilityCapabilityJunction> ccJunctions = (List<CapabilityCapabilityJunction>) ((ArraySink) prerequisiteCapabilityJunctionDAO
-      .where(EQ(CapabilityCapabilityJunction.SOURCE_ID, (String) capability.getId()))
+      .where(EQ(CapabilityCapabilityJunction.SOURCE_ID, ((UserCapabilityJunction) obj).getTargetId()))
       .select(new ArraySink()))
       .getArray();
 
@@ -261,8 +264,6 @@ foam.CLASS({
       type: 'Boolean',
       documentation: `Check if prerequisites of a capability is fulfilled`,
       javaCode: `
-    
-
       // for each of those junctions, check if the prerequisite is granted, if not, return false
       for ( CapabilityCapabilityJunction ccJunction : ccJunctions ) {
         Capability cap = (Capability) ((DAO) x.get("capabilityDAO")).find((String) ccJunction.getSourceId());

--- a/src/foam/nanos/crunch/crunchtest/CapabilityTest.java
+++ b/src/foam/nanos/crunch/crunchtest/CapabilityTest.java
@@ -71,40 +71,12 @@ public class CapabilityTest extends Test {
     p4 = new String("p4");
     p5 = new String("p5");
 
-    // testUserRemovalRule(x);
-    // testCapabilityAuthService(x);
-    // testDeprecatedCapabiltiyJunctionRules(x);
-    // testCapabilityJunctions(x);
-    // testCapability(x);
-
-    User user = new User();
-    user.setFirstName("testuser");
-    user.setId(888);
-    user = (User) userDAO.put_(x, user);
-    Capability dep = new Capability();
-    dep.setId("c1");
-    Capability pre = new Capability();
-    pre.setId("c2");
-    dep = (Capability) capabilityDAO.put(dep);
-    pre = (Capability) capabilityDAO.put(pre);
-
-    CapabilityCapabilityJunction ccjunction = new CapabilityCapabilityJunction();
-    ccjunction.setSourceId(dep.getId());
-    ccjunction.setTargetId(pre.getId());
-    ccjunction = (CapabilityCapabilityJunction) prerequisiteCapabilityJunctionDAO.put_(x, ccjunction);
-
-    UserCapabilityJunction ucjunction = new UserCapabilityJunction();
-    ucjunction.setSourceId(user.getId());
-    ucjunction.setTargetId(dep.getId());
-    ucjunction = (UserCapabilityJunction) userCapabilityJunctionDAO.put_(x, ucjunction);
-
-    List<UserCapabilityJunction> userCapabilityJunctions = (List<UserCapabilityJunction>) ((ArraySink) userCapabilityJunctionDAO
-        .where(EQ(UserCapabilityJunction.SOURCE_ID, user.getId()))
-        .select(new ArraySink()))
-        .getArray();
-
-    test(userCapabilityJunctions.size() > 1, "num of junctions: "+userCapabilityJunctions.size());
-    // testPrerequisiteCapability(x);
+    testPrerequisiteCapability(x);
+    testUserRemovalRule(x);
+    testCapabilityAuthService(x);
+    testDeprecatedCapabiltiyJunctionRules(x);
+    testCapabilityJunctions(x);
+    testCapability(x);
   }
 
   public void testPrerequisiteCapability(X x) {
@@ -134,7 +106,7 @@ public class CapabilityTest extends Test {
         .select(new ArraySink()))
         .getArray();
 
-    test(userCapabilityJunctions.size() > 0, "num of junctions: "+userCapabilityJunctions);
+    test(userCapabilityJunctions.size() > 0, "num of junctions: "+userCapabilityJunctions.size());
   }
 
   public void testUserRemovalRule(X x) {

--- a/src/foam/nanos/crunch/crunchtest/CapabilityTest.java
+++ b/src/foam/nanos/crunch/crunchtest/CapabilityTest.java
@@ -71,11 +71,70 @@ public class CapabilityTest extends Test {
     p4 = new String("p4");
     p5 = new String("p5");
 
-    testUserRemovalRule(x);
-    testCapabilityAuthService(x);
-    testDeprecatedCapabiltiyJunctionRules(x);
-    testCapabilityJunctions(x);
-    testCapability(x);
+    // testUserRemovalRule(x);
+    // testCapabilityAuthService(x);
+    // testDeprecatedCapabiltiyJunctionRules(x);
+    // testCapabilityJunctions(x);
+    // testCapability(x);
+
+    User user = new User();
+    user.setFirstName("testuser");
+    user.setId(888);
+    user = (User) userDAO.put_(x, user);
+    Capability dep = new Capability();
+    dep.setId("c1");
+    Capability pre = new Capability();
+    pre.setId("c2");
+    dep = (Capability) capabilityDAO.put(dep);
+    pre = (Capability) capabilityDAO.put(pre);
+
+    CapabilityCapabilityJunction ccjunction = new CapabilityCapabilityJunction();
+    ccjunction.setSourceId(dep.getId());
+    ccjunction.setTargetId(pre.getId());
+    ccjunction = (CapabilityCapabilityJunction) prerequisiteCapabilityJunctionDAO.put_(x, ccjunction);
+
+    UserCapabilityJunction ucjunction = new UserCapabilityJunction();
+    ucjunction.setSourceId(user.getId());
+    ucjunction.setTargetId(dep.getId());
+    ucjunction = (UserCapabilityJunction) userCapabilityJunctionDAO.put_(x, ucjunction);
+
+    List<UserCapabilityJunction> userCapabilityJunctions = (List<UserCapabilityJunction>) ((ArraySink) userCapabilityJunctionDAO
+        .where(EQ(UserCapabilityJunction.SOURCE_ID, user.getId()))
+        .select(new ArraySink()))
+        .getArray();
+
+    test(userCapabilityJunctions.size() > 1, "num of junctions: "+userCapabilityJunctions.size());
+    // testPrerequisiteCapability(x);
+  }
+
+  public void testPrerequisiteCapability(X x) {
+    User user = new User();
+    user.setFirstName("testuser");
+    user.setId(888);
+    user = (User) userDAO.put_(x, user);
+    Capability dep = new Capability();
+    dep.setId("c1");
+    Capability pre = new Capability();
+    pre.setId("c2");
+    dep = (Capability) capabilityDAO.put(dep);
+    pre = (Capability) capabilityDAO.put(pre);
+
+    CapabilityCapabilityJunction ccjunction = new CapabilityCapabilityJunction();
+    ccjunction.setSourceId(dep.getId());
+    ccjunction.setTargetId(pre.getId());
+    ccjunction = (CapabilityCapabilityJunction) prerequisiteCapabilityJunctionDAO.put_(x, ccjunction);
+
+    UserCapabilityJunction ucjunction = new UserCapabilityJunction();
+    ucjunction.setSourceId(user.getId());
+    ucjunction.setTargetId(dep.getId());
+    ucjunction = (UserCapabilityJunction) userCapabilityJunctionDAO.put_(x, ucjunction);
+
+    List<UserCapabilityJunction> userCapabilityJunctions = (List<UserCapabilityJunction>) ((ArraySink) userCapabilityJunctionDAO
+        .where(EQ(UserCapabilityJunction.SOURCE_ID, user.getId()))
+        .select(new ArraySink()))
+        .getArray();
+
+    test(userCapabilityJunctions.size() > 0, "num of junctions: "+userCapabilityJunctions);
   }
 
   public void testUserRemovalRule(X x) {


### PR DESCRIPTION
problem : When a user is adding a capability that has prerequisites, the userCapabilityJunctionDAO decorator is only checking if the prerequisite is fulfilled when it should be checking if the junction exists between user and prereq, and setting up a junction between them if there isn't one.