### PR TITLE
using style width and height instead of displayHeight and displayWidt…

### DIFF
--- a/src/foam/u2/detail/SectionedDetailPropertyView.js
+++ b/src/foam/u2/detail/SectionedDetailPropertyView.js
@@ -290,12 +290,12 @@ foam.CLASS({
                       .start({
                         class: 'foam.u2.tag.Image',
                         data: 'images/inline-error-icon.svg',
-                        displayHeight: 16,
-                        displayWidth: 16
                       })
                         .style({
                           'justify-content': 'flex-start',
-                          'margin': '0 8px 0 0'
+                          'margin': '0 8px 0 0',
+                          'width': '16px',
+                          'height': '16px'
                         })
                       .end()
                       .start()


### PR DESCRIPTION
address: https://nanopay.atlassian.net/browse/CPF-3446
Note: the reason causing this issue is the `displayHeight` and `displayWidth` are responsive in safari and will change the size of error icon depending on the length of text.  this change will fix the width and height for error icon which is 16px.
