### PR TITLE
Fix a few issues with section-aware detail views

### DIFF
--- a/src/foam/core/lib.js
+++ b/src/foam/core/lib.js
@@ -84,6 +84,7 @@ Object.defineProperty(
 foam.assert = function assert(cond) {
   if ( ! cond ) {
     console.assert(false, Array.from(arguments).slice(1).join(' '));
+    if ( foam.isServer ) console.trace();
   }
 
   return cond;

--- a/src/foam/core/lib.js
+++ b/src/foam/core/lib.js
@@ -84,7 +84,6 @@ Object.defineProperty(
 foam.assert = function assert(cond) {
   if ( ! cond ) {
     console.assert(false, Array.from(arguments).slice(1).join(' '));
-    console.trace();
   }
 
   return cond;

--- a/src/foam/layout/Section.js
+++ b/src/foam/layout/Section.js
@@ -36,6 +36,14 @@ foam.CLASS({
       name: 'gridColumns'
     },
     {
+      class: 'Boolean',
+      name: 'permissionRequired'
+    },
+    {
+      class: 'String',
+      name: 'name'
+    },
+    {
       class: 'Function',
       name: 'createIsAvailableFor',
       value: function(data$) {

--- a/src/foam/layout/SectionAxiom.js
+++ b/src/foam/layout/SectionAxiom.js
@@ -46,29 +46,10 @@ foam.CLASS({
 
   methods: [
     function createIsAvailableFor(data$) {
-      var self = this;
-      var slot = foam.core.ExpressionSlot.create({
+      return foam.core.ExpressionSlot.create({
         obj$: data$,
         code: this.isAvailable
       });
-      if ( this.permissionRequired ) {
-        var permSlot = foam.core.SimpleSlot.create({value: false});
-        var update = function() {
-          var data = data$.get();
-          if ( data && data.__subContext__.auth ) {
-            data.__subContext__.auth.check(null,
-              `${data.cls_.id.toLowerCase()}.section.${self.name}`).then((hasAuth) => {
-                permSlot.set(hasAuth);
-              });
-          }
-        };
-        update();
-        data$.sub(update);
-        slot = foam.core.ArraySlot.create({slots: [slot, permSlot]}).map(arr => {
-          return arr.every(b => b);
-        });
-      }
-      return slot;
     }
   ]
 });

--- a/src/foam/u2/detail/AbstractSectionedDetailView.js
+++ b/src/foam/u2/detail/AbstractSectionedDetailView.js
@@ -13,6 +13,10 @@ foam.CLASS({
     The abstract for property-sheet style Views with sections for editing an FObject.
   `,
 
+  imports: [
+    'auth'
+  ],
+
   requires: [
     'foam.core.Action',
     'foam.core.Property',
@@ -60,7 +64,7 @@ foam.CLASS({
     {
       class: 'FObjectArray',
       of: 'foam.layout.Section',
-      name: 'sections',
+      name: 'sections_',
       factory: null,
       expression: function(of) {
         if ( ! of ) return [];
@@ -102,6 +106,214 @@ foam.CLASS({
 
         return sections;
       }
+    },
+    {
+      class: 'Boolean',
+      name: 'loading',
+      documentation: `True while we're calculating 'sections'.`,
+      expression: function(outstandingCalculations_) {
+        return outstandingCalculations_ > 0;
+      }
+    },
+    {
+      class: 'FObjectArray',
+      of: 'foam.layout.Section',
+      name: 'sections',
+      factory: function() {
+        return this.sections_;
+      }
+    },
+    {
+      class: 'Long',
+      name: 'outstandingCalculations_',
+      documentation: 'Used alongside `loading` to hide the view while it is loading',
+      factory: function() {
+        return 0;
+      }
+    },
+    {
+      class: 'Long',
+      name: 'nextQueuePosition_',
+      value: 1, // Start at a value greater than 0 so the first one can succeed.
+      documentation: 'Used to avoid race conditions where old results can clobber newer results.'
+    },
+    {
+      class: 'Long',
+      name: 'queuePositionWhenLastUpdated_',
+      documentation: 'Used to avoid race conditions where old results can clobber newer results.'
+    }
+  ],
+
+  methods: [
+    function init() {
+      this.onDetach(this.sections_$.sub(this.updateSections));
+      this.onDetach(this.data$.sub(this.updateSections));
+      this.updateSections();
+    }
+  ],
+
+  listeners: [
+    function updateSections() {
+      /**
+       * This function sets 'sections' to a filtered version of 'sections_'
+       * after checking a few different things. The goal is to do all of the
+       * work to determine which sections should be visible in one place, then
+       * set 'sections' to that set of sections once we know what it is. Then
+       * views that extend AbstractSectionedDetailView can simply use a slot of
+       * 'sections' and don't need to worry about doing all of this work
+       * themselves.
+       * 
+       * The things we need to check are:
+       *   1. That the user has permission to see the section if the section is
+       *      configured that way.
+       *   2. That the section is visible based on the data and the section's
+       *      'isAvailable' method if there is one.
+       *   3. That the section has at least one visible property or action,
+       *      which is based on:
+       *        (a) Whether or not the property or action requires permission to
+       *            be seen.
+       *        (b) Whether or not the action is visible based on the
+       *            'isAvailable' method of the action.
+       *        (c) Whether or not the property is visible based on the
+       *            controllerMode, visibility, or visibilityExpression.
+       */
+
+      // Keep track of the number of outstanding calls to this function so we
+      // can hide the view while it's loading.
+      this.outstandingCalculations_++;
+
+      // Record the order in which calls to this function happen so we can use
+      // it to avoid race conditions.
+      var queuePos = this.nextQueuePosition_++;
+
+      // First filter out sections by calling their `isAvailable` method on
+      // `data`. We do this first because it's the cheapest way to filter out
+      // entire sections, which means we don't need to calculate the visibility
+      // of properties or actions in those sections.
+      var visibleSections = this.sections_.filter(s => s.createIsAvailableFor(this.data$).get());
+
+      if ( visibleSections.length === 0 ) {
+        if ( queuePos > this.queuePositionWhenLastUpdated_ ) {
+          this.sections = visibleSections;
+          this.queuePositionWhenLastUpdated_ = queuePos;
+        }
+        this.outstandingCalculations_--;
+        return;
+      }
+
+      // Next we filter out the sections that the user doesn't have permission
+      // to see.
+      Promise.all(visibleSections.map((s) => {
+        if ( ! s.permissionRequired ) return Promise.resolve(true);
+        return this.auth.check(null, this.data.cls_.id.toLowerCase() + '.section.' + s.name);
+      }))
+        .then((sectionPermissionCheckResults) => {
+          visibleSections = visibleSections.filter((_, i) => sectionPermissionCheckResults[i]);
+
+          if ( visibleSections.length === 0 ) {
+            if ( queuePos > this.queuePositionWhenLastUpdated_ ) {
+              this.sections = visibleSections;
+              this.queuePositionWhenLastUpdated_ = queuePos;
+            }
+            return;
+          }
+
+          var final = [];
+
+          // Finally, we filter out any remaining sections that have no visible
+          // properties or actions in them below.
+
+          // As an optimization, we'll calculate the visible properties and
+          // actions here and replace each section with a clone of it where
+          // we only set properties to the ones that are visible and likewise
+          // for actions.
+          // WARNING: Maybe we can't do this. What if visibilityExpression
+          // depends on other properties' data changing but this only gets
+          // triggered when `data` changes?
+          Promise.all(visibleSections.map(s => {
+            var visibleProperties = s.properties
+              .map(prop => {
+                // First filter by visibility based on controllerMode since
+                // that's cheapest.
+                if ( this.controllerMode.getMode(prop) === foam.u2.DisplayMode.HIDDEN ) return null;
+
+                // Next filter by visibility or visibilityExpression since
+                // that's cheaper than the permission check.
+                var vis = prop.visibilityExpression
+                  ? this.data.slot(prop.visibilityExpression).get()
+                  : prop.visibility;
+                if ( vis === foam.u2.Visibility.HIDDEN ) return null;
+
+                return prop;
+              })
+              .filter(prop => prop);
+
+            // Filter out the actions that user can't see.
+            var visibleActions = s.actions
+              .map(action => {
+                // First check based on isAvailable, not including permission
+                // check.
+                if ( ! action.isAvailable ) return action;
+
+                return this.data.slot(action.isAvailable).get() // We assume isAvailable is synchronous.
+                  ? action
+                  : null;
+              })
+              .filter(action => action);
+            
+            if ( visibleProperties.length + visibleActions.length === 0 ) {
+              // No need to do the permission check stuff if we already know
+              // the section is empty.
+              return;
+            }
+
+            // Now we almost have the list of properties that are visible. The
+            // last thing we need to do is filter out the ones that the user
+            // doesn't have permission to see.
+            var propertyPermissionPromises = visibleProperties.map((prop) => {
+              var propName = prop.name.toLowerCase();
+              var clsName  = prop.forClass_.substring(prop.forClass_.lastIndexOf('.') + 1).toLowerCase();
+
+              if ( ! (prop.readPermissionRequired || prop.writePermissionRequired) ) {
+                return Promise.resolve(true);
+              }
+
+              return this.auth.check(null, `${clsName}.rw.${propName}`).then((rw) => {
+                if ( rw ) return foam.u2.Visibility.RW;
+                return this.auth.check(null, `${clsName}.ro.${propName}`).then((ro) => ro ? foam.u2.Visibility.RO : foam.u2.Visibility.HIDDEN);
+              });
+            });
+
+            // Filter out actions that the user doesn't have permission to see.
+            var actionPermissionPromises = visibleActions.map(action => {
+              return Promise.all(action.availablePermissions.map(permission => {
+                return this.auth.check(null, permission);
+              }));
+            });
+
+            return Promise.all([
+              Promise.all(propertyPermissionPromises),
+              Promise.all(actionPermissionPromises)
+            ]).then((tuple) => {
+              let [propertyResults, actionResults] = tuple;
+              visibleProperties = visibleProperties.filter((_, i) => propertyResults[i]);
+              visibleActions = visibleActions.filter((_, i) => actionResults[i].every(b => b));
+              if ( visibleProperties.length + visibleActions.length > 0 ) {
+                final.push(s.clone().copyFrom({
+                  properties: visibleProperties,
+                  actions: visibleActions
+                }));
+              }
+            });
+          })).then(() => {
+            if ( queuePos > this.queuePositionWhenLastUpdated_ ) {
+              this.sections = final;
+              this.queuePositionWhenLastUpdated_ = queuePos;
+            }
+          }).finally(() => {
+            this.outstandingCalculations_--;
+          });
+        });
     }
   ]
 });

--- a/src/foam/u2/detail/SectionView.js
+++ b/src/foam/u2/detail/SectionView.js
@@ -62,7 +62,6 @@ foam.CLASS({
         .add(self.slot(function(section, showTitle, section$title) {
           if ( ! section ) return;
           return self.Rows.create()
-            .show(section.createIsAvailableFor(self.data$))
             .callIf(showTitle && section$title, function() {
               this.start('h2').add(section$title).end();
             })

--- a/src/foam/u2/detail/SectionedDetailView.js
+++ b/src/foam/u2/detail/SectionedDetailView.js
@@ -47,32 +47,26 @@ foam.CLASS({
       this.SUPER();
       this
         .addClass(this.myClass())
-        .add(this.slot(function(sections, data) {
-          if ( ! data ) return;
-
-          return self.E()
-            .start(self.Grid)
-              .forEach(sections, function(s) {
-                this.add(s.createIsAvailableFor(self.data$).map(function(isAvailable) {
-                  if ( ! isAvailable ) return;
-                  return self.E().start(self.GUnit, { columns: s.gridColumns })
-                    .addClass(self.myClass('card-container'))
-                    .start('h2')
-                      .add(s.title$)
-                      .show(s.title$)
-                    .end()
-                    .start(self.border)
-                      .addClass('inner-card')
-                      .tag(self.SectionView, {
-                        data$: self.data$,
-                        section: s,
-                        showTitle: false
-                      })
-                    .end()
-                  .end();
-                }));
-              })
-            .end();
+        .hide(this.loading$)
+        .add(this.slot(function(sections) {
+          return this.E()
+            .forEach(sections, function(s) {
+              this.start(self.GUnit, { columns: s.gridColumns })
+                .addClass(self.myClass('card-container'))
+                .start('h2')
+                  .add(s.title$)
+                  .show(s.title$)
+                .end()
+                .start(self.border)
+                  .addClass('inner-card')
+                  .tag(self.SectionView, {
+                    data$: self.data$,
+                    section: s,
+                    showTitle: false
+                  })
+                .end()
+              .end();
+            });
         }));
     }
   ]

--- a/src/foam/u2/detail/TabbedDetailView.js
+++ b/src/foam/u2/detail/TabbedDetailView.js
@@ -45,32 +45,23 @@ foam.CLASS({
       this.SUPER();
       this
         .addClass(this.myClass())
-        .add(this.slot(function(sections, data) {
-          if ( ! data ) return;
-
-          var arraySlot = foam.core.ArraySlot.create({
-            slots: sections.map((s) => s.createIsAvailableFor(self.data$))
-          });
-
+        .hide(this.loading$)
+        .add(this.slot(function(sections) {
           return self.E()
-            .add(arraySlot.map((visibilities) => {
-              return this.E()
-                .start(self.Tabs)
-                  .forEach(sections, function(s, i) {
-                    if ( ! visibilities[i] ) return;
-                    this
-                      .start(self.Tab, { label: s.title || self.defaultSectionLabel })
-                        .call(function() {
-                          this.tag(self.SectionView, {
-                            data$: self.data$,
-                            section: s,
-                            showTitle: false
-                          })
-                        })
-                      .end();
-                  })
-                .end();
-            }))
+            .start(self.Tabs)
+              .forEach(sections, function(s) {
+                this
+                  .start(self.Tab, { label: s.title || self.defaultSectionLabel })
+                    .call(function() {
+                      this.tag(self.SectionView, {
+                        data$: self.data$,
+                        section: s,
+                        showTitle: false
+                      })
+                    })
+                  .end();
+              })
+            .end();
         }));
     }
   ]

--- a/src/foam/u2/detail/VerticalDetailView.js
+++ b/src/foam/u2/detail/VerticalDetailView.js
@@ -20,18 +20,16 @@ foam.CLASS({
       this.SUPER();
       this
         .addClass(this.myClass())
-        .add(this.slot(function(sections, data) {
-          if ( ! data ) return;
+        .hide(this.loading$)
+        .add(this.slot(function(sections) {
           return self.E()
             .start(self.Rows)
               .forEach(sections, function(s) {
                 this
-                  .start(self.SectionView, {
+                  .tag(self.SectionView, {
                     data$: self.data$,
                     section: s
                   })
-                    .show(s.createIsAvailableFor(self.data$))
-                  .end();
               })
             .end();
         }));

--- a/src/foam/u2/detail/WizardSectionsView.js
+++ b/src/foam/u2/detail/WizardSectionsView.js
@@ -41,7 +41,7 @@ foam.CLASS({
     {
       class: 'Int',
       name: 'prevIndex',
-      expression: function(lastUpdate, currentIndex, sections, data) {
+      expression: function(lastUpdate, currentIndex, sections) {
         for ( var i = currentIndex - 1 ; i >= 0 ; i-- ) {
           if ( sections[i].createIsAvailableFor(this.data$).get() ) return i;
         }
@@ -51,7 +51,7 @@ foam.CLASS({
     {
       class: 'Int',
       name: 'nextIndex',
-      expression: function(lastUpdate, currentIndex, sections, data) {
+      expression: function(lastUpdate, currentIndex, sections) {
         for ( var i = currentIndex + 1 ; i < sections.length ; i++ ) {
           if ( sections[i].createIsAvailableFor(this.data$).get() ) return i;
         }

--- a/src/foam/u2/view/FObjectView.js
+++ b/src/foam/u2/view/FObjectView.js
@@ -89,6 +89,12 @@ foam.CLASS({
     },
 
     function updateChoices() {
+      // If choices is hard-coded to something, just use that instead of pulling
+      // options from the strategizer.
+      if ( Array.isArray(this.choices) && this.choices.length > 0 ) {
+        return;
+      }
+
       if ( this.of == null ) {
         this.choices = [];
         return;

--- a/src/foam/u2/view/FObjectView.js
+++ b/src/foam/u2/view/FObjectView.js
@@ -131,7 +131,7 @@ foam.CLASS({
       this
         .tag(foam.u2.detail.VerticalDetailView, {
           data: this,
-          sections: [{
+          sections_: [{
             properties: [this.OBJECT_CLASS, this.DATA]
           }]
         });


### PR DESCRIPTION
There are a few issues with the current implementation of sections and
detail views that extend AbstractSectionedDetailView that this commit
seeks to remedy.

The first issue is that sections are being rendered even if there are no
visible properties or actions in that section.

The second issue is that, due to a recent change in the way
SectionedDetailView is implemented, sections would be rendered side by
side when they should have been taking up the full width of the parent.
This issue is caused by an extra div being inserted when we return an
element from a slot in detail views. This extra div breaks the CSS grid
and thus the positioning.

The first approach I took to fix the second issue was to use an
ArraySlot of all of the sections and do the forEach inside of the slot's
return value instead of doing a slot of each section individually inside
of the forEach like it currently does (where is where the extra div is
being introduced). This approach had a downside, however. The detail
view would visibly 'flicker' while the slots were re-rendering. This
secondary issue was happening because slots can be hidden if the user
doesn't have permission to see them. Either we hide them by default and
show them if the user does end up having permission, or we show them by
default and hide if the user doesn't end up having permission. Either
way, the view changes. When several sections are doing this at roughly
the same time, the effect is jarring.

The approach taken to fix this secondary issue is to calculate the
visibility of all sections up front while the view is hidden, then show
the view when we're done waiting for all of the async permission checks.
This approach has a few other desirable properties, listed below.

* We can keep track of the properties and actions in each section that
  are visible based on the current 'data' and 'controllerMode' and get
  the detail views to only try to render those properties and actions.
* We also fix the first issue, because while we're calculating which
  sections are visible, we can check if there is at least one visible
  property or action in that section and not include it in the list if
  there isn't one.
* The "interface" that views that extend AbstractSectionedDetailView
  need to work will becomes simpler. In initE, all you need to worry
  about is putting everything inside a slot of `sections`.
  AbstractSectionedDetailView will make sure that `sections` only
  contains visible sections, and will set the properties and actions
  arrays for those sections to be only those that are visible. It does
  this properly by recalculating whenever `data` or `of` changes. This
  removes the need for the views extending AbstractSectionedDetailView
  to use slots of `data`. The slot of `sections` is a slot on `data`
  implicitly.