### PR TITLE
[CPF-3429] Misc. modelDAO-related fixes

### DIFF
--- a/src/foam/core/Validation.js
+++ b/src/foam/core/Validation.js
@@ -26,6 +26,7 @@ foam.CLASS({
       class: 'FObjectProperty',
       of: 'foam.mlang.predicate.Predicate',
       name: 'predicate',
+      transient: true,
       expression: function(predicateFactory) {
         return predicateFactory ?
           predicateFactory(foam.mlang.ExpressionsSingleton.create()) :

--- a/src/foam/core/Window.js
+++ b/src/foam/core/Window.js
@@ -217,6 +217,13 @@ foam.CLASS({
     },
     function cancelAnimationFrame(id) {
       this.clearTimeout(id);
+    },
+    function installCSS(text, id, opt_eid) {
+      var eid = foam.u2.Element.NEXT_ID();
+      /* Create a new <style> tag containing the given CSS code. */
+      console.log(
+        "Attempt to install CSS on node server" +
+        ( opt_eid ) ? ': ' + opt_eid : '');
     }
   ]
 });

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -73,6 +73,9 @@ ${Object.keys(o).map(function(k) {
           var n = d.getTime();
           return `new java.util.Date(` + n +
             (n > Math.pow(2, 31) || n < -Math.pow(2,31) ? 'L' : '') + `)`
+        },
+        Function: function(f) {
+          return null;
         }
       })
     },


### PR DESCRIPTION
This PR makes the following changes

- Property `predicate` of `foam.core.ValidationPredicate` is now transient. This property is generated from validationPredicates, and may include circular references.
- A nully installCSS has been added to WindowNodeJSRefinement
- Java refinements.js reports `null` for the value of a `foam.core.Function`

This is an intermediate step to get DocBrowser working again, and to provide a modelDAO development server for future use.