### PR TITLE
using encodeURIComponent instead

### DIFF
--- a/src/foam/comics/DAOController.js
+++ b/src/foam/comics/DAOController.js
@@ -263,10 +263,10 @@ foam.CLASS({
     function downloadCSV(x, data) {
       this.csvDriver.exportDAO(x, data)
         .then(function(result) {
-          result = 'data:text/csv;charset=utf-8,' + result;
-          var encodedUri = encodeURI(result);
+          let encodedUri = encodeURIComponent(result);
+          let uri = 'data:text/csv;charset=utf-8,' + encodedUri;
           var link = document.createElement('a');
-          link.setAttribute('href', encodedUri.replace(/#/g, '%23'));
+          link.setAttribute('href', uri);
           link.setAttribute('download', 'data.csv');
           document.body.appendChild(link);
           link.click();


### PR DESCRIPTION
address: https://nanopay.atlassian.net/browse/CPF-3596
note: same as previous PR, using `encodeURIComponent` instead. move ecodeuri to the first one since we will not encode `data:text/csv;charset=utf-8,`