### PR TITLE
Fix bug where SubSlot was detaching unnecessarily

### DIFF
--- a/src/foam/core/Slot.js
+++ b/src/foam/core/Slot.js
@@ -270,7 +270,6 @@ foam.CLASS({
       'For internal use only. Is used to implement the Slot.dot() method.',
 
   properties: [
-    'of',
     'parent', // parent slot, not parent object
     'name',
     'value',
@@ -329,19 +328,12 @@ foam.CLASS({
       this.prevSub && this.prevSub.detach();
       var o = this.parent.get();
 
-      // Record the 'of' of the parent so we can tell when it changes.
-      if ( ! this.of && o ) this.of = o.cls_.id;
-
-      // If the parent object changes class, then don't update
-      // because a new class will have different sub-slots.
       // If the new class has the same axiom as the old class, then we keep this
       // SubSlot attached instead of detaching it.
-      if ( o && ( this.of !== o.cls_.id && o.cls_.getAxiomByName(this.name) == null ) ) {
+      if ( o && o.cls_.getAxiomByName(this.name) == null ) {
         this.prevSub = null;
         this.detach();
         return;
-      } else if ( o ) {
-        this.of = o.cls_.id;
       }
 
       this.prevSub = o && o.slot && o.slot(this.name).sub(this.valueChange);

--- a/src/foam/core/Slot.js
+++ b/src/foam/core/Slot.js
@@ -334,10 +334,14 @@ foam.CLASS({
 
       // If the parent object changes class, then don't update
       // because a new class will have different sub-slots.
-      if ( o && ( this.of !== o.cls_.id || o.cls_.getAxiomByName(this.name) == null ) ) {
+      // If the new class has the same axiom as the old class, then we keep this
+      // SubSlot attached instead of detaching it.
+      if ( o && ( this.of !== o.cls_.id && o.cls_.getAxiomByName(this.name) == null ) ) {
         this.prevSub = null;
         this.detach();
         return;
+      } else if ( o ) {
+        this.of = o.cls_.id;
       }
 
       this.prevSub = o && o.slot && o.slot(this.name).sub(this.valueChange);


### PR DESCRIPTION
SubSlots were detaching whenever the class of the object in the parent
slot changed. The reason for this, according to a comment in the code,
is that the new class will have "different SubSlots", which I assume
means different axioms.

An unfortunate side effect of this "feature" is that when the class of
the object in the parent slot changes to another class with the same
axiom, the SubSlot detaches anyway. It would be preferable, in my
opinion, if the SubSlot stays alive as long as the new class has the
same axiom the subslot was set up for. That's what this commit
implements.