### PR TITLE
Fix bug where tableCellFormatter overrides were ignored

### DIFF
--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -59,21 +59,20 @@ foam.CLASS({
       name: 'columns_',
       expression: function(columns, of, allColumns, editColumnsEnabled) {
         if ( ! of ) return [];
-        columns = columns.map(c => foam.String.isInstance(c) ? this.of.getAxiomByName(c) : c);
         if ( ! editColumnsEnabled ) return columns;
 
         // Reorder allColumns to respect the order of columns first followed by
         // the order of allColumns.
         allColumns = columns.concat(allColumns);
         allColumns = allColumns.filter((c, i) => {
-          return allColumns.findIndex(a => a.name == c.name) == i;
+          return allColumns.findIndex(a => a[0] == c[0]) == i;
         });
 
         return allColumns.filter(c => {
-          var v = this.ColumnConfig.create({ of: of, axiom : c }).visibility;
+          var v = this.ColumnConfig.create({ of: of, axiom : (typeof c[0] === 'string' ? of.getAxiomByName(c[0]) : c[0]) }).visibility;
           return v == this.ColumnVisibility.ALWAYS_HIDE ? false :
                  v == this.ColumnVisibility.ALWAYS_SHOW ? true :
-                 columns.find(c2 => c.name == c2.name)  ? true : false;
+                 columns.find(c2 => c[0] == c2[0])  ? true : false;
         });
       },
     },
@@ -82,17 +81,22 @@ foam.CLASS({
       expression: function(of) {
         return ! of ? [] : [].concat(
           of.getAxiomsByClass(foam.core.Property)
-            .filter(p => p.tableCellFormatter && ! p.hidden),
+            .filter(p => p.tableCellFormatter && ! p.hidden)
+            .map(a => [a.name, null]),
           of.getAxiomsByClass(foam.core.Action)
+            .map(a => [a.name, null])
         );
       }
     },
     {
       name: 'columns',
+      adapt: function(_, cols) {
+        return cols.map(c => Array.isArray(c) ? c : [c, null]);
+      },
       expression: function(of, allColumns) {
         if ( ! of ) return [];
         var tc = of.getAxiomByName('tableColumns');
-        return tc ? tc.columns.map(c => of.getAxiomByName(c)) : allColumns;
+        return tc ? tc.columns.map(c => [c, null]) : allColumns;
       },
     },
     {
@@ -199,6 +203,7 @@ foam.CLASS({
       var columnSelectionE;
 
       if ( this.filteredTableColumns$ ) {
+        // TODO
         this.onDetach(this.filteredTableColumns$.follow(
           this.columns_$.map((cols) => cols.map((a) => a.name))));
       }
@@ -248,7 +253,11 @@ foam.CLASS({
               }).
 
               // Render the table headers for the property columns.
-              forEach(columns_, function(column) {
+              forEach(columns_, function([axiomOrColumnName, overrides]) {
+                var column = typeof axiomOrColumnName === 'string'
+                  ? view.of.getAxiomByName(axiomOrColumnName)
+                  : axiomOrColumnName;
+                if ( overrides ) column = column.clone().copyFrom(overrides);
                 this.start().
                   addClass(view.myClass('th')).
                   addClass(view.myClass('th-' + column.name)).
@@ -424,7 +433,11 @@ foam.CLASS({
                   });
                 }).
 
-                forEach(columns_, function(column) {
+                forEach(columns_, function([axiomOrColumnName, overrides]) {
+                  var column = typeof axiomOrColumnName === 'string'
+                    ? obj.cls_.getAxiomByName(axiomOrColumnName)
+                    : axiomOrColumnName;
+                  if ( overrides ) column = column.clone().copyFrom(overrides);
                   this.
                     start().
                       addClass(view.myClass('td')).


### PR DESCRIPTION
The issue was that the axiom that UnstyledTableView was taking the axiom
from was the axiom defined on `of`, which is likely the base class. But
if one of our objects in the table is a subclass of `of` that overrides
`tableCellFormatter` for one of the table columns, then the
`tableCellFormatter` was being ignored because we were looking up the
axiom on the base class and using its `tableCellFormatter`.

This commit fixes that by changing the way we specify which columns to
use. The old way looks like this:

```
columns: [
  'foo',
  my.model.path.MyModel.BAR.clone().copyFrom({
    baz: 'woozle'
  }),
  foam.core.Property.create({ /* ... */ })
]
```

There are three possibilities:

1. A string. This specifies the name of the axiom to use.
2. An axiom. You can also specify an axiom directly and override it if
you want by cloning it and modifying the clone.
3. A new axiom. A variant of #2, but this axiom doesn't actually exist
on the model at all, we're just making one up.

The table view was converting the strings into the axioms by looking
them up on `of`, so we end up with `columns_` being an array of axioms.

The new representation is to make `columns_` an array of tuples instead,
where the first item in the tuple is either an axiom name or case #3, a
made up property, and the other (second) item in the tuple is an object
of overrides, or null if no overrides are desired. Existing code still
works out of the box except for case #2. The new way looks like this:

```
columns: [
  'foo', // same
  ['bar', { baz: 'woozle' }],
  foam.core.Property.create({ /* ... */ }) // same
]
```

By using this representation, we can look up the appropriate axiom on the
subclass using the axiom name for cases #1 and #2, and for #3 we just
use that axiom directly and don't perform a lookup.

FYI: @nanoMichal 