### PR TITLE
Capability improvement

### DIFF
--- a/src/foam/box/SessionServerBox.java
+++ b/src/foam/box/SessionServerBox.java
@@ -85,7 +85,6 @@ public class SessionServerBox
           logger.warning("Remote host for session ", sessionID, " changed from ", session.getRemoteHost(), " to ", req.getRemoteHost(), ". Deleting session and forcing the user to sign in again.");
           sessionDAO.remove(session);
           msg.replyWithException(new AuthenticationException("IP address changed. Your session was deleted to keep your account secure. Please sign in again to verify your identity."));
-          return;
         }
       }
 

--- a/src/foam/nanos/auth/CapabilityAuthService.js
+++ b/src/foam/nanos/auth/CapabilityAuthService.js
@@ -72,7 +72,8 @@ foam.CLASS({
 
         for ( UserCapabilityJunction ucJunction : userCapabilityJunctions ) {
           Capability capability = (Capability) capabilityDAO.find(ucJunction.getTargetId());
-          if ( capability.implies(x, permission) && ! capability.isDeprecated(x) ) return true;
+          if ( capability.isDeprecated(x) ) continue;
+          if ( capability.implies(x, permission) ) return true;
         }
       } catch (Exception e) {
         Logger logger = (Logger) x.get("logger");


### PR DESCRIPTION
Noticed we're running our implied method on capabilities before checking its deprecated state.
The implies method can extend to any process making the call time consuming - it'd be better to check its deprecated state and continue to the next iteration before the call is made.