### PR TITLE
Omits updating objectClass when initializating FObjectView

### DIFF
--- a/src/foam/u2/view/FObjectView.js
+++ b/src/foam/u2/view/FObjectView.js
@@ -36,7 +36,7 @@ foam.CLASS({
         };
       },
       postSet: function(oldValue, newValue) {
-        if ( newValue !== oldValue ) {
+        if ( newValue !== oldValue && oldValue !== '' ) {
           var m = this.__context__.lookup(newValue, true);
           if ( m ) {
             this.data = m.create(null, this);


### PR DESCRIPTION
Data being set on FObjectView causes the postSet condition which checks for updates on objectClass to always pass due to the initial value always consisting an empty string. Added an additional condition of an empty oldValue to dismiss this initialization issue.