### PR TITLE
Fix bug related to cloning actions

### DIFF
--- a/src/foam/core/Action.js
+++ b/src/foam/core/Action.js
@@ -123,15 +123,13 @@ If empty than no permissions are required.`
 If empty than no permissions are required.`,
     },
     {
-      // TODO: Use WeakMap instead. Doing so causes issues when cloning Actions
-      // though, since FOAM doesn't handle cloning WeakMaps right now. Instead,
-      // it converts them to normal objects, which breaks downstream code that
-      // expects a WeakMap.
-      class: 'Map',
       name: 'runningMap',
+      factory: function() {
+        return new WeakMap();
+      },
       hidden: true,
       transient: true,
-      documentation: 'A map to track the running state of action on a per object basis.'
+      documentation: 'A weak Map to track the running state of action on a per object basis.'
     }
   ],
 
@@ -195,10 +193,10 @@ If empty than no permissions are required.`,
     },
 
     function getRunning$(data) {
-      var running = this.runningMap[data];
+      var running = this.runningMap.get(data);
       if ( ! running ) {
         running = foam.core.SimpleSlot.create({ value: false });
-        if ( data ) this.runningMap[data] = running;
+        if ( data ) this.runningMap.set(data, running);
       }
       return running;
     },

--- a/src/foam/core/Action.js
+++ b/src/foam/core/Action.js
@@ -127,6 +127,9 @@ If empty than no permissions are required.`,
       factory: function() {
         return new WeakMap();
       },
+      cloneProperty: function() {
+        return new WeakMap();
+      },
       hidden: true,
       transient: true,
       documentation: 'A weak Map to track the running state of action on a per object basis.'

--- a/src/foam/core/Action.js
+++ b/src/foam/core/Action.js
@@ -123,13 +123,15 @@ If empty than no permissions are required.`
 If empty than no permissions are required.`,
     },
     {
+      // TODO: Use WeakMap instead. Doing so causes issues when cloning Actions
+      // though, since FOAM doesn't handle cloning WeakMaps right now. Instead,
+      // it converts them to normal objects, which breaks downstream code that
+      // expects a WeakMap.
+      class: 'Map',
       name: 'runningMap',
-      factory: function() {
-        return new WeakMap();
-      },
       hidden: true,
       transient: true,
-      documentation: 'A weak Map to track the running state of action on a per object basis.'
+      documentation: 'A map to track the running state of action on a per object basis.'
     }
   ],
 
@@ -193,10 +195,10 @@ If empty than no permissions are required.`,
     },
 
     function getRunning$(data) {
-      var running = this.runningMap.get(data);
+      var running = this.runningMap[data];
       if ( ! running ) {
         running = foam.core.SimpleSlot.create({ value: false });
-        if ( data ) this.runningMap.set(data, running);
+        if ( data ) this.runningMap[data] = running;
       }
       return running;
     },


### PR DESCRIPTION
FOAM currently doesn't handle cloning WeakMaps. When it tries to do so,
it ends up creating a POJO instead, which breaks downstream code. As a
workaround, we revert to using a normal object for runningMap instead of
a WeakMap.

@tharmaman 