### PR TITLE
TableCellFormatter toSummary fix

### DIFF
--- a/src/foam/u2/view/TableCellFormatter.js
+++ b/src/foam/u2/view/TableCellFormatter.js
@@ -126,9 +126,11 @@ foam.CLASS({
       class: 'foam.u2.view.TableCellFormatter',
       name: 'tableCellFormatter',
       value: function(obj) {
-        this.start()
-          .add(obj.toSummary())
-        .end();
+        this.callIf(obj, function() {
+          this.start()
+            .add(obj.toSummary())
+          .end();
+        })
       }
     }
   ]
@@ -187,7 +189,9 @@ foam.CLASS({
       class: 'foam.u2.view.TableCellFormatter',
       name: 'tableCellFormatter',
       value: function(value) {
-        this.add(value.map(o => o.toSummary()).join(', '));
+        this.callIf(value, function() {
+          this.add(value.map(o => o.toSummary()).join(', '));
+        });
       }
     }
   ]


### PR DESCRIPTION
fix for tablecellformatter breaking view when calling obj.tosummary for undefined obj