### PR TITLE
Add bearerToken support to HTTPSink

### DIFF
--- a/src/foam/dao/HTTPSink.java
+++ b/src/foam/dao/HTTPSink.java
@@ -12,6 +12,7 @@ import foam.lib.Outputter;
 import foam.lib.json.OutputterMode;
 import foam.lib.NetworkPropertyPredicate;
 import foam.nanos.http.Format;
+import foam.util.SafetyUtil;
 import org.apache.commons.io.IOUtils;
 
 import javax.servlet.http.HttpServletResponse;
@@ -24,10 +25,16 @@ public class HTTPSink
     extends AbstractSink
 {
   protected String url_;
+  protected String bearerToken_;
   protected Format format_;
 
-  public HTTPSink(String url, Format format) throws IOException {
+  public HTTPSink(String url, Format format) {
+    this(url, "", format);
+  }
+
+  public HTTPSink(String url, String bearerToken, Format format) {
     url_ = url;
+    bearerToken_ = bearerToken;
     format_ = format;
   }
 
@@ -41,6 +48,9 @@ public class HTTPSink
       Outputter outputter = null;
       conn = (HttpURLConnection) new URL(url_).openConnection();
       conn.setRequestMethod("POST");
+      if ( ! SafetyUtil.isEmpty(bearerToken_) ) {
+        conn.setRequestProperty("Authorization", "Bearer " + bearerToken_);
+      }
       conn.setDoInput(true);
       conn.setDoOutput(true);
       if ( format_ == Format.JSON ) {

--- a/src/foam/nanos/dig/DUGRule.js
+++ b/src/foam/nanos/dig/DUGRule.js
@@ -57,6 +57,11 @@ foam.CLASS({
       section: 'basicInfo'
     },
     {
+      class: 'String',
+      name: 'bearerToken',
+      section: 'basicInfo'
+    },
+    {
       class: 'foam.core.Enum',
       of: 'foam.nanos.http.Format',
       name: 'format',
@@ -90,6 +95,7 @@ foam.CLASS({
       javaGetter: `
         DUGRuleAction action = new DUGRuleAction();
         action.setUrl(getUrl());
+        action.setBearerToken(getBearerToken());
         action.setFormat(getFormat());
         return action;
       `

--- a/src/foam/nanos/dig/DUGRuleAction.js
+++ b/src/foam/nanos/dig/DUGRuleAction.js
@@ -21,6 +21,10 @@ foam.CLASS({
       name: 'url'
     },
     {
+      class: 'String',
+      name: 'bearerToken'
+    },
+    {
       class: 'foam.core.Enum',
       of: 'foam.nanos.http.Format',
       name: 'format',
@@ -34,12 +38,7 @@ foam.CLASS({
         agency.submit(x, new ContextAgent() {
           @Override
           public void execute(X x) {
-            HTTPSink sink = null;
-            try {
-              sink = new HTTPSink(getUrl(), getFormat());
-            } catch (Exception e) {
-            }
-            sink.put(obj, null);
+            new HTTPSink(getUrl(), getBearerToken(), getFormat()).put(obj, null);
           }
         }, "DUG Rule (url: " + getUrl() + " )");
       `


### PR DESCRIPTION
This is to allow HTTPSink to include Bearer Authorization header in the HTTP request when the `bearerToken` is given.

Also update DUG rule to support bearerToken.