### PR TITLE
Fix bug where objects couldn't be updated via DAO Controller

### DIFF
--- a/src/foam/comics/BrowserView.js
+++ b/src/foam/comics/BrowserView.js
@@ -116,8 +116,8 @@ foam.CLASS({
         if ( searchMode )  config.searchMode  = searchMode;
         if ( subtitle )    config.subtitle    = subtitle;
         if ( title )       config.title       = title;
+        if ( detailView )  config.detailView  = detailView;
         config.createEnabled = createEnabled;
-        config.detailView    = detailView;
         config.editEnabled   = editEnabled;
         config.exportEnabled = exportEnabled;
         config.exportCSVEnabled = exportCSVEnabled;

--- a/src/foam/comics/DAOController.js
+++ b/src/foam/comics/DAOController.js
@@ -180,7 +180,7 @@ foam.CLASS({
       name: 'detailView',
       factory: function() {
         return {
-          class: 'foam.u2.view.FObjectView',
+          class: 'foam.u2.detail.SectionedDetailView',
           of: this.data.of
         };
       }

--- a/src/foam/comics/DAOCreateControllerView.js
+++ b/src/foam/comics/DAOCreateControllerView.js
@@ -108,9 +108,11 @@ foam.CLASS({
         // Container for the detailview
         .start()
           .addClass(this.myClass('detail-container'))
-          .tag(this.detailView, {
+          .tag({
+            class: 'foam.u2.view.FObjectView',
             of: this.dao.of,
-            data$: this.data$.dot('data')
+            data$: this.data$.dot('data'),
+            dataView: this.detailView
           })
         .end();
     }

--- a/src/foam/comics/DAOUpdateControllerView.js
+++ b/src/foam/comics/DAOUpdateControllerView.js
@@ -85,7 +85,7 @@ foam.CLASS({
       }
     },
     {
-      class: 'String',
+      class: 'foam.u2.ViewSpec',
       name: 'detailView'
     },
     {
@@ -154,12 +154,11 @@ foam.CLASS({
         // Container for the detailview
         .start('div', [], this.container_$)
           .addClass(this.myClass('detail-container'))
-          .tag({
-            class: this.detailView,
+          .tag(this.detailView, {
             of: this.dao.of,
             data$: this.data$.dot('obj'),
             showActions: true
-          }, [], this.detailViewElement_$)
+          }, this.detailViewElement_$)
         .end();
     }
   ],
@@ -178,12 +177,11 @@ foam.CLASS({
       },
       code: function() {
         this.controllerMode = this.ControllerMode.EDIT;
-        var newE = this.container_.createChild_({
-          class: this.detailView,
+        var newE = this.container_.createChild_(this.detailView, {
           of: this.dao.of,
           data$: this.data$.dot('obj'),
           showActions: true
-        }, []);
+        });
         this.container_.replaceChild(newE, this.detailViewElement_);
         this.detailViewElement_ = newE;
       }

--- a/src/foam/u2/view/FObjectView.js
+++ b/src/foam/u2/view/FObjectView.js
@@ -53,10 +53,14 @@ foam.CLASS({
           this.objectClass = data.cls_.id;
         }
       },
-      view: {
-        class: 'foam.u2.view.FObjectPropertyView',
-        writeView: { class: 'foam.u2.detail.SectionedDetailView' }
+      view: function(args, X) {
+        return X.data.dataView || { class: 'foam.u2.view.FObjectPropertyView' }
       }
+    },
+    {
+      class: 'foam.u2.ViewSpec',
+      name: 'dataView',
+      documentation: 'Set this to change the view of the FObject being created.'
     },
     {
       class: 'Class',


### PR DESCRIPTION
## High Level

I had only tested create yesterday, not viewing or updating, and
because of that I didn't realize that my changes had broken viewing and
editing via the GUI.

This commit fixes the issue.

## Technical

Now we only use FObjectView in the create controller, not the update
controller. This allows users to select the subclass when creating a new
instance, but not when editing an existing object.

To respect the DAO Controller's feature of a custom detail view, this
commit updates FObjectView so that it supports changing the view used
for the FObject. In DAOCreateControllerView we set that view to the
custom detail view for the DAO controller if it's available.