### PR TITLE
Fix bug where editing table columns wasn't working

### DIFF
--- a/src/foam/u2/view/EditColumnsView.js
+++ b/src/foam/u2/view/EditColumnsView.js
@@ -107,8 +107,10 @@ foam.CLASS({
         mode: 'RO'
       },
       factory: function() {
-        return this.allColumns.map(c => {
-          return this.ColumnConfig.create({ of: this.of, axiom: c });
+        return this.allColumns.map(([axiomName, overridesMap]) => {
+          const axiom = this.of.getAxiomByName(axiomName);
+          if ( overridesMap ) axiom = axiom.clone().copyFrom(overridesMap);
+          return this.ColumnConfig.create({ of: this.of, axiom: axiom });
         });
       }
     },

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -200,12 +200,12 @@ foam.CLASS({
 
     function initE() {
       var view = this;
-      var columnSelectionE;
 
       if ( this.filteredTableColumns$ ) {
-        // TODO
         this.onDetach(this.filteredTableColumns$.follow(
-          this.columns_$.map((cols) => cols.map((a) => a.name))));
+          this.columns_$.map((cols) => cols.map(([axiomOrColumnName, overrides]) => {
+            return (typeof axiomOrColumnName) === 'string' ? axiomOrColumnName : axiomOrColumnName.name;
+          }))));
       }
 
       this.


### PR DESCRIPTION
I accidentally broke the feature where users are able to edit the table columns in commit b56452e466719c6ebb37c95a91cfe79b65b8f104. This commit fixes that regression.

Also resolved a TODO comment I forgot about in the same commit that @kgrgreer mentioned here: https://github.com/foam-framework/foam2/pull/3080#discussion_r372423337