### PR TITLE
Fix bug when changing class in create controller

### DIFF
--- a/src/foam/u2/view/FObjectView.js
+++ b/src/foam/u2/view/FObjectView.js
@@ -39,9 +39,7 @@ foam.CLASS({
         if ( newValue !== oldValue ) {
           var m = this.__context__.lookup(newValue, true);
           if ( m ) {
-            var n = m.create(null, this);
-            n.copyFrom(this.data);
-            this.data = n;
+            this.data = m.create(null, this);
           }
         }
       }


### PR DESCRIPTION
When creating a new object, the user might change between different subclasses.
The current behaviour of FObjectView is to copyFrom the old object to the
new one when the class changes, but this causes an often unwanted side
effect where default values of the first class chosen are copied to the
new class chosen instead of using the new class' default values.

This commit gets rid of that behaviour and simply creates a new instance
of the new subclass when chosen.