### PR TITLE
Fix phone number validation when not required

### DIFF
--- a/src/foam/core/Validation.js
+++ b/src/foam/core/Validation.js
@@ -356,6 +356,7 @@ foam.CLASS({
   package: 'foam.core',
   name: 'PhoneNumberPropertyValidationRefinement',
   refines: 'foam.core.PhoneNumber',
+
   properties: [
     {
       class: 'FObjectArray',
@@ -363,19 +364,36 @@ foam.CLASS({
       name: 'validationPredicates',
       factory: function() {
         var self = this;
-        if ( ! this.required ) return [];
-        return [
-          {
-            args: [this.name],
-            predicateFactory: function(e) {
-                return e.REG_EXP(
-                  self,
-                  /^(?:\+?1[-.●]?)?\(?([0-9]{3})\)?[-.●]?([0-9]{3})[-.●]?([0-9]{4})$/
-                 );
-            },
-            errorString: 'Please enter phone number'
-          }
-        ];
+        const PHONE_NUMBER_REGEX = /^(?:\+?1[-.●]?)?\(?([0-9]{3})\)?[-.●]?([0-9]{3})[-.●]?([0-9]{4})$/;
+        return this.required
+          ? [
+              {
+                args: [this.name],
+                predicateFactory: function(e) {
+                  return e.HAS(self);
+                },
+                errorString: 'Phone number required.'
+              },
+              {
+                args: [this.name],
+                predicateFactory: function(e) {
+                  return e.REG_EXP(self, PHONE_NUMBER_REGEX);
+                },
+                errorString: 'Invalid phone number.'
+              }
+            ]
+          : [
+              {
+                args: [this.name],
+                predicateFactory: function(e) {
+                    return e.OR(
+                      e.EQ(foam.mlang.StringLength.create({ arg1: self }), 0),
+                      e.REG_EXP(self, PHONE_NUMBER_REGEX)
+                    );
+                },
+                errorString: 'Invalid phone number.'
+              }
+            ];
       }
     }
   ]


### PR DESCRIPTION
Before this commit, if a PhoneNumber property was not required: true,
then validation wouldn't be applied at all, even if the user typed
something into the input. Instead, we want an empty input to be valid,
but we still want to use the normal validation logic if a value is
entered.