### PR TITLE
Map email args to user - EmailSettings

### DIFF
--- a/src/foam/nanos/notification/EmailSetting.js
+++ b/src/foam/nanos/notification/EmailSetting.js
@@ -11,14 +11,47 @@ foam.CLASS({
   extends: 'foam.nanos.notification.NotificationSetting',
 
   javaImports: [
+    'foam.core.PropertyInfo',
+    'foam.dao.DAO',
+    'foam.nanos.auth.User',
     'foam.nanos.logger.Logger',
     'foam.nanos.notification.email.EmailMessage',
     'foam.util.Emails.EmailsUtility',
     'java.util.Arrays',
+    'java.util.Iterator',
     'java.util.List',
+    'java.util.Map',
+    'static foam.mlang.MLang.EQ'
   ],
 
   methods: [
+    {
+      name: 'mapNotificationArguments',
+      type: 'Map',
+      documentation: `Iterate through arguments to replace propertyInfo values with the notified user' values.`,
+      args: [
+        { name: 'x', type: 'Context' },
+        { name: 'arguments', type: 'Map' },
+        { name: 'user', type: 'User' }
+      ],
+      javaCode: `
+        Logger logger = (Logger) x.get("logger");
+
+        Iterator entries = arguments.entrySet().iterator();
+        while (entries.hasNext()) {
+          Map.Entry entry = (Map.Entry) entries.next();
+          if ( entry.getValue() instanceof PropertyInfo ) {
+            if ( ! ((PropertyInfo) entry.getValue()).getClassInfo().equals(User.getOwnClassInfo()) ) {
+              logger.error("Cannot set a none User PropertyInfo as an email argument value");
+              continue;
+            }
+            String newValue = (String) ((PropertyInfo) entry.getValue()).get(user);
+            arguments.replace(entry.getKey(), newValue);
+          }
+        }
+        return arguments;
+      `
+    },
     {
       name: 'sendNotification',
       javaCode: `
@@ -27,6 +60,11 @@ foam.CLASS({
           if ( ! disabledTopics.contains(notification.getNotificationType()) ) {
             EmailMessage message = new EmailMessage();
             message.setTo(new String[]{user.getEmail()});
+
+            if ( notification.getEmailArgs() != null ) {
+              Map<String, Object> emailArgs = mapNotificationArguments(x, notification.getEmailArgs(), user);
+              notification.setEmailArgs(emailArgs);
+            }
 
             try {
               if ( foam.util.SafetyUtil.isEmpty(notification.getEmailName()) ) {
@@ -46,4 +84,3 @@ foam.CLASS({
     }
   ]
 });
-  


### PR DESCRIPTION
Replaces argument map values that reference User propertyInfo' with user values in email settings. This satisfies the condition where a notification references a single user and an extended or replaced doNotify interface method implies logic where multiple users notification settings are called. 

Each value referencing a User PropertyInfo is replaced with user values that pertain to the user receiving the notification, not the originating 'send to' user which the doNotify method is called on.

Example: 
```
args.put("account", accountNumber);
args.put("firstName", User.FIRST_NAME);

mapNotificationArguments will resolve argument list to:

args.put("account", accountNumber);
args.put("account", "userFirstName");
```