### PR TITLE
[CPF-3206] Remove ANSI colour escapes and control characters prior to JSON output

### DIFF
--- a/src/foam/lib/json/Outputter.java
+++ b/src/foam/lib/json/Outputter.java
@@ -12,6 +12,7 @@ import foam.core.FObject;
 import foam.core.PropertyInfo;
 import foam.dao.AbstractSink;
 import foam.lib.PermissionedPropertyPredicate;
+import foam.lib.PropertyPredicate;
 import foam.util.SafetyUtil;
 import java.io.*;
 import java.lang.reflect.Array;

--- a/src/foam/lib/json/Outputter.java
+++ b/src/foam/lib/json/Outputter.java
@@ -129,14 +129,17 @@ public class Outputter
   public String escapeControlCharacters(String s) {
     int lastStart = 0;
     String escapedString = "";
-    for ( int i=0; i < s.length(); i++ ) {
-      if ( s.charAt(i) >= ' ' ) continue;
-      char c = s.charAt(i);
+    char c;
+    for ( int i = 0; i < s.length(); i++ ) {
+      c = s.charAt(i);
+      if ( c >= ' ' ) continue;
       // Character to hex
       char right = (char) (c & 0x0F);
       char left = (char) ((c & 0xF0) >> 4);
-      right += '0'; if ( right > '9' ) right += 'A' - '9' - 1;
-      left += '0'; if ( left > '9' ) left += 'A' - '9' - 1;
+      right += '0';
+      if ( right > '9' ) right += 'A' - '9' - 1;
+      left += '0';
+      if ( left > '9' ) left += 'A' - '9' - 1;
       char[] escape = new char[] {'\\','u','0','0',left,right};
       // Add previous string segment
       escapedString += s.substring(lastStart, i);

--- a/src/foam/lib/json/Outputter.java
+++ b/src/foam/lib/json/Outputter.java
@@ -111,6 +111,8 @@ public class Outputter
   }
 
   public String escape(String s) {
+    s = removeColour(s);
+    s = removeControlCharacters(s);
     return s.replace("\\", "\\\\")
             .replace("\"", "\\\"")
             .replace("\t", "\\t")
@@ -119,7 +121,41 @@ public class Outputter
   }
 
   public String escapeMultiline(String s) {
+    s = removeColour(s);
+    s = removeControlCharacters(s);
     return s.replace("\\", "\\\\");
+  }
+
+  // TODO: This does not cover all possible ANSI escape codes yet
+  public String removeColour(String s) {
+    int lastStart = 0;
+    int exitMode = 0; // 0 -> string, 1 -> colour
+    String noColourString = "";
+    for ( int i=0; i < s.length()-2; i++ ) {
+      if ( s.charAt(i) != 033 || s.charAt(i+1) != '[' ) continue;
+      noColourString += s.substring(lastStart, i);
+      for (;;) if ( ++i == s.length() ) {
+        exitMode = 1;
+        break;
+      } else if ( s.charAt(i) == 'm' ) {
+        lastStart = i+1;
+        break;
+      }
+    }
+    if ( exitMode == 0 ) {
+      noColourString += s.substring(lastStart, s.length());
+    }
+    return noColourString;
+  }
+
+  public String removeControlCharacters(String s) {
+    char[] ca = s.toCharArray();
+    char[] caNew = new char[ca.length];
+    int j = 0;
+    for ( int i=0; i < ca.length; i++ ) {
+        if ( ca[i] >= ' ' ) caNew[j++] = ca[i];
+    }
+    return new String(caNew).substring(0,j);
   }
 
   protected void outputNumber(Number value) {

--- a/src/foam/lib/json/Outputter.java
+++ b/src/foam/lib/json/Outputter.java
@@ -12,16 +12,14 @@ import foam.core.FObject;
 import foam.core.PropertyInfo;
 import foam.dao.AbstractSink;
 import foam.lib.PermissionedPropertyPredicate;
-import foam.lib.PropertyPredicate;
 import foam.util.SafetyUtil;
 import java.io.*;
 import java.lang.reflect.Array;
 import java.text.SimpleDateFormat;
-import java.util.*;
 import java.util.Iterator;
 import java.util.List;
+import java.util.*;
 import org.apache.commons.io.IOUtils;
-
 
 public class Outputter
   extends AbstractSink

--- a/src/foam/lib/json/Outputter.java
+++ b/src/foam/lib/json/Outputter.java
@@ -112,18 +112,20 @@ public class Outputter
 
   public String escape(String s) {
     s = removeColour(s);
-    s = removeControlCharacters(s);
-    return s.replace("\\", "\\\\")
+    s = s.replace("\\", "\\\\")
             .replace("\"", "\\\"")
             .replace("\t", "\\t")
             .replace("\r","\\r")
             .replace("\n","\\n");
+    s = removeControlCharacters(s);
+    return s;
   }
 
   public String escapeMultiline(String s) {
     s = removeColour(s);
+    s = s.replace("\\", "\\\\");
     s = removeControlCharacters(s);
-    return s.replace("\\", "\\\\");
+    return s;
   }
 
   // TODO: This does not cover all possible ANSI escape codes yet


### PR DESCRIPTION
Outputting ANSI colour escapes through the logger causes invalid JSON to be sent when logs are requested by the browser. Additionally, this reveals that control characters are not being removed from strings when they're serialized.

This PR removes ANSI colour escapes, then remaining control characters, prior to calling the existing escape functionality.