### PR TITLE
when mode is RO or DISABLED, the label should not clickable

### DIFF
--- a/src/foam/u2/CheckBox.js
+++ b/src/foam/u2/CheckBox.js
@@ -56,6 +56,7 @@ foam.CLASS({
                       this.labelFormatter,
                       function() { this.add(self.label$); })
           .on('click', function() {
+          if (self.mode === foam.u2.DisplayMode.RO || self.mode === foam.u2.DisplayMode.DISABLED) return;
             this.data = ! this.data;
           }.bind(this))
         .end();

--- a/src/foam/u2/CheckBox.js
+++ b/src/foam/u2/CheckBox.js
@@ -56,7 +56,7 @@ foam.CLASS({
                       this.labelFormatter,
                       function() { this.add(self.label$); })
           .on('click', function() {
-          if (self.mode === foam.u2.DisplayMode.RO || self.mode === foam.u2.DisplayMode.DISABLED) return;
+            if ( self.getAttribute('disabled') ) return;
             this.data = ! this.data;
           }.bind(this))
         .end();


### PR DESCRIPTION
origin ticket address:  https://nanopay.atlassian.net/browse/CPF-3393
change: add condition to the click event, when the mode for checkbox is RO or DISABLED, the label should unclickable.
@TW80000 
@jlhughes 