### PR TITLE
[DOP-153] Fix NodeFileJournal and JDAO

### DIFF
--- a/src/foam/dao/JDAO.js
+++ b/src/foam/dao/JDAO.js
@@ -27,8 +27,13 @@ foam.CLASS({
       name: 'promise',
       factory: function() {
         var self = this;
-        return this.journal.replay(this.delegate).then(function(dao) {
-          dao.listen(self.journal);
+        return this.journal.replay(null, this.delegate).then(function(dao) {
+          // TODO: can't use `requires` for class used inside factory
+          sink = foam.dao.JournalSink.create({
+            journal: self.journal,
+            dao: self.delegate,
+          });
+          dao.listen(sink);
           return dao;
         });
       }

--- a/src/foam/dao/Journal.js
+++ b/src/foam/dao/Journal.js
@@ -110,7 +110,12 @@ if ( foam.isServer ) {
               "));\n"));
       },
 
-      function remove(x, obj) {
+      function put(x, prefix, dao, obj) {
+        var old = dao.find_(x, obj.id);
+        this.put_(x, old, obj);
+      },
+
+      function remove(x, prefix, dao, obj) {
         return this.write_(Buffer.from(
             "remove(foam.json.parse(" +
               foam.json.Storage.stringify(obj, this.of) +

--- a/src/foam/dao/Sink.js
+++ b/src/foam/dao/Sink.js
@@ -789,3 +789,54 @@ foam.CLASS({
     }
   ]
 });
+
+foam.CLASS({
+  package: 'foam.dao',
+  name: 'JournalSink',
+
+  implements: [ 'foam.dao.Sink' ],
+
+  properties: [
+    {
+      name: 'journal',
+      class: 'FObjectProperty',
+      of: 'foam.dao.Journal'
+    },
+    {
+      name: 'dao',
+      class: 'foam.dao.DAOProperty'
+    },
+    {
+      name: 'prefix',
+      class: 'String',
+      value: ''
+    }
+  ],
+
+  methods: [
+    {
+      name: 'put',
+      code: function(o) {
+        var x = this.__context__; // TODO: is this always correct?
+        this.journal.put(x, '', this.dao, o);
+      },
+    },
+    {
+      name: 'remove',
+      code: function(o) {
+        var x = this.__context__; // TODO: is this always correct?
+        this.journal.remove(x, '', this.dao, o);
+      },
+    },
+    {
+      name: 'eof',
+      code: function() {},
+    },
+    {
+      name: 'reset',
+      code: function() {
+        console.warn('use of unimplemented JournalSink.reset()');
+      },
+    }
+  ]
+});


### PR DESCRIPTION
The Javascript-side JDAO is currently broken and cannot be used with NodeFileJournal. This is because JDAO passes a journal to `dao.listen()`, which assumes Journal implements Sink (this was probably true at a previous time). This PR fixes the issue by creating a Sink for implementors of Journal.