### PR TITLE
Allow create controller title to be configured separately

### DIFF
--- a/src/foam/comics/v2/DAOControllerConfig.js
+++ b/src/foam/comics/v2/DAOControllerConfig.js
@@ -57,6 +57,11 @@ foam.CLASS({
       expression: function(of) { return foam.String.pluralize(of.model_.label); }
     },
     {
+      class: 'String',
+      name: 'createTitle',
+      expression: function(of) { return 'Create a New ' + of.model_.label; }
+    },
+    {
       class: 'StringArray',
       name: 'defaultColumns',
       factory: null,

--- a/src/foam/comics/v2/DAOCreateView.js
+++ b/src/foam/comics/v2/DAOCreateView.js
@@ -112,7 +112,7 @@ foam.CLASS({
       this.SUPER();
       this
         .addClass(this.myClass())
-        .add(self.slot(function(config$viewBorder, config$browseTitle) {
+        .add(self.slot(function(config$viewBorder) {
           return self.E()
             .start(self.Rows)
               .start(self.Rows)
@@ -125,8 +125,8 @@ foam.CLASS({
                 .endContext()
                 .start(self.Cols).style({ 'align-items': 'center' })
                   .start()
-                    .add(`Create your ${config$browseTitle}`)
-                      .addClass(this.myClass('account-name'))
+                    .add(self.slot('config$createTitle'))
+                    .addClass(this.myClass('account-name'))
                   .end()
                   .startContext({ data: self }).add(self.SAVE).endContext()
                 .end()


### PR DESCRIPTION
Currently the browse title is used for the create controller, which often leads to strange titles like "Create your Users" when creating a single user.