### PR TITLE
Make propertyWhitelist more flexible

### DIFF
--- a/src/foam/u2/detail/AbstractSectionedDetailView.js
+++ b/src/foam/u2/detail/AbstractSectionedDetailView.js
@@ -47,6 +47,15 @@ foam.CLASS({
         included in the detail view.
       `,
       factory: null,
+      adapt: function(_, newValue) {
+        if ( Array.isArray(newValue) ) return newValue;
+        if ( typeof newValue !== 'object' ) throw new Error('You must set propertyWhitelist to an array of properties or a map from names to overrides encoded as an object.');
+        return Object.entries(newValue).reduce((acc, [propertyName, overrides]) => {
+          var axiom = this.of.getAxiomByName(propertyName);
+          if ( axiom ) acc.push(axiom.clone().copyFrom(overrides));
+          return acc;
+        }, []);
+      },
       preSet: function(_, ps) {
         foam.assert(ps, 'Properties required.');
         for ( var i = 0; i < ps.length; i++ ) {


### PR DESCRIPTION
The problem I encountered was that when you supply an array of
`Property`-ies for `propertyWhitelist`, you naturally have to specify a
specific axiom on a specific model. This runs into problems when the
same axiom is modified on a subclass of that model because
`propertyWhitelist` just uses the exact axiom it was given, which likely
wasn't the subclass.

To solve this problem, I wrote an adapt method for `propertyWhitelist`
that will take a map from axiom name to an object containing overrides,
then will look up the axiom on `of`, giving us the axiom for the class we
care about, and then will apply the overrides (if any) to that axiom.

Then I can do something like:

```JavaScript
{
  name: 'propertyWhitelist',
  value: {
    foo: {
      label: 'Label Override',
      updateMode: 'RO'
    },
    bar: {} // Use an empty object to include in the whitelist but
            // without overrides.
  }
}
```

and it will be adapted behind the scenes to use the `foo` and `bar`
axioms defined on `of`, which is what we want.

Before, I'd have to do something like:

```JavaScript
{
  name: 'propertyWhitelist',
  value: [
    foam.made.up.package.Baz.FOO.clone().copyFrom({
      label: 'Label Override',
      updateMode: 'RO'
    },
    foam.made.up.package.Baz.BAR
  ]
}
```

but if `foo` or `bar` were modified in subclasses of `Baz`, then those
overrides wouldn't be respected.