### PR TITLE
[CPF-3993] bankAccountTable fix

### DIFF
--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -256,7 +256,7 @@ foam.CLASS({
                     if ( column.tableWidth ) {
                       this.style({ flex: `0 0 ${column.tableWidth}px` });
                     } else {
-                      this.style({ flex: '1 0 auto' });
+                      this.style({ flex: '1 0 0' });
                     }
                   }).
                   on('click', function(e) {
@@ -443,7 +443,7 @@ foam.CLASS({
                         if ( column.tableWidth ) {
                           this.style({ flex: `0 0 ${column.tableWidth}px` });
                         } else {
-                          this.style({ flex: '1 0 auto' });
+                          this.style({ flex: '1 0 0' });
                         }
                       }).
                     end();


### PR DESCRIPTION
set flex value back to 0 from auto so that values that are too long to fit in the column are chopped off and columns are no longer misaligned.