### PR TITLE
Updates to ApplicationLogoView

### DIFF
--- a/src/foam/nanos/u2/navigation/ApplicationLogoView.js
+++ b/src/foam/nanos/u2/navigation/ApplicationLogoView.js
@@ -16,6 +16,10 @@ foam.CLASS({
     'theme'
   ],
 
+  requires: [
+    'foam.u2.tag.Image'
+  ],
+
   css: `
     ^ {
       display: flex;
@@ -25,13 +29,6 @@ foam.CLASS({
     ^ .logo {
       max-height: 40px;
     }
-    ^ .appName {
-      color: white;
-      font-size: 20px;
-      display: flex;
-      align-items: center;
-      margin-left: 10px;
-    }
   `,
 
   methods: [
@@ -39,25 +36,13 @@ foam.CLASS({
       this
         .addClass(this.myClass())
         .on('click', this.goToDefault)
-          .start({
-            class: 'foam.u2.tag.Image',
-            data$: this.theme$.dot('logo')
+        .start(this.Image, {
+          data$: this.slot(function(theme$largeLogoEnabled, theme$logo, theme$largeLogo) {
+            return theme$largeLogoEnabled ? theme$largeLogo : theme$logo;
           })
-            .hide(this.theme$.dot('largeLogoEnabled'))
-            .addClass('logo')
-          .end()
-          .start('span')
-            .addClass('appName')
-            .hide(this.theme$.dot('largeLogoEnabled'))
-            .add(this.theme$.dot('appName'))
-          .end()
-          .start({
-            class: 'foam.u2.tag.Image',
-            data$: this.theme$.dot('largeLogo')
-          })
-            .addClass('logo')
-            .show(this.theme$.dot('largeLogoEnabled'))
-          .end();
+        })
+          .addClass('logo')
+        .end();
     }
   ],
 


### PR DESCRIPTION
* Stop loading both large and normal logos but only showing one of them. Instead, only load the one we're going to display.
* Stop showing the app name beside the logo.

FYI @zahnno 