### PR TITLE
Add ability to clear rich choice view selection

### DIFF
--- a/src/foam/core/Validation.js
+++ b/src/foam/core/Validation.js
@@ -102,7 +102,8 @@ foam.CLASS({
         }
         return !required ? null : [[name],
           function() {
-            return !this.hasOwnProperty(name) && (`Please enter ${label.toLowerCase()}`);
+            const axiom = this.cls_.getAxiomByName(name);
+            return axiom.isDefaultValue(this[name]) && (`Please enter ${label.toLowerCase()}`);
           }]
       },
     },

--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -348,6 +348,9 @@ foam.CLASS({
       // when the user clicks somewhere else.
       var containerU2Element;
       const fn = function(evt) {
+        // This prevents a console error when opening the dropdown.
+        if ( containerU2Element === undefined ) return;
+
         var selfDOMElement = self.el();
         var containerDOMElement = containerU2Element.el();
 
@@ -362,9 +365,6 @@ foam.CLASS({
 
         var selfRect = selfDOMElement.getClientRects()[0];
         var containerRect = containerDOMElement.getClientRects()[0];
-
-        // This prevents a console error when opening the dropdown.
-        if ( containerRect === undefined ) return;
 
         if (
           ! (

--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -96,6 +96,10 @@ foam.CLASS({
     {
       name: 'CHOOSE_FROM',
       message: 'Choose from '
+    },
+    {
+      name: 'CLEAR_SELECTION',
+      message: 'Clear Selection'
     }
   ],
 
@@ -177,7 +181,8 @@ foam.CLASS({
       width: 100%;
     }
 
-    ^ .search input {
+    ^ .search input,
+    ^clear-btn {
       width: 100%;
       border: none;
       padding-left: %INPUTHORIZONTALPADDING%;
@@ -201,6 +206,15 @@ foam.CLASS({
 
     ^ .disabled:hover {
       cursor: default;
+    }
+
+    ^clear-btn {
+      background-color: /*%GREY4%*/ #e7eaec;
+    }
+
+    ^clear-btn:hover {
+      color: /*%DESTRUCTIVE3%*/ #d9170e;
+      cursor: pointer;
     }
   `,
 
@@ -324,6 +338,13 @@ foam.CLASS({
         Optional. If this is provided, an action will be included at the bottom
         of the dropdown.
       `
+    },
+    {
+      class: 'Boolean',
+      name: 'allowClearingSelection',
+      documentation: `
+        Set to true if you want the user to be able to clear their selection.
+      `
     }
   ],
 
@@ -434,6 +455,13 @@ foam.CLASS({
                         .endContext()
                       .end();
                   }))
+                  .add(self.slot(function(allowClearingSelection) {
+                    if ( ! allowClearingSelection ) return null;
+                    return this.E('button')
+                      .addClass(self.myClass('clear-btn'))
+                      .on('click', self.clearSelection)
+                      .add(self.CLEAR_SELECTION)
+                  }))
                   .add(self.slot(function(sections) {
                     var promiseArray = [];
                     sections.forEach(function(section) {
@@ -499,6 +527,11 @@ foam.CLASS({
           });
         }
       }
+    },
+    function clearSelection() {
+      this.data = undefined;
+      this.fullObject_ = undefined;
+      this.isOpen_ = false;
     }
   ],
 


### PR DESCRIPTION
An alternative to #3088.

Use a flag to determine whether or not to allow the user to clear their selection. If enabled, a button will be included in the dropdown that lets the user clear their selection.

Also fixes a console error and a validation bug.

## Screenshots
<img width="1616" alt="Screen Shot 2020-01-24 at 3 11 36 PM" src="https://user-images.githubusercontent.com/4259165/73100998-c221f300-3ebc-11ea-9f66-5228c600577c.png">
with hover:
<img width="1605" alt="Screen Shot 2020-01-24 at 3 11 46 PM" src="https://user-images.githubusercontent.com/4259165/73100999-c221f300-3ebc-11ea-9a3c-651a1403e330.png">
