### PR TITLE
Remove AuthService.checkUserPermission method

### DIFF
--- a/src/foam/nanos/auth/AuthService.js
+++ b/src/foam/nanos/auth/AuthService.js
@@ -25,7 +25,6 @@ foam.INTERFACE({
     and the methods relating to authorization are:
 
       * check
-      * checkUserPermission
       * checkUser
   `,
 
@@ -169,33 +168,6 @@ foam.INTERFACE({
         {
           name: 'permission',
           type: 'String'
-        }
-      ]
-    },
-    // TODO: Remove this. We just need one method that checks a permission
-    // string. We don't need a second method that works for
-    // java.security.Permissions specifically.
-    {
-      name: 'checkUserPermission',
-      documentation: `
-        Like the 'checkUser' method, but with a different type for the third
-        method.
-      `,
-      type: 'Boolean',
-      async: true,
-      swiftThrows: true,
-      args: [
-        {
-          name: 'x',
-          type: 'Context'
-        },
-        {
-          name: 'user',
-          type: 'foam.nanos.auth.User'
-        },
-        {
-          name: 'permission',
-          javaType: 'java.security.Permission'
         }
       ]
     },

--- a/src/foam/nanos/auth/CapabilityAuthService.js
+++ b/src/foam/nanos/auth/CapabilityAuthService.js
@@ -26,7 +26,6 @@ foam.CLASS({
     'foam.nanos.session.Session',
     'java.util.Date',
     'java.util.List',
-    'javax.security.auth.AuthPermission',
     'static foam.mlang.MLang.*'
   ],
 

--- a/src/foam/nanos/auth/CapabilityAuthService.js
+++ b/src/foam/nanos/auth/CapabilityAuthService.js
@@ -51,52 +51,54 @@ foam.CLASS({
         implied by a capability in userCapabilityJunctions for a given user.
       `,
       javaCode: `
-      if ( x == null || permission == null ) return false;
-      if ( x.get(Session.class) == null ) return false;
-      if ( user == null || ! user.getEnabled() ) return false;
-      
-      // Check whether user has permission to check user permissions.
-      if ( ! getDelegate().check(x, "service.auth.checkUser") ) return false;
+        if ( x == null || permission == null ) return false;
+        if ( x.get(Session.class) == null ) return false;
+        if ( user == null || ! user.getEnabled() ) return false;
 
-      try {
-        DAO capabilityDAO = (DAO) x.get("capabilityDAO");
+        // Check whether user has permission to check user permissions.
+        if ( ! getDelegate().check(x, "service.auth.checkUser") ) return false;
 
-        Capability cap = (Capability) capabilityDAO.find(permission);
-        if ( cap != null && cap.isDeprecated(x) ) return getDelegate().checkUser(x, user, permission);
+        try {
+          DAO capabilityDAO = (DAO) x.get("capabilityDAO");
 
-        Date now = new Date();
-        Predicate capabilityScope = AND(
-          EQ(UserCapabilityJunction.SOURCE_ID, user.getId()),
-          OR(
-            NOT(HAS(UserCapabilityJunction.EXPIRY)),
-            NOT(EQ(UserCapabilityJunction.STATUS, CapabilityJunctionStatus.EXPIRED))
-          )
-        );
+          Capability cap = (Capability) capabilityDAO.find(permission);
+          if ( cap != null && cap.isDeprecated(x) ) return getDelegate().checkUser(x, user, permission);
 
-        DAO userCapabilityJunctionDAO = (DAO) x.get("userCapabilityJunctionDAO");
+          Date now = new Date();
+          Predicate capabilityScope = AND(
+            EQ(UserCapabilityJunction.SOURCE_ID, user.getId()),
+            OR(
+              NOT(HAS(UserCapabilityJunction.EXPIRY)),
+              NOT(EQ(UserCapabilityJunction.STATUS, CapabilityJunctionStatus.EXPIRED))
+            )
+          );
 
-        if ( userCapabilityJunctionDAO.find(
-          AND(
-            capabilityScope,
-            EQ(UserCapabilityJunction.TARGET_ID, permission),
-            EQ(UserCapabilityJunction.STATUS, CapabilityJunctionStatus.GRANTED)
-          )) != null ) return true;
-        
-        List<UserCapabilityJunction> userCapabilityJunctions = ((ArraySink) user.getCapabilities(x).getJunctionDAO()
-          .where(capabilityScope)
-          .select(new ArraySink())).getArray();
+          DAO userCapabilityJunctionDAO = (DAO) x.get("userCapabilityJunctionDAO");
 
-        for ( UserCapabilityJunction ucJunction : userCapabilityJunctions ) {
-          Capability capability = (Capability) capabilityDAO.find(ucJunction.getTargetId());
-          if ( capability.isDeprecated(x) ) continue;
-          if ( capability.implies(x, permission) ) return true;
+          if ( userCapabilityJunctionDAO.find(
+            AND(
+              capabilityScope,
+              EQ(UserCapabilityJunction.TARGET_ID, permission),
+              EQ(UserCapabilityJunction.STATUS, CapabilityJunctionStatus.GRANTED)
+            )) != null ) return true;
+
+          List<UserCapabilityJunction> userCapabilityJunctions = ((ArraySink) user.getCapabilities(x).getJunctionDAO()
+            .where(capabilityScope)
+            .select(new ArraySink())).getArray();
+
+          for ( UserCapabilityJunction ucJunction : userCapabilityJunctions ) {
+            Capability capability = (Capability) capabilityDAO.find(ucJunction.getTargetId());
+            if ( capability.isDeprecated(x) ) continue;
+            if ( capability.implies(x, permission) ) return true;
+          }
+        } catch (Exception e) {
+          Logger logger = (Logger) x.get("logger");
+          logger.error("check", permission, e);
         }
-      } catch (Exception e) {
-        Logger logger = (Logger) x.get("logger");
-        logger.error("check", permission, e);
       } 
+        }
 
-      return getDelegate().checkUser(x, user, permission);
+        return getDelegate().checkUser(x, user, permission);
       `
     },
     {

--- a/src/foam/nanos/auth/CapabilityAuthService.js
+++ b/src/foam/nanos/auth/CapabilityAuthService.js
@@ -94,16 +94,8 @@ foam.CLASS({
           Logger logger = (Logger) x.get("logger");
           logger.error("check", permission, e);
         }
-      } 
-        }
 
         return getDelegate().checkUser(x, user, permission);
-      `
-    },
-    {
-      name: 'checkUserPermission',
-      javaCode: `
-      return checkUser( x, user, permission.getName() );
       `
     }
   ]

--- a/src/foam/nanos/auth/UserAndGroupAuthService.js
+++ b/src/foam/nanos/auth/UserAndGroupAuthService.js
@@ -39,6 +39,7 @@ foam.CLASS({
     'foam.util.Password',
     'foam.util.SafetyUtil',
 
+    'java.security.Permission',
     'java.util.Calendar',
     'java.util.regex.Pattern',
     'javax.security.auth.AuthPermission',
@@ -223,7 +224,7 @@ foam.CLASS({
       javaCode: `
         if ( x == null || permission == null ) return false;
 
-        java.security.Permission p = new AuthPermission(permission);
+        Permission p = new AuthPermission(permission);
 
         try {
           Group group = getCurrentGroup(x);

--- a/src/foam/nanos/auth/UserAndGroupAuthService.js
+++ b/src/foam/nanos/auth/UserAndGroupAuthService.js
@@ -185,7 +185,7 @@ foam.CLASS({
       `
     },
     {
-      name: 'checkUserPermission',
+      name: 'checkUser',
       documentation: `Checks if the user passed into the method has the passed
         in permission attributed to it by checking their group. No check on User
         and group enabled flags.`,
@@ -276,12 +276,6 @@ foam.CLASS({
 
         // Validate the password against the password policy
         passwordPolicy.validate(user, potentialPassword);
-      `
-    },
-    {
-      name: 'checkUser',
-      javaCode: `
-        return checkUserPermission(x, user, new AuthPermission(permission));
       `
     },
     {

--- a/src/foam/nanos/auth/UserAndGroupAuthService.js
+++ b/src/foam/nanos/auth/UserAndGroupAuthService.js
@@ -206,7 +206,7 @@ foam.CLASS({
             if ( group == null ) break;
 
             // check permission
-            if ( group.implies(x, permission) ) return true;
+            if ( group.implies(x, new AuthPermission(permission)) ) return true;
 
             // check parent group
             groupId = group.getParent();


### PR DESCRIPTION
Resolves this comment:

```
    // TODO: Remove this. We just need one method that checks a permission	
    // string. We don't need a second method that works for	
    // java.security.Permissions specifically.
```