### PR TITLE
TabChoiceView CSS Fix

### DIFF
--- a/src/foam/u2/view/TabChoiceView.js
+++ b/src/foam/u2/view/TabChoiceView.js
@@ -34,8 +34,8 @@ foam.CLASS({
 
     ^ label {
       cursor: pointer;
-      line-height: 48px;
-      padding: 0 32px;
+      line-height: 1.4px;
+      padding: 16px 32px;
       text-align:center;
       font-size: 14px;
     }

--- a/src/foam/u2/view/TabChoiceView.js
+++ b/src/foam/u2/view/TabChoiceView.js
@@ -34,7 +34,7 @@ foam.CLASS({
 
     ^ label {
       cursor: pointer;
-      line-height: 1.4px;
+      line-height: 1.4;
       padding: 16px 32px;
       text-align:center;
       font-size: 14px;


### PR DESCRIPTION
Modified line-height and padding css of TabChoiceView's label to display properly when the view does not have a lot of space.