### PR TITLE
DO_NOT_MERGE Unsafe xdao

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -277,6 +277,7 @@ FOAM_FILES([
   { name: "foam/dao/NoNeqDAO" },
   { name: "foam/dao/FixedSizeDAO" },
   { name: "foam/dao/PutOnlyDAO" },
+  { name: "foam/dao/UnsafeXDAO" },
   { name: "foam/glang/glang" },
   { name: "foam/parse/QueryParser" },
   { name: "foam/parse/QueryParserUserTest" },

--- a/src/foam/dao/PutOnlyDAO.js
+++ b/src/foam/dao/PutOnlyDAO.js
@@ -43,7 +43,7 @@ foam.CLASS({
         }
       },
       {
-        name: 'removeAll',
+        name: 'removeAll_',
         javaCode: `throw new UnsupportedOperationException("Cannot removeAll from PutOnlyDAO");`,
         swiftCode: `throw FoamError("Cannot removeAll from PutOnlyDAO")`,
         code: function removeAll_() {

--- a/src/foam/dao/UnsafeXDAO.js
+++ b/src/foam/dao/UnsafeXDAO.js
@@ -14,7 +14,6 @@ foam.CLASS({
       name: 'nspecName',
       class: 'String'
     },
-    
     {
       class: 'FObjectProperty',
       of: 'foam.nanos.logger.Logger',
@@ -27,62 +26,76 @@ foam.CLASS({
         return logger;
       `
     },
+    {
+      name: 'xIsSet',
+      class: 'Boolean',
+      javaFactory: ` 
+      return false; 
+      `
+    }
   ],
 
   methods: [
     {
+      name: 'inX',
+      javaCode: `
+      return new ProxyDAO.Builder(x).setDelegate(this.setXIsSet(true)).build();
+      this.setXIsSet(false);
+      `
+    },
+    {
       name: 'find',
       javaCode: `
-      getLogger().warning("Unsafe access : " + getNspecName() + ".find().  Please use context-oriented calls instead.");
+      if ( ! getXIsSet() ) getLogger().warning("Unsafe access : " + getNspecName() + ".find().  Please use context-oriented calls instead.");
       return getDelegate().find(id);
       `
     },
     {
       name: 'put',
       javaCode: `
-      getLogger().warning("Unsafe access : " + getNspecName() + ".put(). Please use context-oriented calls instead.");
+      if ( ! getXIsSet() ) getLogger().warning("Unsafe access : " + getNspecName() + ".put(). Please use context-oriented calls instead.");
       return getDelegate().put(obj);
       `
     },
     {
       name: 'select',
       javaCode: `
-      getLogger().warning("Unsafe access : " + getNspecName() + ".select(). Please use context-oriented calls instead.");
+      if ( ! getXIsSet() ) getLogger().warning("Unsafe access : " + getNspecName() + ".select(). Please use context-oriented calls instead.");
       return getDelegate().select(sink);
       `
     },
     {
       name: 'remove',
       javaCode: `
-      getLogger().warning("Unsafe access : " + getNspecName() + ".remove(). Please use context-oriented calls instead.");
+      if ( ! getXIsSet() ) getLogger().warning("Unsafe access : " + getNspecName() + ".remove(). Please use context-oriented calls instead.");
       return getDelegate().remove(obj);
       `
     },
     {
       name: 'removeAll',
       javaCode: `
-      getLogger().warning("Unsafe access : " + getNspecName() + ".removeAll(). Please use context-oriented calls instead.");
+      if ( ! getXIsSet() ) getLogger().warning("Unsafe access : " + getNspecName() + ".removeAll(). Please use context-oriented calls instead.");
       getDelegate().removeAll();
       `
     },
     {
       name: 'listen',
       javaCode: `
-      getLogger().warning("Unsafe access : " + getNspecName() + ".listen(). Please use context-oriented calls instead.");
+      if ( ! getXIsSet() ) getLogger().warning("Unsafe access : " + getNspecName() + ".listen(). Please use context-oriented calls instead.");
       getDelegate().listen(sink, predicate);
       `
     },
     {
       name: 'pipe',
       javaCode: `
-      getLogger().warning("Unsafe access : " + getNspecName() + ".pipe(). Please use context-oriented calls instead.");
+      if ( ! getXIsSet() ) getLogger().warning("Unsafe access : " + getNspecName() + ".pipe(). Please use context-oriented calls instead.");
       getDelegate().pipe(sink);
       `
     },
     {
       name: 'cmd',
       javaCode: `
-      getLogger().warning("Unsafe access to : " + getNspecName() + ".cmd(). Please use context-oriented calls instead.");
+      if ( ! getXIsSet() ) getLogger().warning("Unsafe access to : " + getNspecName() + ".cmd(). Please use context-oriented calls instead.");
       return getDelegate().cmd(obj);
       `
     }

--- a/src/foam/dao/UnsafeXDAO.js
+++ b/src/foam/dao/UnsafeXDAO.js
@@ -33,56 +33,56 @@ foam.CLASS({
     {
       name: 'find',
       javaCode: `
-      getLogger().warning("Unsafe access to : " + getNspecName() + ". Please use context-oriented calls instead.");
+      getLogger().warning("Unsafe access : " + getNspecName() + ".find().  Please use context-oriented calls instead.");
       return getDelegate().find(id);
       `
     },
     {
       name: 'put',
       javaCode: `
-      getLogger().warning("Unsafe access to : " + getNspecName() + ". Please use context-oriented calls instead.");
+      getLogger().warning("Unsafe access : " + getNspecName() + ".put(). Please use context-oriented calls instead.");
       return getDelegate().put(obj);
       `
     },
     {
       name: 'select',
       javaCode: `
-      getLogger().warning("Unsafe access to : " + getNspecName() + ". Please use context-oriented calls instead.");
+      getLogger().warning("Unsafe access : " + getNspecName() + ".select(). Please use context-oriented calls instead.");
       return getDelegate().select(sink);
       `
     },
     {
       name: 'remove',
       javaCode: `
-      getLogger().warning("Unsafe access to : " + getNspecName() + ". Please use context-oriented calls instead.");
+      getLogger().warning("Unsafe access : " + getNspecName() + ".remove(). Please use context-oriented calls instead.");
       return getDelegate().remove(obj);
       `
     },
     {
       name: 'removeAll',
       javaCode: `
-      getLogger().warning("Unsafe access to : " + getNspecName() + ". Please use context-oriented calls instead.");
+      getLogger().warning("Unsafe access : " + getNspecName() + ".removeAll(). Please use context-oriented calls instead.");
       getDelegate().removeAll();
       `
     },
     {
       name: 'listen',
       javaCode: `
-      getLogger().warning("Unsafe access to : " + getNspecName() + ". Please use context-oriented calls instead.");
+      getLogger().warning("Unsafe access : " + getNspecName() + ".listen(). Please use context-oriented calls instead.");
       getDelegate().listen(sink, predicate);
       `
     },
     {
       name: 'pipe',
       javaCode: `
-      getLogger().warning("Unsafe access to : " + getNspecName() + ". Please use context-oriented calls instead.");
+      getLogger().warning("Unsafe access : " + getNspecName() + ".pipe(). Please use context-oriented calls instead.");
       getDelegate().pipe(sink);
       `
     },
     {
       name: 'cmd',
       javaCode: `
-      getLogger().warning("Unsafe access to : " + getNspecName() + ". Please use context-oriented calls instead.");
+      getLogger().warning("Unsafe access to : " + getNspecName() + ".cmd(). Please use context-oriented calls instead.");
       return getDelegate().cmd(obj);
       `
     }

--- a/src/foam/dao/UnsafeXDAO.js
+++ b/src/foam/dao/UnsafeXDAO.js
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2019 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.dao',
+  name: 'UnsafeXDAO',
+  extends: 'foam.dao.ProxyDAO',
+
+  properties: [
+    {
+      name: 'nspecName',
+      class: 'String'
+    },
+    
+    {
+      class: 'FObjectProperty',
+      of: 'foam.nanos.logger.Logger',
+      name: 'logger',
+      javaFactory: `
+        foam.nanos.logger.Logger logger = (foam.nanos.logger.Logger) getX().get("logger");
+        if ( logger == null ) {
+          logger = new foam.nanos.logger.StdoutLogger();
+        }
+        return logger;
+      `
+    },
+  ],
+
+  methods: [
+    {
+      name: 'find',
+      javaCode: `
+      getLogger().warning("Unsafe access to : " + getNspecName() + ". Please use context-oriented calls instead.");
+      return getDelegate().find(id);
+      `
+    },
+    {
+      name: 'put',
+      javaCode: `
+      getLogger().warning("Unsafe access to : " + getNspecName() + ". Please use context-oriented calls instead.");
+      return getDelegate().put(obj);
+      `
+    },
+    {
+      name: 'select',
+      javaCode: `
+      getLogger().warning("Unsafe access to : " + getNspecName() + ". Please use context-oriented calls instead.");
+      return getDelegate().select(sink);
+      `
+    },
+    {
+      name: 'remove',
+      javaCode: `
+      getLogger().warning("Unsafe access to : " + getNspecName() + ". Please use context-oriented calls instead.");
+      return getDelegate().remove(obj);
+      `
+    },
+    {
+      name: 'removeAll',
+      javaCode: `
+      getLogger().warning("Unsafe access to : " + getNspecName() + ". Please use context-oriented calls instead.");
+      getDelegate().removeAll();
+      `
+    },
+    {
+      name: 'listen',
+      javaCode: `
+      getLogger().warning("Unsafe access to : " + getNspecName() + ". Please use context-oriented calls instead.");
+      getDelegate().listen(sink, predicate);
+      `
+    },
+    {
+      name: 'pipe',
+      javaCode: `
+      getLogger().warning("Unsafe access to : " + getNspecName() + ". Please use context-oriented calls instead.");
+      getDelegate().pipe(sink);
+      `
+    },
+    {
+      name: 'cmd',
+      javaCode: `
+      getLogger().warning("Unsafe access to : " + getNspecName() + ". Please use context-oriented calls instead.");
+      return getDelegate().cmd(obj);
+      `
+    }
+  ]
+});

--- a/src/foam/dao/UnsafeXDAO.js
+++ b/src/foam/dao/UnsafeXDAO.js
@@ -29,9 +29,7 @@ foam.CLASS({
     {
       name: 'xIsSet',
       class: 'Boolean',
-      javaFactory: ` 
-      return false; 
-      `
+      value: false
     }
   ],
 
@@ -39,8 +37,10 @@ foam.CLASS({
     {
       name: 'inX',
       javaCode: `
-      return new ProxyDAO.Builder(x).setDelegate(this.setXIsSet(true)).build();
+      this.setXIsSet(true);
+      ProxyDAO proxy = new ProxyDAO.Builder(x).setDelegate(this).build();
       this.setXIsSet(false);
+      return proxy;
       `
     },
     {

--- a/src/foam/nanos/boot/NSpec.js
+++ b/src/foam/nanos/boot/NSpec.js
@@ -202,6 +202,14 @@ foam.CLASS({
         try {
           shell.set("x", x);
           Object service = shell.eval(getServiceScript());
+
+          if ( service instanceof foam.dao.DAO ) {
+            service = new foam.dao.UnsafeXDAO.Builder(x)
+              .setDelegate((DAO) service)
+              .setNspecName(getName())
+              .build();
+          }
+
           saveService(x, service);
           return service;
         } catch (EvalError e) {

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -161,6 +161,7 @@ var classes = [
   'foam.dao.PMDAO',
   'foam.nanos.pm.PMInfo',
   'foam.dao.PutOnlyDAO',
+  'foam.dao.UnsafeXDAO',
   'foam.mlang.order.Comparator',
   'foam.mlang.order.Desc',
   'foam.mlang.sink.Count',


### PR DESCRIPTION
This pr is meant to log a warning when developers do not use context-oriented methods when reading/writing from a dao. 
However this is still failing 2 tests, and in practice there are too many warnings logged to merge this.
Will come back to it when I have some extra time but it is low priority