### PR TITLE
Create a new object when parsing an FObject

### DIFF
--- a/src/foam/lib/json/FObjectParser.java
+++ b/src/foam/lib/json/FObjectParser.java
@@ -46,7 +46,7 @@ public class FObjectParser
               subx.set("enum", c);
               subParser = EnumParserFactory.getInstance(c);
             } else {
-              Object obj = ((X) x.get("X")).create(c);
+              Object obj = ( x.get("X") != null ) ? ((X) x.get("X")).create(c) : c.newInstance() ;
               subx.set("obj", obj);
               subParser = ModelParserFactory.getInstance(c);
             }

--- a/src/foam/lib/json/FObjectParser.java
+++ b/src/foam/lib/json/FObjectParser.java
@@ -46,7 +46,7 @@ public class FObjectParser
               subx.set("enum", c);
               subParser = EnumParserFactory.getInstance(c);
             } else {
-              Object obj = ( x.get("X") != null ) ? ((X) x.get("X")).create(c) : c.newInstance() ;
+              Object obj= ( x.get("X") != null ) ? ((X) x.get("X")).create(c) : c.newInstance() ;
               subx.set("obj", obj);
               subParser = ModelParserFactory.getInstance(c);
             }

--- a/src/foam/lib/json/FObjectParser.java
+++ b/src/foam/lib/json/FObjectParser.java
@@ -46,7 +46,7 @@ public class FObjectParser
               subx.set("enum", c);
               subParser = EnumParserFactory.getInstance(c);
             } else {
-              Object obj= ( x.get("X") != null ) ? ((X) x.get("X")).create(c) : c.newInstance();
+              Object obj = ( x.get("X") != null ) ? ((X) x.get("X")).create(c) : c.newInstance();
               subx.set("obj", obj);
               subParser = ModelParserFactory.getInstance(c);
             }

--- a/src/foam/lib/json/FObjectParser.java
+++ b/src/foam/lib/json/FObjectParser.java
@@ -46,7 +46,7 @@ public class FObjectParser
               subx.set("enum", c);
               subParser = EnumParserFactory.getInstance(c);
             } else {
-              Object obj= ( x.get("X") != null ) ? ((X) x.get("X")).create(c) : c.newInstance() ;
+              Object obj= ( x.get("X") != null ) ? ((X) x.get("X")).create(c) : c.newInstance();
               subx.set("obj", obj);
               subParser = ModelParserFactory.getInstance(c);
             }


### PR DESCRIPTION
When we parse an object, the context may return null. (in case that the
object is send from the client)

ProxyParser jsonP =  new MapParser();
Map mapPostParam = (Map) jsonP.value();
jsonP.setX(x);

Even setting the context don't fix the issue.