### PR TITLE
Let user select class to create in DAO controller

### DIFF
--- a/src/foam/comics/BrowserView.js
+++ b/src/foam/comics/BrowserView.js
@@ -148,9 +148,8 @@ foam.CLASS({
     // This is the DAOCreateControllerView, not the DetailView
     'createControllerView',
     {
-      class: 'String',
-      name: 'detailView',
-      value: 'foam.u2.DetailView'
+      class: 'foam.u2.ViewSpec',
+      name: 'detailView'
     }
   ],
 

--- a/src/foam/comics/DAOController.js
+++ b/src/foam/comics/DAOController.js
@@ -176,9 +176,14 @@ foam.CLASS({
       `
     },
     {
-      class: 'String',
+      class: 'foam.u2.ViewSpec',
       name: 'detailView',
-      value: 'foam.u2.DetailView'
+      factory: function() {
+        return {
+          class: 'foam.u2.view.FObjectView',
+          of: this.data.of
+        };
+      }
     },
     'selectedObjects'
   ],

--- a/src/foam/comics/DAOCreateControllerView.js
+++ b/src/foam/comics/DAOCreateControllerView.js
@@ -70,7 +70,7 @@ foam.CLASS({
       }
     },
     {
-      class: 'String',
+      class: 'foam.u2.ViewSpec',
       name: 'detailView'
     }
   ],
@@ -108,8 +108,7 @@ foam.CLASS({
         // Container for the detailview
         .start()
           .addClass(this.myClass('detail-container'))
-          .tag({
-            class: this.detailView,
+          .tag(this.detailView, {
             of: this.dao.of,
             data$: this.data$.dot('data')
           })

--- a/src/foam/nanos/menu/DAOMenu.js
+++ b/src/foam/nanos/menu/DAOMenu.js
@@ -63,9 +63,8 @@ foam.CLASS({
       }
     },
     {
-      class: 'String',
+      class: 'foam.u2.ViewSpec',
       name: 'detailView',
-      value: 'foam.u2.DetailView',
       displayWidth: 80
     },
     {

--- a/src/foam/u2/view/FObjectView.js
+++ b/src/foam/u2/view/FObjectView.js
@@ -52,6 +52,10 @@ foam.CLASS({
         } else if ( data.cls_.id != this.objectClass ) {
           this.objectClass = data.cls_.id;
         }
+      },
+      view: {
+        class: 'foam.u2.view.FObjectPropertyView',
+        writeView: { class: 'foam.u2.detail.SectionedDetailView' }
       }
     },
     {


### PR DESCRIPTION
This commit changes the default detailView for the DAO Controller to
FObjectView instead of DetailView. This allows the user to select the
class that they want to create an instance of.

Since FObjectView's class dropdown is populated by the Strategizer, one
can add StrategyReferences to populate the dropdown. If there are no
alternative strategies for the model being created, then the field to
select the class will be hidden and the base class will be used, (the
'of' of the DAO being controlled), which is consistent with the current
behaviour.