### PR TITLE
Show property when readPermissionRequired=false

### DIFF
--- a/src/foam/u2/Element.js
+++ b/src/foam/u2/Element.js
@@ -2257,10 +2257,12 @@ foam.CLASS({
 
           var propName = this.name.toLowerCase();
           var clsName  = this.forClass_.substring(this.forClass_.lastIndexOf('.') + 1).toLowerCase();
+          var canRead  = this.readPermissionRequired === false;
 
           return auth.check(null, `${clsName}.rw.${propName}`)
               .then(function(rw) {
                 if ( rw ) return Visibility.RW;
+                if ( canRead ) return Visibility.RO;
                 return auth.check(null, `${clsName}.ro.${propName}`)
                   .then((ro) => ro ? Visibility.RO : Visibility.HIDDEN);
               });


### PR DESCRIPTION
If a property has `readPermissionRequired = false` then it should be shown in the detail view.

## Screenshot
- Before
<img width="274" alt="Screen Shot 2020-01-15 at 5 34 07 PM" src="https://user-images.githubusercontent.com/441658/72477380-628d5e80-37bd-11ea-8173-1356c64b42f4.png">

- After
<img width="272" alt="Screen Shot 2020-01-15 at 5 34 42 PM" src="https://user-images.githubusercontent.com/441658/72477374-5f926e00-37bd-11ea-896f-eebb40a5d9c6.png">
