### PR TITLE
[CPF-4327] Fix repeat icon requests with ClientResourceCache

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -183,6 +183,7 @@ FOAM_FILES([
   { name: "foam/u2/Visibility"},
   { name: "foam/u2/RowFormatter" },
   { name: "foam/u2/WeakMap", flags: ['web'] },
+  { name: "foam/u2/ClientResourceCache", flags: ['js'] },
   { name: "foam/u2/Element", flags: ['js'] },
   { name: "foam/u2/Tooltip", flags: ['web'] },
   { name: "foam/u2/MNRowFormatter", flags: ['web'] },

--- a/src/foam/u2/ClientResourceCache.js
+++ b/src/foam/u2/ClientResourceCache.js
@@ -1,0 +1,50 @@
+foam.CLASS({
+  package: 'foam.u2',
+  name: 'ClientResourceCache',
+
+  axioms: [ foam.pattern.Singleton.create() ],
+
+  properties: [
+    {
+      name: 'files',
+      class: 'Map'
+    }
+  ],
+  
+  methods: [
+    {
+      name: 'saveImageFromURL',
+      documentation: `
+        This method saves an image to a client-side cache as a base64 url.
+        If the url was found in the cache, the corresponding base64 url is
+        returned, otherwise the original url is returned so the image can
+        be loaded as normal.
+      `,
+      code: function(url) {
+        var self = this;
+
+        if ( this.files[url] ) {
+          console.log('Found "'+url+'" in ClientResourceCache.');
+          return this.files[url];
+        }
+
+        var image = new Image();
+        image.crossOrigin = 'Anonymous';
+        image.addEventListener('load', (e) => {
+          var canvas = document.createElement('canvas');
+          var cctx = canvas.getContext('2d');
+
+          canvas.width = image.width;
+          canvas.height = image.height;
+          cctx.drawImage(image, 0, 0);
+
+          self.files[url] = canvas.toDataURL();
+          console.log('Added "'+url+'" to ClientResourceCache.');
+        });
+        image.src = url;
+
+        return url;
+      }
+    }
+  ]
+});

--- a/src/foam/u2/view/OverlayActionListView.js
+++ b/src/foam/u2/view/OverlayActionListView.js
@@ -31,22 +31,22 @@ foam.CLASS({
       name: 'obj'
     },
     {
-      class: 'URL',
+      class: 'Image',
       name: 'activeImageURL',
       value: 'images/Icon_More_Active.svg'
     },
     {
-      class: 'URL',
+      class: 'Image',
       name: 'restingImageURL',
       value: 'images/Icon_More_Resting.svg'
     },
     {
-      class: 'URL',
+      class: 'Image',
       name: 'hoverImageURL',
       value: 'images/Icon_More_Hover.svg'
     },
     {
-      class: 'URL',
+      class: 'Image',
       name: 'disabledImageURL',
       value: 'images/Icon_More_Disabled.svg'
     },
@@ -54,10 +54,16 @@ foam.CLASS({
       class: 'URL',
       name: 'imageURL_',
       expression: function(restingImageURL, hoverImageURL, disabledImageURL, activeImageURL, hovered_, disabled_, active_) {
-        if ( disabled_ ) return `url(${disabledImageURL})`;
-        if ( active_ ) return `url(${activeImageURL})`;
-        if ( hovered_ ) return `url(${hoverImageURL})`;
-        return `url(${restingImageURL})`;
+        var url = null;
+
+        if ( disabled_ ) url = disabledImageURL;
+        else if ( active_ ) url = activeImageURL;
+        else if ( hovered_ ) url = hoverImageURL;
+        else url = restingImageURL;
+
+        var ccache = foam.u2.ClientResourceCache.create();
+        url = ccache.saveImageFromURL(url);
+        return `url('${url}')`;
       }
     },
     {


### PR DESCRIPTION
This fixes repeat requests for icon images from OverlayActionListView. Because of [`oops, no reason was found`] adding a Cache-Control header to ResourceImageServlet doesn't prevent the browser from downloading hundreds of copies of the same icon. To fix this issue, a ClientResourceCache was added that stores the icon on the client as a base64 string.