### PR TITLE
Make delete modal buttons consistent with rest of app

### DIFF
--- a/src/foam/u2/DeleteModal.js
+++ b/src/foam/u2/DeleteModal.js
@@ -23,24 +23,6 @@ foam.CLASS({
       display: flex;
       justify-content: flex-end;
     }
-    ^ .foam-u2-ActionView-delete,
-    ^ .foam-u2-ActionView-delete:hover {
-      border-radius: 4px;
-      box-shadow: 0 1px 0 0 /*%GREY4%*/ rgba(22, 29, 37, 0.05);
-      background: /*%DESTRUCTIVE2%*/ #f91c1c;
-      color: white;
-      vertical-align: middle;
-    }
-    ^ .foam-u2-ActionView-delete:hover {
-      opacity: 0.9;
-    }
-    ^ .foam-u2-ActionView-cancel,
-    ^ .foam-u2-ActionView-cancel:hover {
-      background: none;
-      color: /*%GREY1%*/ #525455;
-      border: none;
-      box-shadow: none;
-    }
   `,
 
   messages: [
@@ -82,8 +64,8 @@ foam.CLASS({
         .start()
           .addClass('buttons')
           .startContext({ data: this })
-            .add(this.CANCEL)
-            .add(this.DELETE)
+            .tag(this.CANCEL, { buttonStyle: 'SECONDARY' })
+            .tag(this.DELETE, { isDestructive: true })
           .endContext()
         .end();
     }


### PR DESCRIPTION
Custom CSS should almost never be used for buttons anymore. Instead, the style of buttons is derived from a few properties on `ActionView`.

## Old
<img width="499" alt="Screen Shot 2020-01-02 at 9 58 57 AM" src="https://user-images.githubusercontent.com/4259165/71673348-8aed7580-2d46-11ea-835f-86fd0d1509cf.png">

## New
<img width="500" alt="Screen Shot 2020-01-02 at 9 56 33 AM" src="https://user-images.githubusercontent.com/4259165/71673357-904ac000-2d46-11ea-88dc-ae4cae071a27.png">
