### PR TITLE
User create view improvements

### DIFF
--- a/src/foam/comics/v2/DAOCreateView.js
+++ b/src/foam/comics/v2/DAOCreateView.js
@@ -81,6 +81,9 @@ foam.CLASS({
   actions: [
     {
       name: 'save',
+      isEnabled: function(data$errors_) {
+        return ! data$errors_;
+      },
       code: function() {
         var cData = this.data;
 

--- a/src/foam/nanos/auth/User.js
+++ b/src/foam/nanos/auth/User.js
@@ -203,15 +203,8 @@ foam.CLASS({
       class: 'String',
       name: 'organization',
       documentation: 'The organization/business associated with the User.',
-      displayWidth: 80,
-      width: 100,
       tableWidth: 160,
-      // TODO: Use validatationPredicates instead.
-      validateObj: function(organization) {
-        if ( ! organization.trim() ) {
-          return 'Organization Required.';
-        }
-      },
+      required: true,
       section: 'business'
     },
     {
@@ -220,6 +213,7 @@ foam.CLASS({
       documentation: `The department associated with the organization/business
         of the User.`,
       width: 50,
+      createMode: 'HIDDEN',
       section: 'business'
     },
     {
@@ -266,6 +260,7 @@ foam.CLASS({
         return this.Phone.create();
       },
       view: { class: 'foam.u2.detail.VerticalDetailView' },
+      createMode: 'HIDDEN',
       section: 'personal'
     },
     {
@@ -290,12 +285,14 @@ foam.CLASS({
       },
       view: { class: 'foam.u2.detail.VerticalDetailView' },
       section: 'personal',
+      createMode: 'HIDDEN',
       includeInDigest: true
     },
     {
       class: 'PhoneNumber',
       name: 'mobileNumber',
       documentation: 'Returns the mobile phone number of the User from the Phone model.',
+      createMode: 'HIDDEN',
       section: 'personal'
     },
     {
@@ -325,6 +322,7 @@ foam.CLASS({
       class: 'Date',
       name: 'birthday',
       documentation: 'The date of birth of the individual person, or real user.',
+      createMode: 'HIDDEN',
       section: 'personal'
     },
     {
@@ -346,6 +344,7 @@ foam.CLASS({
       factory: function() {
         return this.Address.create();
       },
+      createMode: 'HIDDEN',
       section: 'personal'
     },
     {
@@ -354,6 +353,7 @@ foam.CLASS({
       documentation: 'The default language preferred by the User.',
       of: 'foam.nanos.auth.Language',
       value: 'en',
+      createMode: 'HIDDEN',
       section: 'personal'
     },
     {
@@ -361,6 +361,7 @@ foam.CLASS({
       name: 'timeZone',
       documentation: 'The preferred time zone of the User.',
       width: 5,
+      createMode: 'HIDDEN',
       section: 'personal'
       // TODO: create custom view or DAO
     },
@@ -373,14 +374,12 @@ foam.CLASS({
       displayWidth: 30,
       width: 100,
       storageTransient: true,
-      validateObj: function (password) {
-        var re = /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9]).{7,32}$/;
-
-        if ( password.length > 0 && ! re.test(password) ) {
-          return 'Password must contain one lowercase letter, one uppercase letter, one digit, and be between 7 and 32 characters in length.';
-        }
-      },
-      section: 'administrative'
+      // TODO: Validation that's consistent with the PasswordPolicy feature but
+      // also only applies on create.
+      createMode: 'RW',
+      updateMode: 'HIDDEN',
+      readMode: 'HIDDEN',
+      section: 'personal'
     },
     {
       class: 'Password',
@@ -477,6 +476,7 @@ foam.CLASS({
           return 'Invalid website';
         }
       },
+      createMode: 'HIDDEN',
       section: 'personal'
     },
     {

--- a/src/foam/nanos/auth/User.js
+++ b/src/foam/nanos/auth/User.js
@@ -184,11 +184,6 @@ foam.CLASS({
       class: 'String',
       name: 'jobTitle',
       section: 'personal',
-      validateObj: function(jobTitle) {
-        if ( ! jobTitle.trim() ) {
-          return 'Job title required.';
-        }
-      },
       view: function(args, X) {
         return {
           class: 'foam.u2.view.ChoiceWithOtherView',
@@ -380,11 +375,11 @@ foam.CLASS({
       displayWidth: 30,
       width: 100,
       storageTransient: true,
-      // TODO: Validation that's consistent with the PasswordPolicy feature but
-      // also only applies on create.
-      validateObj: function(desiredPassword, passwordLastModified) {
-        if ( passwordLastModified === undefined && desiredPassword.length < 6 ) {
-          return 'Password must be at least 6 characters long.';
+      validateObj: function (password) {
+        var re = /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9]).{7,32}$/;
+
+        if ( password.length > 0 && ! re.test(password) ) {
+          return 'Password must contain one lowercase letter, one uppercase letter, one digit, and be between 7 and 32 characters in length.';
         }
       },
       createMode: 'RW',

--- a/src/foam/nanos/auth/User.js
+++ b/src/foam/nanos/auth/User.js
@@ -204,7 +204,6 @@ foam.CLASS({
       name: 'organization',
       documentation: 'The organization/business associated with the User.',
       tableWidth: 160,
-      required: true,
       section: 'business'
     },
     {

--- a/src/foam/nanos/auth/User.js
+++ b/src/foam/nanos/auth/User.js
@@ -345,7 +345,6 @@ foam.CLASS({
       factory: function() {
         return this.Address.create();
       },
-      createMode: 'HIDDEN',
       section: 'personal'
     },
     {

--- a/src/foam/nanos/auth/User.js
+++ b/src/foam/nanos/auth/User.js
@@ -145,7 +145,7 @@ foam.CLASS({
       // TODO: Use validatationPredicates instead.
       validateObj: function(firstName) {
         if ( ! firstName.trim() ) {
-          return 'First Name Required.';
+          return 'First name required.';
         }
       },
       gridColumns: 4,
@@ -167,7 +167,7 @@ foam.CLASS({
       // TODO: Use validatationPredicates instead.
       validateObj: function(lastName) {
         if ( ! lastName.trim() ) {
-          return 'Last Name Required.';
+          return 'Last name required.';
         }
       },
       gridColumns: 4,
@@ -184,6 +184,11 @@ foam.CLASS({
       class: 'String',
       name: 'jobTitle',
       section: 'personal',
+      validateObj: function(jobTitle) {
+        if ( ! jobTitle.trim() ) {
+          return 'Job title required.';
+        }
+      },
       view: function(args, X) {
         return {
           class: 'foam.u2.view.ChoiceWithOtherView',
@@ -203,6 +208,8 @@ foam.CLASS({
       class: 'String',
       name: 'organization',
       documentation: 'The organization/business associated with the User.',
+      displayWidth: 80,
+      width: 100,
       tableWidth: 160,
       section: 'business'
     },
@@ -234,7 +241,7 @@ foam.CLASS({
         var emailRegex = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
         if ( ! email.trim() ) {
-          return 'Email Required.';
+          return 'Email required.';
         }
 
         if ( ! emailRegex.test(email.trim()) ) {
@@ -375,6 +382,11 @@ foam.CLASS({
       storageTransient: true,
       // TODO: Validation that's consistent with the PasswordPolicy feature but
       // also only applies on create.
+      validateObj: function(desiredPassword, passwordLastModified) {
+        if ( passwordLastModified === undefined && desiredPassword.length < 6 ) {
+          return 'Password must be at least 6 characters long.';
+        }
+      },
       createMode: 'RW',
       updateMode: 'HIDDEN',
       readMode: 'HIDDEN',

--- a/src/foam/nanos/auth/email/EmailVerificationWebAgent.java
+++ b/src/foam/nanos/auth/email/EmailVerificationWebAgent.java
@@ -10,6 +10,7 @@ import foam.core.X;
 import foam.dao.DAO;
 import foam.nanos.auth.User;
 import foam.nanos.http.WebAgent;
+import foam.nanos.logger.Logger;
 import foam.nanos.notification.email.DAOResourceLoader;
 import foam.nanos.notification.email.EmailTemplate;
 import org.apache.commons.lang3.StringUtils;
@@ -62,7 +63,10 @@ public class EmailVerificationWebAgent
       user = (User) user.fclone();
       emailToken.processToken(x, user, token);
     } catch (Throwable t) {
-      message = "Problem verifying your email.<br>" + t.getMessage();
+      String msg = t.getMessage();
+      ((Logger) x.get("logger")).error(msg);
+      t.printStackTrace();
+      message = "Problem verifying your email.<br>" + msg;
     } finally {
       if ( config_ == null ) {
         config_ = EnvironmentConfigurationBuilder

--- a/src/foam/nanos/menu/DAOMenu2.js
+++ b/src/foam/nanos/menu/DAOMenu2.js
@@ -7,15 +7,17 @@
 foam.CLASS({
   package: 'foam.nanos.menu',
   name: 'DAOMenu2',
+  extends: 'foam.nanos.menu.AbstractMenu',
+
   documentation: `
     A DAOMenu which can accept a DAOControllerConfig and uses
     the v2 DAOController
   `,
 
-  extends: 'foam.nanos.menu.AbstractMenu',
   requires: [
     'foam.comics.v2.DAOControllerConfig'
   ],
+
   properties: [
     {
       class: 'FObjectProperty',
@@ -26,6 +28,7 @@ foam.CLASS({
       }
     }
   ],
+
   methods: [
     function createView(X) {
       return {

--- a/src/foam/nanos/ruler/Rule.js
+++ b/src/foam/nanos/ruler/Rule.js
@@ -208,13 +208,15 @@
     {
       class: 'DateTime',
       name: 'created',
-      visibility: 'RO'
+      createMode: 'HIDDEN',
+      updateMode: 'RO'
     },
     {
       class: 'Reference',
       of: 'foam.nanos.auth.User',
       name: 'createdBy',
-      visibility: 'RO',
+      createMode: 'HIDDEN',
+      updateMode: 'RO',
       tableCellFormatter: function(value, obj) {
         obj.userDAO.find(value).then(function(user) {
           if ( user ) {
@@ -226,13 +228,15 @@
     {
       class: 'DateTime',
       name: 'lastModified',
-      visibility: 'RO'
+      createMode: 'HIDDEN',
+      updateMode: 'RO'
     },
     {
       class: 'Reference',
       of: 'foam.nanos.auth.User',
       name: 'lastModifiedBy',
-      visibility: 'RO',
+      createMode: 'HIDDEN',
+      updateMode: 'RO',
       tableCellFormatter: function(value, obj) {
         obj.userDAO.find(value).then(function(user) {
           if ( user ) {

--- a/src/foam/u2/Element.js
+++ b/src/foam/u2/Element.js
@@ -2626,6 +2626,24 @@ foam.CLASS({
   ]
 });
 
+foam.CLASS({
+  package: 'foam.u2',
+  name: 'PasswordPropertyRefinement',
+  refines: 'foam.core.Password',
+  requires: [
+    'foam.u2.view.PasswordView'
+  ],
+  properties: [
+    {
+      name: 'view',
+      value: {
+        class: 'foam.u2.view.PasswordView',
+        passwordIcon: true
+      }
+    }
+  ]
+});
+
 
 foam.CLASS({
   package: 'foam.u2',

--- a/src/foam/u2/detail/AbstractSectionedDetailView.js
+++ b/src/foam/u2/detail/AbstractSectionedDetailView.js
@@ -41,11 +41,12 @@ foam.CLASS({
     {
       class: 'FObjectArray',
       of: 'foam.core.Property',
-      name: 'propertyWhiteList',
+      name: 'propertyWhitelist',
       documentation: `
         If this array is not empty, only the properties listed in it will be
         included in the detail view.
       `,
+      factory: null,
       preSet: function(_, ps) {
         foam.assert(ps, 'Properties required.');
         for ( var i = 0; i < ps.length; i++ ) {

--- a/src/foam/u2/detail/AbstractSectionedDetailView.js
+++ b/src/foam/u2/detail/AbstractSectionedDetailView.js
@@ -93,7 +93,11 @@ foam.CLASS({
         if ( this.propertyWhitelist ) {
           sections = sections
             .map((s) => {
-              s.properties = s.properties.filter((p) => this.propertyWhitelist.includes(p));
+              s.properties = s.properties.reduce((acc, sectionProp) => {
+                var prop = this.propertyWhitelist.find(whitelistProp => whitelistProp.name === sectionProp.name);
+                if ( prop ) acc.push(prop);
+                return acc;
+              }, []);
               return s;
             })
             .filter((s) => {


### PR DESCRIPTION
## Changes

### Main
* Hide a bunch of properties when creating a User
* Update client-side validation of a bunch of User properties
  * I used `validateObj` directly instead of `validationPredicates` because that way the back end doesn't do any validation checks. I don't want the back end to check validation because it breaks a large number of tests. I know this is bad, but we don't currently have a good solution for application-specific validation. I plan on thinking about this next, but consider it outside the scope of this PR.
* Made `PasswordView` the default view for `Password` properties
* Disable "Save" button in DAO Controller v2 if data is invalid
* Use properties supplied by `propertyWhitelist` directly so cloned properties with overrides are respected

### Other
* Formatting
* Hid a few props when creating Rules that don't make sense to set, such as `created` and `lastModified`