### PR TITLE
Fix MLang Predicate GUI

### DIFF
--- a/src/foam/u2/view/FObjectArrayView.js
+++ b/src/foam/u2/view/FObjectArrayView.js
@@ -17,7 +17,9 @@ foam.CLASS({
     {
       name: 'defaultNewItem',
       expression: function(of) {
-        return of.create();
+        return foam.core.InterfaceModel.isInstance(of.model_)
+          ? null
+          : of.create();
       }
     },
     {


### PR DESCRIPTION
Trying to create a predicate results in an error being thrown because
'of' is an interface, not a concrete class. When you call `.create()` on
an interface it throws an error.