### PR TITLE
move journal printing into sync part of assembly line

### DIFF
--- a/src/foam/dao/AbstractFileJournal.js
+++ b/src/foam/dao/AbstractFileJournal.js
@@ -182,7 +182,10 @@ try {
             dao.put_(x, obj);
           }
 
-          public void executeJob() {
+          public void executeJob() { }
+
+          public void endJob() {
+
             try {
               record_ = ( old != null ) ?
                 getOutputter().stringifyDelta(old, obj) :
@@ -190,9 +193,8 @@ try {
             } catch (Throwable t) {
               getLogger().error("Failed to write put entry to journal", t);
             }
-          }
 
-          public void endJob() {
+
             if ( foam.util.SafetyUtil.isEmpty(record_) ) return;
 
             try {


### PR DESCRIPTION
under high load of puts journal entries are written out of order, leading to digest verification failure.
By syncing the print, we slow things down but ensure they are printed in order.