### PR TITLE
Don't hide date of birth field by default

### DIFF
--- a/src/foam/nanos/auth/User.js
+++ b/src/foam/nanos/auth/User.js
@@ -323,7 +323,6 @@ foam.CLASS({
       class: 'Date',
       name: 'birthday',
       documentation: 'The date of birth of the individual person, or real user.',
-      createMode: 'HIDDEN',
       section: 'personal'
     },
     {


### PR DESCRIPTION
We'll override it elsewhere instead, since other applications depend on
the default being not hidden.

FYI @minsunny 