### PR TITLE
Move clear button

### DIFF
--- a/src/foam/u2/detail/SectionedDetailPropertyView.js
+++ b/src/foam/u2/detail/SectionedDetailPropertyView.js
@@ -87,8 +87,8 @@ foam.CLASS({
     ^error .foam-u2-FloatView,
     ^error .foam-u2-DateView,
     ^error .foam-u2-view-date-DateTimePicker .date-display-box,
-    ^error .foam-u2-view-RichChoiceView-selection-view
-
+    ^error .foam-u2-view-RichChoiceView-selection-view,
+    ^error .foam-u2-view-RichChoiceView-clear-btn
     {
       border-color: /*%DESTRUCTIVE3%*/ #d9170e !important;
     }

--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -99,7 +99,7 @@ foam.CLASS({
     },
     {
       name: 'CLEAR_SELECTION',
-      message: 'Clear Selection'
+      message: 'Clear'
     }
   ],
 
@@ -144,8 +144,8 @@ foam.CLASS({
 
       height: /*%INPUTHEIGHT%*/ 32px;
       font-size: 14px;
-      padding-left: %INPUTHORIZONTALPADDING%;
-      padding-right: %INPUTHORIZONTALPADDING%;
+      padding-left: /*%INPUTHORIZONTALPADDING%*/ 8px;
+      padding-right: /*%INPUTHORIZONTALPADDING%*/ 8px;
       border: 1px solid;
       border-radius: 3px;
       color: /*%BLACK%*/ #1e1f21;
@@ -156,7 +156,8 @@ foam.CLASS({
       min-width: 94px;
     }
 
-    ^selection-view:hover {
+    ^selection-view:hover,
+    ^selection-view:hover ^clear-btn {
       border-color: /*%GREY2%*/ #9ba1a6;
     }
 
@@ -164,7 +165,8 @@ foam.CLASS({
       outline: none;
     }
 
-    ^:focus ^selection-view {
+    ^:focus ^selection-view,
+    ^:focus ^selection-view ^clear-btn {
       border-color: /*%PRIMARY3%*/ #406dea;
     }
 
@@ -181,12 +183,11 @@ foam.CLASS({
       width: 100%;
     }
 
-    ^ .search input,
-    ^clear-btn {
+    ^ .search input {
       width: 100%;
       border: none;
-      padding-left: %INPUTHORIZONTALPADDING%;
-      padding-right: %INPUTHORIZONTALPADDING%;
+      padding-left: /*%INPUTHORIZONTALPADDING%*/ 8px;
+      padding-right: /*%INPUTHORIZONTALPADDING%*/ 8px;
       height: /*%INPUTHEIGHT%*/ 32px;
     }
 
@@ -209,7 +210,16 @@ foam.CLASS({
     }
 
     ^clear-btn {
-      background-color: /*%GREY4%*/ #e7eaec;
+      display: flex;
+      align-items: center;
+      border-left: 1px;
+      padding-left: /*%INPUTHORIZONTALPADDING%*/ 8px;
+      padding-right: /*%INPUTHORIZONTALPADDING%*/ 8px;
+      height: /*%INPUTHEIGHT%*/ 32px;
+      border-left: 1px solid;
+      border-color: /*%GREY3%*/ #cbcfd4;
+      margin-left: 12px;
+      padding-left: 16px;
     }
 
     ^clear-btn:hover {
@@ -431,6 +441,13 @@ foam.CLASS({
                 .start()
                   .addClass(this.myClass('chevron'))
                 .end()
+                .add(this.slot(function(allowClearingSelection) {
+                  if ( ! allowClearingSelection ) return null;
+                  return this.E()
+                    .addClass(self.myClass('clear-btn'))
+                    .on('click', self.clearSelection)
+                    .add(self.CLEAR_SELECTION)
+                }))
               .end()
               .add(this.slot(function(hasBeenOpenedYet_) {
                 if ( ! hasBeenOpenedYet_ ) return this.E();
@@ -454,13 +471,6 @@ foam.CLASS({
                           } }))
                         .endContext()
                       .end();
-                  }))
-                  .add(self.slot(function(allowClearingSelection) {
-                    if ( ! allowClearingSelection ) return null;
-                    return this.E('button')
-                      .addClass(self.myClass('clear-btn'))
-                      .on('click', self.clearSelection)
-                      .add(self.CLEAR_SELECTION)
                   }))
                   .add(self.slot(function(sections) {
                     var promiseArray = [];
@@ -528,10 +538,10 @@ foam.CLASS({
         }
       }
     },
-    function clearSelection() {
+    function clearSelection(evt) {
+      evt.stopImmediatePropagation();
       this.data = undefined;
       this.fullObject_ = undefined;
-      this.isOpen_ = false;
     }
   ],
 


### PR DESCRIPTION
Moves the new clear button for the RichChoiceView inline with the selection view.

See #3090 for context.

## Screenshots

### Resting, Invalid
<img width="1381" alt="Screen Shot 2020-01-27 at 9 39 23 AM" src="https://user-images.githubusercontent.com/4259165/73183759-56709d80-40e9-11ea-976d-0de48790a0d8.png">

### Hovering on the clear button
<img width="1380" alt="Screen Shot 2020-01-27 at 9 39 56 AM" src="https://user-images.githubusercontent.com/4259165/73183757-55d80700-40e9-11ea-8d9f-10dbe0ed3cf7.png">

### Focused
<img width="1378" alt="Screen Shot 2020-01-27 at 9 39 44 AM" src="https://user-images.githubusercontent.com/4259165/73183758-56709d80-40e9-11ea-9653-5d20f1b268e5.png">

