### PR TITLE
Improve efficiency by using entrySet over keySet

### DIFF
--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -1538,7 +1538,7 @@ foam.CLASS({
                 if ( prop.get(obj) == null ) prop.set(obj, prop.of().newInstance());
                 entry.getValue().set((foam.core.FObject) prop.get(obj), str);
               } catch ( Throwable t ) {
-                // ???
+                t.printStackTrace() // cannot use logging from logging. 
               }
             }
           });

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -1531,12 +1531,12 @@ foam.CLASS({
           p.fromCSVLabelMapping(map2);
         });
 
-        for ( String key : map2.keySet() ) {
-          map.put(getName() + "." + key, new foam.lib.csv.FromCSVSetter() {
+        for ( java.util.Map.Entry<String, foam.lib.csv.FromCSVSetter> entry : map2.entrySet() ) {
+          map.put(getName() + "." + entry.getKey(), new foam.lib.csv.FromCSVSetter() {
             public void set(foam.core.FObject obj, String str) {
               try {
                 if ( prop.get(obj) == null ) prop.set(obj, prop.of().newInstance());
-                map2.get(key).set((foam.core.FObject) prop.get(obj), str);
+                entry.getValue().set((foam.core.FObject) prop.get(obj), str);
               } catch ( Throwable t ) {
                 // ???
               }


### PR DESCRIPTION
This is more efficient because the map gets queried once per key rather than twice.

The change turned out to be much easier than I expected because it exists in code generation.