### PR TITLE
Avoid naming conflict between permissions

### DIFF
--- a/src/foam/nanos/auth/LifecycleAwareDAO.js
+++ b/src/foam/nanos/auth/LifecycleAwareDAO.js
@@ -43,12 +43,12 @@ foam.CLASS({
     {
       class: 'String',
       name: 'deletePermission_',
-      javaFactory: 'return getName() + ".read.lifecyclestate.deleted";'
+      javaFactory: 'return "lifecyclestate.deleted.read." + getName();'
     },
     {
       class: 'String',
       name: 'rejectPermission_',
-      javaFactory: 'return getName() + ".read.lifecyclestate.rejected";'
+      javaFactory: 'return "lifecyclestate.rejected.read." + getName();'
     }
   ],
 


### PR DESCRIPTION
A group with "user.read.*" will be able to read all users, as intended,
but that permission also implies "user.read.lifecyclestate.deleted" (and
rejected), which is unintentional. We need to be able to give a group
access to read all users without letting them read those that have been
marked as deleted or rejected.