### PR TITLE
[CPF-3429] Add handler decorator for CORS to foam.net.node

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -587,6 +587,7 @@ FOAM_FILES([
   { name: "foam/net/node/PathnameRouter", flags: ['node'] },
   { name: "foam/net/node/RequestIdentifier", flags: ['node'] },
   { name: "foam/net/node/CacheHandler", flags: ['node'] },
+  { name: "foam/net/node/CORSHandler", flags: ['node'] },
   { name: "foam/net/node/FileHandler", flags: ['node'] },
   { name: "foam/net/node/DirTreeHandler", flags: ['node'] },
   { name: "foam/net/node/RestDAOHandler", flags: ['node'] },

--- a/src/foam/net/node/CORSHandler.js
+++ b/src/foam/net/node/CORSHandler.js
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2019 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.net.node',
+  name: 'CORSHandler',
+  extends: 'foam.net.node.BaseHandler',
+  flags: ['node'],
+  documentation: `Handler decorator that adds a CORS header.`,
+
+  properties: [
+    {
+      class: 'Proxy',
+      of: 'foam.net.node.Handler',
+      name: 'delegate',
+      required: true
+    },
+    {
+      class: 'String',
+      name: 'allowOrigin',
+      documentation: `
+        Value for Access-Control-Allow-Origin header.
+      `
+    },
+    {
+      class: 'StringArray',
+      name: 'allowMethods',
+      documentation: `
+        Value for Access-Control-Allow-Methods header.
+      `,
+      value: ['GET']
+    },
+    {
+      class: 'StringArray',
+      name: 'allowHeaders',
+      documentation: `
+        Value for Access-Control-Allow-Methods header.
+      `,
+      value: []
+    }
+  ],
+
+  methods: [
+    function handle(req, res) {
+      res.setHeader('Access-Control-Allow-Origin', this.allowOrigin);
+      if ( this.allowMethods.length > 0 ) {
+        res.setHeader('Access-Control-Allow-Methods',
+          this.allowMethods.join(','));
+      }
+      if ( this.allowHeaders.length > 0 ) {
+        res.setHeader('Access-Control-Allow-Headers',
+          this.allowHeaders.join(','));
+      }
+      if ( req.method == 'OPTIONS' ) {
+        res.setHeader('Allow', this.allowMethods.join(','));
+        this.sendMessage(req, res, 204, 'No Content' + req.urlString);
+        return true;
+      }
+      return this.delegate.handle(req, res);
+    }
+  ]
+});


### PR DESCRIPTION
This PR adds a handler decorator to foam/net/node for Cross-Origin Resource Sharing. The CORSHandler adds appropriate headers and responds to HTTP requests with method OPTIONS.

This is an intermediate step to get DocBrowser working again, and to provide a modelDAO development server for future use.