### PR TITLE
Fixed tree search omg

### DIFF
--- a/src/foam/graphics/TreeGraph.js
+++ b/src/foam/graphics/TreeGraph.js
@@ -51,7 +51,7 @@
    ],
 
    topics: [
-    'onSizeChange'
+    'onSizeChangeComplete'
    ],
 
    methods: [
@@ -115,7 +115,8 @@
            this.invalidate();
            this.doLayout();
 
-           this.onSizeChange.pub();
+         } else {
+          this.onSizeChangeComplete.pub();
          }
       }
      }


### PR DESCRIPTION
Basically the onSizeChangeComplete publish should fire off once the canvas finishes changing rather than anytime a change is done.