### PR TITLE
Fix crashing PropertyExpr view

### DIFF
--- a/src/foam/mlang/expr/PropertyExpr.js
+++ b/src/foam/mlang/expr/PropertyExpr.js
@@ -27,15 +27,9 @@ foam.CLASS({
       factory: function() {
         return this.property ? this.property.forClass_ : null;
       },
-      view: function(_, X) {
-        var choicesSlot = foam.core.SimpleSlot.create({ value: [] });
-        X.strategizer.query(null, 'foam.Class').then((strategyReferences) => {
-          choicesSlot.set([[null, 'Select...']].concat(strategyReferences.map((sr) => [sr.strategy, sr.strategy.name])));
-        });
-        return {
-          class: 'foam.u2.view.ChoiceView',
-          choices$: choicesSlot
-        };
+      view: {
+        class: 'foam.u2.view.StrategizerChoiceView',
+        desiredModelId: 'foam.Class'
       }
     },
     {

--- a/src/foam/u2/view/StrategizerChoiceView.js
+++ b/src/foam/u2/view/StrategizerChoiceView.js
@@ -49,7 +49,7 @@ foam.CLASS({
               }
 
               return arr.concat([[sr.strategy.id, sr.strategy.name]]);
-            }, [])
+            }, [[null, 'Select...']])
             .filter(x => x);
         })
       }


### PR DESCRIPTION
* Fix bug where PropertyExpr view would crash
  * The view would throw an error if an invalid StrategyReference were
returned from a call to Strategizer.query. After I had written the view
for PropertyExpr.model, I ended up adding StrategizerChoiceView, which
does the same thing, but also gracefully handles invalid
StrategyReferences by logging a warning and continuing rather than
throwning an Exception.
  * So changing the view to StrategizerChoiceView has two benefits, it fixes
the crash and it simplifies the code.
* Add a default/null option to StrategizerChoiceView
  * To stay consistent with previous behaviour of view for PropertyExpr