### PR TITLE
Fix infinite loop in FullReferenceView

### DIFF
--- a/src/foam/u2/view/FullReferenceView.js
+++ b/src/foam/u2/view/FullReferenceView.js
@@ -23,7 +23,7 @@ foam.CLASS({
       this.SUPER();
       this.add(this.slot(function(dao, data, detailView) {
         return dao.find(data).then(d => {
-          if ( ! d ) return;
+          if ( ! d ) return null; // NOTE: We have to return null here instead of undefined, otherwise we end up with an infinite loop.
           return self.E()
             .startContext({ controllerMode: foam.u2.ControllerMode.VIEW })
               .tag(detailView, { data: d })


### PR DESCRIPTION
The slot returns a promise.

`ExpressionSlot` will detect that its value was set to a promise and will
set its `promise` property to that value. When the promise resolves, it
will set its `value` property to the value that promise resolved to.

In some cases, the `then` callback of the promise in question simply
returns, which means it resolves to `undefined` in those cases.

Therefore, `ExpressionSlot` tries to set `value` to undefined in those
cases.

When a property is set to `undefined`, `clearProperty` is called, which
causes a `propertyChange` event to fire.

There must be something that's listening for that event that ends up
causing the original slot in question to fire again, thus causing an
infinite loop.

By returning `null` instead of `undefined`, we avoid `clearProperty`
being triggered and thus the loop doesn't start.