### PR TITLE
Remove the placeholder option from FObjectView's class dropdown

### DIFF
--- a/src/foam/u2/view/FObjectView.js
+++ b/src/foam/u2/view/FObjectView.js
@@ -28,7 +28,6 @@ foam.CLASS({
       view: function(args, X) {
         return {
           class: 'foam.u2.view.ChoiceView',
-          placeholder: '--',
           choices$: X.data.choices$,
           defaultValue$: X.data.choices$.map((choices) => {
             return Array.isArray(choices) && choices.length > 0 ? choices[0][0] : '';


### PR DESCRIPTION
It doesn't make sense as a valid option when creating an FObject. The user should be forced to pick one of the options.

Fixes: https://nanopay.atlassian.net/browse/CPF-3861