### PR TITLE
Cron UI and FObjectView improvements

### DIFF
--- a/src/foam/nanos/cron/Cron.js
+++ b/src/foam/nanos/cron/Cron.js
@@ -42,7 +42,6 @@ foam.CLASS({
       class: 'FObjectProperty',
       of: 'foam.nanos.cron.Schedule',
       name: 'schedule',
-      view: { class: 'foam.u2.DetailView' },
       section: 'scheduling',
       javaFactory: `return new CronSchedule.Builder(getX()).build();`
     },

--- a/src/foam/nanos/cron/TimeHMS.js
+++ b/src/foam/nanos/cron/TimeHMS.js
@@ -14,8 +14,20 @@ foam.CLASS({
   `,
 
   properties: [
-    { name: 'hour',   class: 'Int' },
-    { name: 'minute', class: 'Int' },
-    { name: 'second', class: 'Int' }
+    {
+      class: 'Int',
+      name: 'hour',
+      gridColumns: 4
+    },
+    {
+      class: 'Int',
+      name: 'minute',
+      gridColumns: 4
+    },
+    {
+      class: 'Int',
+      name: 'second',
+      gridColumns: 4
+    }
   ]
 });

--- a/src/foam/nanos/cron/strategyReferences.jrl
+++ b/src/foam/nanos/cron/strategyReferences.jrl
@@ -1,0 +1,30 @@
+p({
+  "class": "foam.strategy.StrategyReference",
+  "id": "179551cb-2c89-4f86-9eeb-03219a822723",
+  "desiredModelId": "foam.nanos.cron.Schedule",
+  "strategy": "foam.nanos.cron.OrSchedule"
+})
+p({
+  "class": "foam.strategy.StrategyReference",
+  "id": "1ffe9179-85ea-4b9b-98cf-5e468fb850cc",
+  "desiredModelId": "foam.nanos.cron.Schedule",
+  "strategy": "foam.nanos.cron.CronSchedule"
+})
+p({
+  "class": "foam.strategy.StrategyReference",
+  "id": "28dda8d3-4b9c-49e0-8e27-8e02eb2adb39",
+  "desiredModelId": "foam.nanos.cron.Schedule",
+  "strategy": "foam.nanos.cron.NeverSchedule"
+})
+p({
+  "class": "foam.strategy.StrategyReference",
+  "id": "5d9a7dea-4385-47f5-9689-9cba577b179e",
+  "desiredModelId": "foam.nanos.cron.Schedule",
+  "strategy": "foam.nanos.cron.IntervalSchedule"
+})
+p({
+  "class": "foam.strategy.StrategyReference",
+  "id": "9428957b-69e7-4ec5-94e8-81160f77d773",
+  "desiredModelId": "foam.nanos.cron.Schedule",
+  "strategy": "foam.nanos.cron.TimeOfDaySchedule"
+})

--- a/src/foam/u2/view/ChoiceView.js
+++ b/src/foam/u2/view/ChoiceView.js
@@ -269,7 +269,8 @@ foam.CLASS({
       code: function() {
         var d = this.data;
         if ( this.choices.length ) {
-          this.choice = ( d != null && this.findChoiceByData(d) ) || this.defaultValue;
+          var choice = this.findChoiceByData(d);
+          this.choice = choice === null ? this.findChoiceByData(this.defaultValue) : choice;
         }
       }
     },

--- a/src/foam/u2/view/FObjectPropertyView.js
+++ b/src/foam/u2/view/FObjectPropertyView.js
@@ -23,7 +23,12 @@ foam.CLASS({
     },
     {
       name: 'writeView',
-      value: { class: 'foam.u2.detail.VerticalDetailView' }
+      factory: function() {
+        return {
+          class: 'foam.u2.view.FObjectView',
+          of: this.prop.of
+        }
+      }
     }
   ],
 });

--- a/src/foam/u2/view/FObjectView.js
+++ b/src/foam/u2/view/FObjectView.js
@@ -57,8 +57,11 @@ foam.CLASS({
           this.objectClass = data.cls_.id;
         }
       },
+      // We need to override the default view, otherwise we end up with a
+      // circular definition where FObjectView has an FObjectProperty which gets
+      // rendered as an FObjectView, which leads to infinite recursion.
       view: function(args, X) {
-        return X.data.dataView || { class: 'foam.u2.view.FObjectPropertyView' }
+        return X.data.dataView || { class: 'foam.u2.detail.SectionedDetailView' }
       }
     },
     {

--- a/src/foam/u2/view/FObjectView.js
+++ b/src/foam/u2/view/FObjectView.js
@@ -86,7 +86,7 @@ foam.CLASS({
 
   methods: [
     function init() {
-      this.of$.sub(this.updateChoices);
+      this.onDetach(this.of$.sub(this.updateChoices));
       this.updateChoices();
     },
 

--- a/src/foam/u2/view/FObjectView.js
+++ b/src/foam/u2/view/FObjectView.js
@@ -102,16 +102,26 @@ foam.CLASS({
       // implements and extends relations.
       if ( this.strategizer != null ) {
         this.strategizer.query(null, this.of.id).then((strategyReferences) => {
-          this.choices = strategyReferences
+          if ( ! Array.isArray(strategyReferences) || strategyReferences.length === 0 ) {
+            this.choices = [[this.of.id, this.of.model_.label]];
+            return;
+          }
+
+          var choices = strategyReferences
             .reduce((arr, sr) => {
               if ( ! sr.strategy ) {
                 console.warn('Invalid strategy reference: ' + sr.id);
                 return arr;
               }
 
-              return arr.concat([[sr.strategy.id, sr.strategy.name]]);
+              return arr.concat([[sr.strategy.id, sr.strategy.model_.label]]);
             }, [])
             .filter(x => x);
+
+          // Sort choices alphabetically by label.
+          choices.sort((a, b) => a[1] > b[1] ? 1 : -1);
+
+          this.choices = choices;
         });
       } else {
         this.choices = this.choicesFallback(this.of);

--- a/src/foam/u2/view/FObjectView.js
+++ b/src/foam/u2/view/FObjectView.js
@@ -25,11 +25,15 @@ foam.CLASS({
           foam.u2.Visibility.RW :
           foam.u2.Visibility.HIDDEN;
       },
-      view: function(_, x) {
-        return foam.u2.view.ChoiceView.create({
+      view: function(args, X) {
+        return {
+          class: 'foam.u2.view.ChoiceView',
           placeholder: '--',
-          choices$: x.data.choices$
-        }, x);
+          choices$: X.data.choices$,
+          defaultValue$: X.data.choices$.map((choices) => {
+            return Array.isArray(choices) && choices.length > 0 ? choices[0][0] : '';
+          })
+        };
       },
       postSet: function(oldValue, newValue) {
         if ( newValue !== oldValue ) {


### PR DESCRIPTION
* Add strategy references for cron schedules
* Fallback on 'of' when no strategies available
* Sort class dropdown in `FObjectView` alphabetically
* Add missing detach listener
* Use `FObjectView` as default write view for `FObjectProperty`-ies
* Set default choice in `FObjectView` to first choice
* Fix bug where default value of `ChoiceView` wasn't being respected
* Put `TimeHSM` UI inputs inline to save screen space