### PR TITLE
Make ChoiceView use default value when user selects placeholder

### DIFF
--- a/src/foam/u2/view/ChoiceView.js
+++ b/src/foam/u2/view/ChoiceView.js
@@ -60,7 +60,7 @@ foam.CLASS({
 
         try {
           if ( ! n && this.placeholder ) {
-            this.data  = undefined;
+            this.data  = this.defaultValue !== undefined ? this.defaultValue : undefined;
             this.text  = this.placeholder;
             this.index = -1;
           } else {

--- a/src/foam/u2/view/ChoiceView.js
+++ b/src/foam/u2/view/ChoiceView.js
@@ -60,7 +60,7 @@ foam.CLASS({
 
         try {
           if ( ! n && this.placeholder ) {
-            this.data  = this.defaultValue !== undefined ? this.defaultValue : undefined;
+            this.data  = this.defaultValue;
             this.text  = this.placeholder;
             this.index = -1;
           } else {


### PR DESCRIPTION
Otherwise the user doesn't have any way of explicitly choosing the
default value.

The important part is that it's an _explicit_ action taken by the user.
When we were setting `this.data` to `undefined` before, we were telling
the data to go back to an "untouched" state. This has the undesirable
side effect of copyFrom ignoring that property since it's in an
untouched state. Instead, we want to explicitly set that property to a
default value (such as 0 for a long property, or "" for a string
property) so that copyFrom will copy that default value over.