### PR TITLE
Fixing JS factory method exception in Group create

### DIFF
--- a/src/foam/nanos/auth/Group.js
+++ b/src/foam/nanos/auth/Group.js
@@ -13,7 +13,10 @@ foam.CLASS({
     'foam.nanos.auth.EnabledAware'
   ],
 
-  requires: [ 'foam.nanos.app.AppConfig' ],
+  requires: [ 
+    'foam.nanos.app.AppConfig',
+    'foam.nanos.auth.PasswordPolicy'
+  ],
 
   documentation: 'A Group of Users.',
 


### PR DESCRIPTION
The reference in the JS factory wasn't working because the PasswordPolicy was not required.