### PR TITLE
[DO_NOT_MERGE] Add createdByAgent to createdByAwareDAO

### DIFF
--- a/src/foam/nanos/auth/CreatedByAware.js
+++ b/src/foam/nanos/auth/CreatedByAware.js
@@ -43,6 +43,15 @@ foam.CLASS({
       createMode: 'HIDDEN',
       updateMode: 'RO',
       section: 'administrative'
+    },
+    {
+      class: 'Reference',
+      of: 'foam.nanos.auth.User',
+      name: 'createdByAgent',
+      documentation: 'Agent acting as User who created the entry',
+      createMode: 'HIDDEN',
+      updateMode: 'RO',
+      section: 'administrative'
     }
   ]
 });

--- a/src/foam/nanos/auth/CreatedByAwareDAO.js
+++ b/src/foam/nanos/auth/CreatedByAwareDAO.js
@@ -21,6 +21,7 @@ foam.CLASS({
         return this.delegate.find_(x, obj).then(function(result) {
           if ( result == null ) {
             obj.createdBy = x.user.id;
+            obj.createdByAgent = x.agent != null ? x.agent.id : x.user.id;
           }
           return this.delegate.put_(x, obj);
         }.bind(this));
@@ -30,7 +31,8 @@ foam.CLASS({
         if ( obj instanceof CreatedByAware && getDelegate().find_(x, obj) == null ) {
           User user = (User) x.get("user");
           User agent = (User) x.get("agent");
-          ((CreatedByAware) obj).setCreatedBy(agent != null ? agent.getId() : user.getId());
+          ((CreatedByAware) obj).setCreatedBy(user.getId());
+          ((CreatedByAware) obj).setCreatedByAgent(agent != null ? agent.getId() : user.getId());
         }
         return super.put_(x, obj);
       `


### PR DESCRIPTION
Objects implementing the createdByAwareDAO should consider acting as agents. Current implementation breaks previous logic where created by references user not agent.