### PR TITLE
adding a filter for export data type - exportDriverRegistry

### DIFF
--- a/src/foam/comics/v2/DAOBrowserView.js
+++ b/src/foam/comics/v2/DAOBrowserView.js
@@ -171,7 +171,8 @@ foam.CLASS({
       code: function() {
         this.add(this.Popup.create().tag({
           class: 'foam.u2.ExportModal',
-          exportData: this.predicatedDAO$proxy
+          exportData: this.predicatedDAO$proxy,
+          predicate: this.config.filterExportPredicate
         }));
       }
     }

--- a/src/foam/comics/v2/DAOControllerConfig.js
+++ b/src/foam/comics/v2/DAOControllerConfig.js
@@ -135,6 +135,12 @@ foam.CLASS({
       name: 'deleteEnabled',
       documentation: 'True to enable the delete button.',
       value: true
+    },
+    {
+      class: 'FObjectProperty',
+      of: 'foam.mlang.predicate.Predicate',
+      name: 'filterExportPredicate',
+      documentation: 'Filtering the types of formats user is able to export from TableView'
     }
   ]
 });

--- a/src/foam/u2/ExportModal.js
+++ b/src/foam/u2/ExportModal.js
@@ -25,7 +25,7 @@ foam.CLASS({
       name: 'dataType',
       view: function(_, X) {
         return foam.u2.view.ChoiceView.create({
-          dao: X.exportDriverRegistryDAO,
+          dao: X.exportDriverRegistryDAO.where(X.data.predicate),
           objToChoice: function(a) {
             return [a.id, a.id];
           }
@@ -36,6 +36,11 @@ foam.CLASS({
       name: 'note',
       view: 'foam.u2.tag.TextArea',
       value: ''
+    },
+    {
+      class: 'FObjectProperty',
+      of: 'foam.mlang.predicate.Predicate',
+      name: 'predicate'
     },
     'exportData',
     'exportObj'


### PR DESCRIPTION
There are specific model types that don't make sense to have all file export types.
Ex) CSV as a format for polymorphic classes - models that have many subTypes.

Thus adding the predicate filter for export types.