### PR TITLE
Fix bug where clearing a reference property wasn't working

### DIFF
--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -527,6 +527,11 @@ foam.CLASS({
       if ( mode !== foam.u2.DisplayMode.RW ) {
         this.isOpen_ = false;
       }
+    },
+
+    function fromProperty(property) {
+      this.SUPER(property);
+      this.prop = property;
     }
   ],
 
@@ -543,8 +548,17 @@ foam.CLASS({
     },
     function clearSelection(evt) {
       evt.stopImmediatePropagation();
-      this.data = undefined;
       this.fullObject_ = undefined;
+
+      // If this view is being used for a property, then when the user clears
+      // their selection we set the value back to the default value for that
+      // property type. We can't simply set it to undefined because that
+      // introduces a bug where it's impossible to update an object to set a
+      // Reference property back to a default value, since a value of undefined
+      // will cause the JSON outputter to ignore that property when performing
+      // the put. Instead, we need to explicitly set the value to the default
+      // value.
+      this.data = this.prop ? this.prop.value : undefined;
     }
   ],
 


### PR DESCRIPTION
The data-binding was working in that the property was being reset back
to a sort of default state. So when I inspected the value of the
property before being put, it appeared correct. For instance, for a
Reference property to something with a Long id property, the reference
property's value would be 0 after clearing, which is what I'd expect.
However, after inspecting the HTTP request that gets sent out for the
put, I noticed that the Reference property I wanted to reset back to 0
wasn't included in the request.

FOAM has a concept of properties being in one of two states: explicitly
set or not. I admittedly don't have very good terminology for describing
this, but this is my understanding. If a property hasn't been explicitly
set to something (via code like `foo.bar = 42`), then when you access
it, it will fall back on either a `getter`, `factory`, `expression`,
`value`, or possibly even other things. When it falls back on such
things to retrieve a value, this is the 'not explicitly set' state, for
lack of a better term.

The JSON outputter uses this idea of a property being 'explicitly set'
or not when deciding how to output an instance of an FObject. It ignores
properties that are not explicitly set. Since the JSON outputter is used
when putting an object to a DAO from the client where the DAO is
server-side, we need to force the property into an explicitly set state
that contains the default value, since a not explicitly set state will
be ignored, even if it has the same value.