### PR TITLE
DO_NOT_MERGE System Authorizer

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -261,6 +261,7 @@ FOAM_FILES([
   { name: "foam/nanos/boot/NSpec" },
   { name: "foam/nanos/boot/NSpecAware" },
   { name: "foam/nanos/auth/Authorizer" },
+  { name: "foam/nanos/auth/SystemAuthorizer" },
   { name: "foam/nanos/auth/EnabledAware" },
   { name: "foam/nanos/auth/ServiceProviderAware" },
   { name: "foam/nanos/logger/Logger" },

--- a/src/foam/nanos/auth/SystemAuthorizer.js
+++ b/src/foam/nanos/auth/SystemAuthorizer.js
@@ -5,7 +5,7 @@
  */
 
 foam.CLASS({
-  package: 'foam.nanos.auth.',
+  package: 'foam.nanos.auth',
   name: 'SystemAuthorizer',
   implements: [ 'foam.nanos.auth.Authorizer' ],
 
@@ -78,4 +78,4 @@ foam.CLASS({
       `
     }
   ]
-})
+});

--- a/src/foam/nanos/auth/SystemAuthorizer.js
+++ b/src/foam/nanos/auth/SystemAuthorizer.js
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2019 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.nanos.auth.',
+  name: 'SystemAuthorizer',
+  implements: [ 'foam.nanos.auth.Authorizer' ],
+
+  javaImports: [
+    'foam.core.X',
+    'foam.nanos.auth.AuthorizationException',
+    'foam.nanos.auth.User'
+  ],
+
+  documentation: `
+  Authorizer to be used for authorization on DAOs meant to be accessed by only the following entities: 
+    1. System user
+    2. Users of the "admin" group
+    3. Users of the "system" group 
+  `,
+
+  methods: [
+    {
+      name: 'isSystemUser',
+      args: [ 
+        { name: 'x', javaType: 'X' }
+      ],
+      javaCode: `
+        User user = (User) x.get("user");
+        return ( user != null && ( user.getId() == User.SYSTEM_USER_ID || user.getGroup().equals("admin") || user.getGroup().equals("system") ) );
+      `
+    },
+    {
+      name: 'authorizeOnCreate',
+      javaCode: `
+        if ( ! isSystemUser(x) ){
+          throw new AuthorizationException("You do not have permission to create this object");
+        }
+      `
+    },
+    {
+      name: 'authorizeOnRead',
+      javaCode: `
+        if ( ! isSystemUser(x) ){
+          throw new AuthorizationException("You do not have permission to read this object");
+        }
+      `
+    },
+    {
+      name: 'authorizeOnUpdate',
+      javaCode: `
+        if ( ! isSystemUser(x) ){
+          throw new AuthorizationException("You do not have permission to update this object");
+        }
+      `
+    },
+    {
+      name: 'authorizeOnDelete',
+      javaCode: `
+        if ( ! isSystemUser(x) ){
+          throw new AuthorizationException("You do not have permission to delete this object");
+        }
+      `
+    },
+    {
+      name: 'checkGlobalRead',
+      javaCode: `
+        return isSystemUser(x);
+      `
+    },
+    {
+      name: 'checkGlobalRemove',
+      javaCode: `
+        return isSystemUser(x);
+      `
+    }
+  ]
+})

--- a/src/foam/nanos/auth/SystemAuthorizer.js
+++ b/src/foam/nanos/auth/SystemAuthorizer.js
@@ -28,9 +28,10 @@ foam.CLASS({
       args: [ 
         { name: 'x', javaType: 'X' }
       ],
+      javaType: 'Boolean',
       javaCode: `
         User user = (User) x.get("user");
-        return ( user != null && ( user.getId() == User.SYSTEM_USER_ID || user.getGroup().equals("admin") || user.getGroup().equals("system") ) );
+        return ( user != null && ( user.getId() == User.SYSTEM_USER_ID || "admin".equals(user.getGroup()) || "system".equals(user.getGroup()) ) );
       `
     },
     {

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -179,6 +179,7 @@ var classes = [
   'foam.nanos.app.Mode',
   'foam.nanos.bench.Benchmark',
   'foam.nanos.auth.Authorizer',
+  'foam.nanos.auth.SystemAuthorizer',
   'foam.nanos.auth.AuthorizationDAO',
   'foam.nanos.auth.EnabledAware',
   'foam.nanos.auth.EnabledAwareDummy',


### PR DESCRIPTION
Added model for system authorizer, so that we can avoid repeating this check in every other Authorizer and instead use this in conjunction with other authorizers by using OrAuthorizer

SystemAuthorizer = Authorizer to be used for authorization on DAOs meant to be accessed by only the following entities: 
    1. System user
    2. Users of the "admin" group
    3. Users of the "system" group 