### PR TITLE
Define Pixel Value

### DIFF
--- a/src/foam/u2/detail/SectionedDetailPropertyView.js
+++ b/src/foam/u2/detail/SectionedDetailPropertyView.js
@@ -291,8 +291,8 @@ foam.CLASS({
                       .start({
                         class: 'foam.u2.tag.Image',
                         data: 'images/inline-error-icon.svg',
-                        displayHeight: 16,
-                        displayWidth: 16
+                        displayHeight: '16px',
+                        displayWidth: '16px'
                       })
                         .style({
                           'justify-content': 'flex-start',


### PR DESCRIPTION
Addresses: https://nanopay.atlassian.net/browse/CPF-3446

Explicitly set a pixel value to the error image displayHeight and displayWidth on the sectionedDetailPropertyView. This was causing issues on various browsers.