### PR TITLE
[CPF-3791] Do not add filter predicate if undefined

### DIFF
--- a/src/foam/u2/search/SearchManager.js
+++ b/src/foam/u2/search/SearchManager.js
@@ -59,6 +59,7 @@ foam.CLASS({
     function and(views) {
       return this.And.create({
         args: Object.keys(views).map(function(k) { return views[k].predicate; })
+          .filter(function(predicate) { return predicate !== undefined })
       }).partialEval();
     },
 


### PR DESCRIPTION
After clicking "id" in some views, and before selecting a filter, IntegerFilterView momentarily exists in a state where its `predicate` is undefined. This doesn't cause any issues but it does produce a gross-looking error message in the console. This PR adds a check to ignore undefined predicates.