### PR TITLE
Support outputting and replaying new class info id

### DIFF
--- a/src/foam/dao/AbstractFileJournal.js
+++ b/src/foam/dao/AbstractFileJournal.js
@@ -454,7 +454,7 @@ try {
           PropertyInfo prop = (PropertyInfo) e.next();
           mergeProperty(oldFObject, diffFObject, prop);
         }
-        return oldFObject;
+        return diffFObject.copyFrom(oldFObject);
       `
     },
     {

--- a/src/foam/lib/json/Outputter.java
+++ b/src/foam/lib/json/Outputter.java
@@ -25,7 +25,7 @@ import org.apache.commons.io.IOUtils;
 public class Outputter
   extends AbstractSink
   implements foam.lib.Outputter {
-  
+
   protected static ThreadLocal<SimpleDateFormat> sdf = new ThreadLocal<SimpleDateFormat>() {
     @Override
     protected SimpleDateFormat initialValue() {
@@ -340,12 +340,13 @@ public class Outputter
 
     if ( includeComma ) writer_.append(",");
     if ( multiLineOutput_ ) addInnerNewline();
-    outputProperty(fo, prop); 
+    outputProperty(fo, prop);
     return true;
   }
 
   protected void outputFObjectDelta(FObject oldFObject, FObject newFObject) {
     ClassInfo info           = oldFObject.getClassInfo();
+    ClassInfo newInfo        = newFObject.getClassInfo();
     boolean   outputComma    = true;
     boolean   isDiff         = false;
     boolean   isPropertyDiff = false;
@@ -367,11 +368,11 @@ public class Outputter
               writer_.append("class");
               writer_.append(afterKey_());
               writer_.append(":");
-              outputString(info.getId());
+              outputString(newInfo.getId());
             }
             if ( outputClassNames_ ) writer_.append(",");
             addInnerNewline();
-            PropertyInfo id = (PropertyInfo) info.getAxiomByName("id");
+            PropertyInfo id = (PropertyInfo) newInfo.getAxiomByName("id");
             outputProperty(newFObject, id);
             isDiff = true;
           }
@@ -380,10 +381,10 @@ public class Outputter
           outputProperty(newFObject, prop);
         }
       }
-      
-      if ( isDiff ) { 
+
+      if ( isDiff ) {
         if ( multiLineOutput_ )  writer_.append("\n");
-        writer_.append("}"); 
+        writer_.append("}");
       }
     }
   }


### PR DESCRIPTION
Liquid transaction approval flow saves generic transaction object to the journal and send out approval requests, after the transaction is approved it then goes through the normal transaction DAO where the transaction is quoted and the type is changed.

The journal entry should reflect that and be able set the correct type on replay.

### Screenshot
<img width="1641" alt="Screen Shot 2020-01-13 at 4 44 17 PM" src="https://user-images.githubusercontent.com/441658/72294747-2b377a00-3624-11ea-9cc4-304c13b13bbf.png">
