### PR TITLE
Run OrderedSink before PredicatedSink to improve performance

### DIFF
--- a/src/foam/dao/AbstractDAO.js
+++ b/src/foam/dao/AbstractDAO.js
@@ -594,12 +594,12 @@ if ( ( skip > 0 ) && ( skip < AbstractDAO.MAX_SAFE_INTEGER ) ) {
   sink = new SkipSink(skip, 0, sink);
 }
 
-if ( order != null ) {
-  sink = new OrderedSink(order, null, sink);
-}
-
 if ( predicate != null && predicate.partialEval() != null && ! ( predicate instanceof foam.mlang.predicate.True) ) {
   sink = new PredicatedSink(predicate, sink);
+}
+
+if ( order != null ) {
+  sink = new OrderedSink(order, null, sink);
 }
 
 return sink;


### PR DESCRIPTION
This change was benchmarked with contactDAO. contactDAO was populated with 50k entries, and then a 1000 iterations of the following query were run for each trial:
```
 contactDAO
      .orderBy(new foam.mlang.order.Desc(Contact.ID))
      .limit(500)
      .select(new ArraySink());
```

Results were as follows:

### Prior to the change
trial1: 7.8ms avg
trial2: 7.1ms avg
trial3: 8.8ms avg

### After the change
trial1: 6.7ms avg
trial2: 5.8ms avg
trial3: 6.7ms avg

Credit to @TW80000 for coming up with a theory that this will boost performance