### PR TITLE
encode hastags with %23

### DIFF
--- a/src/foam/comics/DAOController.js
+++ b/src/foam/comics/DAOController.js
@@ -266,7 +266,7 @@ foam.CLASS({
           result = 'data:text/csv;charset=utf-8,' + result;
           var encodedUri = encodeURI(result);
           var link = document.createElement('a');
-          link.setAttribute('href', encodedUri);
+          link.setAttribute('href', encodedUri.replace(/#/g, '%23'));
           link.setAttribute('download', 'data.csv');
           document.body.appendChild(link);
           link.click();


### PR DESCRIPTION
address: https://nanopay.atlassian.net/browse/CPF-3596
note: the `#` has special mean when it in the URI. `encodeURI` will not encode the # which will casuing missing the data after the `#`. When using encodeURIComponent it will break and failed to download file.