### PR TITLE
Set PM endtime regardless if pmLogger is in context to handle PMs cre…

### DIFF
--- a/src/foam/nanos/pm/PM.js
+++ b/src/foam/nanos/pm/PM.js
@@ -63,12 +63,12 @@ foam.CLASS({
       ],
       javaCode: `
     if ( x == null ) return;
+    setEndTime(new java.util.Date());
     PMLogger pmLogger = (PMLogger) x.get(DAOPMLogger.SERVICE_NAME);
     if ( pmLogger != null ) {
-      setEndTime(new java.util.Date());
       pmLogger.log(this);
     }
-`
+      `
     },
     {
       name: 'getTime',


### PR DESCRIPTION
…ated early in startup.

Occurs on MedusaNode as it has minimal services and startup is very fast. 