### PR TITLE
Cpf 4032/setinner dao will overwirite inner dao java factory

### DIFF
--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -277,12 +277,8 @@ foam.CLASS({
         .setOf(getOf())
         .build();
       }
-      if ( getJournalType().equals(JournalType.SINGLE_JOURNAL) ) {
-        if ( getMDAO() != null )
-          return new foam.dao.java.JDAO(getX(), getMDAO(), getJournalName());
-        else
+      if ( getJournalType().equals(JournalType.SINGLE_JOURNAL) )
         return new foam.dao.java.JDAO(getX(), getOf(), getJournalName());
-      }
       return new foam.dao.MDAO(getOf());
       `
     },

--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -270,11 +270,6 @@ foam.CLASS({
     {
       class: 'Object',
       type: 'foam.dao.DAO',
-      name: 'mDAO'
-    },
-    {
-      class: 'Object',
-      type: 'foam.dao.DAO',
       name: 'innerDAO',
       javaFactory: `
       if ( getNullify() ) {

--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -270,6 +270,11 @@ foam.CLASS({
     {
       class: 'Object',
       type: 'foam.dao.DAO',
+      name: 'mDAO'
+    },
+    {
+      class: 'Object',
+      type: 'foam.dao.DAO',
       name: 'innerDAO',
       javaFactory: `
       if ( getNullify() ) {
@@ -277,8 +282,12 @@ foam.CLASS({
         .setOf(getOf())
         .build();
       }
-      if ( getJournalType().equals(JournalType.SINGLE_JOURNAL) )
+      if ( getJournalType().equals(JournalType.SINGLE_JOURNAL) ) {
+        if ( getMDAO() != null )
+          return new foam.dao.java.JDAO(getX(), getMDAO(), getJournalName());
+        else
         return new foam.dao.java.JDAO(getX(), getOf(), getJournalName());
+      }
       return new foam.dao.MDAO(getOf());
       `
     },

--- a/src/foam/nanos/notification/services
+++ b/src/foam/nanos/notification/services
@@ -21,7 +21,7 @@ p({
         new foam.nanos.notification.SendSlackNotificationDAO(x)))).build())
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
       .setJournalName("notifications")
-      .setInnerDAO(dao)
+      .serMDAO(dao)
       .build();
   """
 })

--- a/src/foam/nanos/notification/services
+++ b/src/foam/nanos/notification/services
@@ -4,11 +4,6 @@ p({
   "lazy": false,
   "serve": false,
   "serviceScript": """
-  foam.dao.DAO dao = new foam.dao.MDAO(foam.nanos.notification.Notification.getOwnClassInfo());
-    dao.addIndex(new foam.core.PropertyInfo[] { foam.nanos.notification.Notification.GROUP_ID,foam.nanos.notification.Notification.READ });
-    dao.addIndex(new foam.core.PropertyInfo[] { foam.nanos.notification.Notification.BROADCASTED,foam.nanos.notification.Notification.READ });
-    dao.addIndex(new foam.core.PropertyInfo[] { foam.nanos.notification.Notification.USER_ID,foam.nanos.notification.Notification.READ });
-    dao.addIndex(new foam.core.PropertyInfo[] { foam.nanos.notification.Notification.EXPIRY_DATE });
     return new foam.dao.EasyDAO.Builder(x)
       .setOf(foam.nanos.notification.Notification.getOwnClassInfo())
       .setAuthorize(false)
@@ -21,7 +16,12 @@ p({
         new foam.nanos.notification.SendSlackNotificationDAO(x)))).build())
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
       .setJournalName("notifications")
-      .setMDAO(dao)
+      .setIndex(new foam.core.PropertyInfo[]{
+        foam.nanos.notification.Notification.GROUP_ID,foam.nanos.notification.Notification.READ,
+        foam.nanos.notification.Notification.BROADCASTED,foam.nanos.notification.Notification.READ,
+        foam.nanos.notification.Notification.USER_ID,foam.nanos.notification.Notification.READ,
+        foam.nanos.notification.Notification.EXPIRY_DATE
+       })
       .build();
   """
 })

--- a/src/foam/nanos/notification/services
+++ b/src/foam/nanos/notification/services
@@ -21,7 +21,7 @@ p({
         new foam.nanos.notification.SendSlackNotificationDAO(x)))).build())
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
       .setJournalName("notifications")
-      .serMDAO(dao)
+      .setMDAO(dao)
       .build();
   """
 })


### PR DESCRIPTION
address: https://nanopay.atlassian.net/browse/CPF-4032
note: setInnerDAO in `localNotificationDAO`   will overwrite the `javaFactory` code due to 
```
  public foam.dao.DAO getInnerDAO() {
    if ( ! innerDAOIsSet_ ) {
      setInnerDAO(InnerDAOFactory_());
    }
    return innerDAO_;
  }
```
so the data will never gose in JDAO

@carl-zzz && @nanoNeel  find the issue
@xuerongCode found the way to fixed it