### PR TITLE
Add missing JS IsClassOf mlang convenience method

### DIFF
--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -3400,7 +3400,8 @@ foam.CLASS({
     },
     function THEN_BY(a, b) { return this.ThenBy.create({head: a, tail: b}); },
 
-    function INSTANCE_OF(cls) { return this.IsInstanceOf.create({ targetClass: cls }); }
+    function INSTANCE_OF(cls) { return this.IsInstanceOf.create({ targetClass: cls }); },
+    function CLASS_OF(cls) { return this.IsClassOf.create({ targetClass: cls }); }
   ]
 });
 


### PR DESCRIPTION
We have this on the Java side a la `MLang.java`, but I guess it was never added on the JavaScript side.