### PR TITLE
Fix bug where mode was being lost

### DIFF
--- a/src/foam/u2/view/ModeAltView.js
+++ b/src/foam/u2/view/ModeAltView.js
@@ -55,12 +55,18 @@ foam.CLASS({
           case self.DisplayMode.RW:
           case self.DisplayMode.DISABLED:
             return self.E()
-              .start(self.writeView, { data$: self.data$ })
+              .start(self.writeView, {
+                data$: self.data$,
+                mode: mode
+              })
                 .call(callFromProperty)
               .end();
           case self.DisplayMode.RO:
             return self.E()
-              .start(self.readView, { data$: self.data$ })
+              .start(self.readView, {
+                data$: self.data$,
+                mode: mode
+              })
                 .call(callFromProperty)
               .end();
           case self.DisplayMode.HIDDEN:


### PR DESCRIPTION
ModeAltView was "consuming" the mode for views of properties and not
passing that mode on to the child views. This caused a bug where write
views that we expected to be in DISABLED mode would be in RW mode
instead.