### PR TITLE
Change permissions to be consistent across system

### DIFF
--- a/src/foam/nanos/auth/StandardAuthorizer.java
+++ b/src/foam/nanos/auth/StandardAuthorizer.java
@@ -75,7 +75,7 @@ public class StandardAuthorizer implements Authorizer {
   }
 
   public boolean checkGlobalRead(X x) {
-    String permission = createPermission("read");
+    String permission = createPermission("read", "*");
     AuthService authService = (AuthService) x.get("auth");
     try {
       return authService.check(x, permission);
@@ -85,7 +85,7 @@ public class StandardAuthorizer implements Authorizer {
   }
 
   public boolean checkGlobalRemove(X x) {
-    String permission = createPermission("remove");
+    String permission = createPermission("remove", "*");
     AuthService authService = (AuthService) x.get("auth");
     try {
       return authService.check(x, permission);


### PR DESCRIPTION
The `StandardAuthorizer` was treating `<model>.read` as a global read permission instead of `<model>.read.*`, which the rest of the system uses. This PR fixes that inconsistency and lets users in groups with `<model>.read.*` permissions take advantage of the huge performance improvement that performing one global read check instead of individual checks on each item provides.