### PR TITLE
Don't render sections with no visible properties or actions

### DIFF
--- a/src/foam/u2/detail/AbstractSectionedDetailView.js
+++ b/src/foam/u2/detail/AbstractSectionedDetailView.js
@@ -105,6 +105,13 @@ foam.CLASS({
             });
         }
 
+        // Filter out any sections where we know that there are no actions and
+        // no visible properties.
+        sections = sections.filter(s => {
+          return s.actions.length > 0 ||
+                 s.properties.some(p => this.controllerMode.getMode(p) !== foam.u2.DisplayMode.HIDDEN);
+        });
+
         return sections;
       }
     }


### PR DESCRIPTION
This helps when a subclass of some model hides a property and that's the only property in a section. This way we just don't show the section at all rather than showing an empty section. This is only a partial fix though. There are other ways for a property to be hidden that this PR doesn't cover, but I plan on addressing those in a refactor later. For now, this will fix some but not all cases of empty sections.