### PR TITLE
Fix bug where the table refresh button wouldn't work sometimes

### DIFF
--- a/src/foam/comics/v2/DAOBrowserView.js
+++ b/src/foam/comics/v2/DAOBrowserView.js
@@ -191,7 +191,7 @@ foam.CLASS({
       toolTip: 'Refresh Table',
       icon: 'images/refresh-icon-black.svg',
       code: function(X) {
-        this.data.cmd_(X, foam.dao.CachingDAO.PURGE);
+        this.config.dao.cmd_(X, foam.dao.CachingDAO.PURGE);
         this.add(foam.u2.dialog.NotificationMessage.create({
           message: this.REFRESH_MSG
         }));


### PR DESCRIPTION
The issue was that it was expecting `this.data` to be set to a DAO, but really the DAO it uses comes from the DAOControllerConfig.