### PR TITLE
CPF-3923/adding a generic delete modal to DAOSummaryView

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -173,6 +173,7 @@ FOAM_FILES([
   { name: "foam/web/URLState", flags: ['web'] },
   { name: "lib/input", flags: ['web'] },
   { name: "foam/box/Remote" },
+  { name: 'foam/u2/DeleteModal', flags: ['web'] },
   { name: 'foam/u2/ModalHeader', flags: ['web'] },
   { name: 'foam/u2/ExportModal', flags: ['web'] },
   { name: 'foam/u2/MultiView' },

--- a/src/foam/comics/v2/DAOSummaryView.js
+++ b/src/foam/comics/v2/DAOSummaryView.js
@@ -116,7 +116,7 @@ foam.CLASS({
             this.finished.pub();
             this.stack.back();
           },
-          obj: this.data
+          data: this.data
         }));
       }
     }

--- a/src/foam/comics/v2/DAOSummaryView.js
+++ b/src/foam/comics/v2/DAOSummaryView.js
@@ -111,8 +111,11 @@ foam.CLASS({
       code: function() {
         this.add(this.Popup.create().tag({
           class: 'foam.u2.DeleteModal',
-          dao_: this.config.dao,
-          data: this,
+          dao: this.config.dao,
+          onDelete: () => {
+            this.finished.pub();
+            this.stack.back();
+          },
           obj: this.data
         }));
       }

--- a/src/foam/comics/v2/DAOSummaryView.js
+++ b/src/foam/comics/v2/DAOSummaryView.js
@@ -52,7 +52,8 @@ foam.CLASS({
     'foam.u2.layout.Cols',
     'foam.u2.layout.Rows',
     'foam.u2.ControllerMode',
-    'foam.u2.dialog.NotificationMessage'
+    'foam.u2.dialog.NotificationMessage',
+    'foam.u2.dialog.Popup',
   ],
   imports: [
     'stack'
@@ -107,18 +108,13 @@ foam.CLASS({
     },
     {
       name: 'delete',
-      confirmationRequired: true,
       code: function() {
-        this.config.dao.remove(this.data).then(o => {
-          this.finished.pub();
-          this.stack.back();
-        }, e => {
-          this.throwError.pub(e);
-          this.add(this.NotificationMessage.create({
-            message: e.message,
-            type: 'error'
-          }));
-        });
+        this.add(this.Popup.create().tag({
+          class: 'foam.u2.DeleteModal',
+          dao_: this.config.dao,
+          data: this,
+          obj: this.data
+        }));
       }
     }
   ],

--- a/src/foam/u2/DeleteModal.js
+++ b/src/foam/u2/DeleteModal.js
@@ -51,7 +51,7 @@ foam.CLASS({
   ],
 
   properties: [
-    'dao', 'onDelete', 'obj'
+    'dao', 'onDelete', 'data'
   ],
 
   methods: [
@@ -62,10 +62,10 @@ foam.CLASS({
         .start()
           .addClass(this.myClass('main'))
           .start('h2')
-            .add(this.TITLE).add(this.obj.cls_.name).add('?')
+            .add(this.TITLE).add(this.data.cls_.name).add('?')
           .end()
           .start('p')
-            .add(`${this.CONFIRM_DELETE_1} '${this.obj.toSummary()}'?`)
+            .add(`${this.CONFIRM_DELETE_1} '${this.data.toSummary()}'?`)
           .end()
         .end()
         .start()
@@ -83,7 +83,7 @@ foam.CLASS({
       name: 'delete',
       label: 'Delete',
       code: function(X) {
-        this.dao.remove(this.obj).then((_) => {
+        this.dao.remove(this.data).then((_) => {
           this.onDelete();
           this.notify(this.SUCCESS_MSG);
         }).catch((err) => {

--- a/src/foam/u2/DeleteModal.js
+++ b/src/foam/u2/DeleteModal.js
@@ -47,7 +47,7 @@ foam.CLASS({
     { name: 'TITLE', message: 'Delete ' },
     { name: 'CONFIRM_DELETE_1', message: 'Are you sure you want to delete' },
     { name: 'SUCCESS_MSG', message: 'Successfully deleted' },
-    { name: 'FAIL_MSG', message: 'Failed to delete.' }
+    { name: 'FAIL_MSG', message: 'Failed to delete' }
   ],
 
   properties: [

--- a/src/foam/u2/DeleteModal.js
+++ b/src/foam/u2/DeleteModal.js
@@ -1,0 +1,111 @@
+foam.CLASS({
+  package: 'foam.u2',
+  name: 'DeleteModal',
+  extends: 'foam.u2.View',
+
+  documentation: 'View for deleting any object',
+
+  imports: [
+    'notify'
+  ],
+
+  css: `
+    ^ {
+      width: 25vw;
+    }
+    ^main {
+      padding: 1vh 2vw 1.5vh 2vw;
+    }
+    ^ .buttons {
+      background: /*%GREY5%*/ #fafafa;
+      padding: 2vh;
+      box-sizing: border-box;
+      display: flex;
+      justify-content: flex-end;
+    }
+    ^ .foam-u2-ActionView-delete,
+    ^ .foam-u2-ActionView-delete:hover {
+      border-radius: 4px;
+      box-shadow: 0 1px 0 0 /*%GREY4%*/ rgba(22, 29, 37, 0.05);
+      background: /*%DESTRUCTIVE2%*/ #f91c1c;
+      color: white;
+      vertical-align: middle;
+    }
+    ^ .foam-u2-ActionView-delete:hover {
+      opacity: 0.9;
+    }
+    ^ .foam-u2-ActionView-cancel,
+    ^ .foam-u2-ActionView-cancel:hover {
+      background: none;
+      color: /*%GREY1%*/ #525455;
+      border: none;
+      box-shadow: none;
+    }
+  `,
+
+  messages: [
+    { name: 'TITLE', message: 'Delete ' },
+    { name: 'CONFIRM_DELETE_1', message: 'Are you sure you want to delete ' },
+    { name: 'CONFIRM_DELETE_2', message: ' from your list?' },
+    { name: 'SUCCESS_MSG', message: 'Successfully deleted' },
+    { name: 'FAIL_MSG', message: 'Failed to delete.' }
+  ],
+
+  properties: [
+    'dao_', 'data', 'obj'
+  ],
+
+  methods: [
+    function initE() {
+      this.SUPER();
+      this
+        .addClass(this.myClass())
+        .start()
+          .addClass(this.myClass('main'))
+          .start('h2')
+            .add(this.TITLE).add(this.obj.cls_.name).add('?')
+          .end()
+          .start('p')
+            .add(`${this.CONFIRM_DELETE_1} '${this.obj.name}' ${this.CONFIRM_DELETE_2}`)
+          .end()
+        .end()
+        .start()
+          .addClass('buttons')
+          .startContext({ data: this })
+            .add(this.CANCEL)
+            .add(this.DELETE)
+          .endContext()
+        .end();
+    },
+
+    function deleteObj() {
+      this.dao_.remove(this.obj).then((_) => {
+        if ( this.data ) {
+          if ( this.data.finished ) this.data.finished.pub();
+          if ( this.data.stack ) this.data.stack.back();
+        }
+        this.notify(this.SUCCESS_MSG);
+      }).catch((err) => {
+        this.notify(err.message || this.FAIL_MSG, 'error');
+      });
+    }
+  ],
+
+  actions: [
+    {
+      name: 'delete',
+      label: 'Delete',
+      code: function(X) {
+        this.deleteObj();
+        X.closeDialog();
+      }
+    },
+    {
+      name: 'cancel',
+      label: 'Cancel',
+      code: function(X) {
+        X.closeDialog();
+      }
+    }
+  ]
+});

--- a/src/foam/u2/DeleteModal.js
+++ b/src/foam/u2/DeleteModal.js
@@ -65,7 +65,7 @@ foam.CLASS({
             .add(this.TITLE).add(this.data.cls_.name).add('?')
           .end()
           .start('p')
-            .add(`${this.CONFIRM_DELETE_1} '${this.data.toSummary()}'?`)
+            .add(`${this.CONFIRM_DELETE_1} ${this.data.toSummary()}?`)
           .end()
         .end()
         .start()

--- a/src/foam/u2/DeleteModal.js
+++ b/src/foam/u2/DeleteModal.js
@@ -51,7 +51,19 @@ foam.CLASS({
   ],
 
   properties: [
-    'dao', 'onDelete', 'data'
+    {
+      class: 'foam.dao.DAOProperty',
+      name: 'dao'
+    },
+    {
+      class: 'Function',
+      name: 'onDelete',
+      value: () => {}
+    },
+    {
+      class: 'FObject',
+      name: 'data'
+    }
   ],
 
   methods: [
@@ -84,8 +96,8 @@ foam.CLASS({
       label: 'Delete',
       code: function(X) {
         this.dao.remove(this.data).then((_) => {
-          this.onDelete();
           this.notify(this.SUCCESS_MSG);
+          this.onDelete();
         }).catch((err) => {
           this.notify(err.message || this.FAIL_MSG, 'error');
         });

--- a/src/foam/u2/DeleteModal.js
+++ b/src/foam/u2/DeleteModal.js
@@ -45,14 +45,13 @@ foam.CLASS({
 
   messages: [
     { name: 'TITLE', message: 'Delete ' },
-    { name: 'CONFIRM_DELETE_1', message: 'Are you sure you want to delete ' },
-    { name: 'CONFIRM_DELETE_2', message: ' from your list?' },
+    { name: 'CONFIRM_DELETE_1', message: 'Are you sure you want to delete' },
     { name: 'SUCCESS_MSG', message: 'Successfully deleted' },
     { name: 'FAIL_MSG', message: 'Failed to delete.' }
   ],
 
   properties: [
-    'dao_', 'data', 'obj'
+    'dao', 'onDelete', 'obj'
   ],
 
   methods: [
@@ -66,7 +65,7 @@ foam.CLASS({
             .add(this.TITLE).add(this.obj.cls_.name).add('?')
           .end()
           .start('p')
-            .add(`${this.CONFIRM_DELETE_1} '${this.obj.name}' ${this.CONFIRM_DELETE_2}`)
+            .add(`${this.CONFIRM_DELETE_1} '${this.obj.toSummary()}'?`)
           .end()
         .end()
         .start()
@@ -76,18 +75,6 @@ foam.CLASS({
             .add(this.DELETE)
           .endContext()
         .end();
-    },
-
-    function deleteObj() {
-      this.dao_.remove(this.obj).then((_) => {
-        if ( this.data ) {
-          if ( this.data.finished ) this.data.finished.pub();
-          if ( this.data.stack ) this.data.stack.back();
-        }
-        this.notify(this.SUCCESS_MSG);
-      }).catch((err) => {
-        this.notify(err.message || this.FAIL_MSG, 'error');
-      });
     }
   ],
 
@@ -96,7 +83,12 @@ foam.CLASS({
       name: 'delete',
       label: 'Delete',
       code: function(X) {
-        this.deleteObj();
+        this.dao.remove(this.obj).then((_) => {
+          this.onDelete();
+          this.notify(this.SUCCESS_MSG);
+        }).catch((err) => {
+          this.notify(err.message || this.FAIL_MSG, 'error');
+        });
         X.closeDialog();
       }
     },

--- a/src/foam/u2/DeleteModal.js
+++ b/src/foam/u2/DeleteModal.js
@@ -57,8 +57,7 @@ foam.CLASS({
     },
     {
       class: 'Function',
-      name: 'onDelete',
-      value: () => {}
+      name: 'onDelete'
     },
     {
       class: 'FObject',


### PR DESCRIPTION
#addresses: https://nanopay.atlassian.net/browse/CPF-3923
Simple but better User experience. Displays a simple white/red modal to confirm delete or cancel. 

notify() -> displays error or success

success goes back on stack, error stays on detailView