### PR TITLE
Slightly improve UX for editing table columns

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -488,6 +488,7 @@ FOAM_FILES([
   { name: "foam/u2/view/UnstyledTableView", flags: ['web'] },
   { name: "foam/u2/view/TableView", flags: ['web'] },
   { name: "foam/u2/view/EditColumnsView", flags: ['web'] },
+  { name: "foam/u2/view/ColumnConfigView", flags: ['web'] },
   { name: "foam/u2/md/OverlayDropdown", flags: ['web'] },
   { name: "foam/u2/view/ScrollTableView", flags: ['web'] },
   { name: "foam/u2/view/ScrollDAOView", flags: ['web'] },

--- a/src/files2.js
+++ b/src/files2.js
@@ -430,6 +430,7 @@ FOAM_FILES([
   { name: "foam/u2/view/UnstyledTableView", flags: ['web'] },
   { name: "foam/u2/view/TableView", flags: ['web'] },
   { name: "foam/u2/view/EditColumnsView", flags: ['web'] },
+  { name: "foam/u2/view/ColumnConfigView", flags: ['web'] },
   { name: "foam/u2/md/OverlayDropdown", flags: ['web'] },
   { name: "foam/u2/view/ScrollTableView", flags: ['web'] },
   { name: "foam/u2/view/ScrollDAOView", flags: ['web'] },

--- a/src/foam/comics/v2/DAOControllerConfig.js
+++ b/src/foam/comics/v2/DAOControllerConfig.js
@@ -62,7 +62,7 @@ foam.CLASS({
       expression: function(of) { return 'Create a New ' + of.model_.label; }
     },
     {
-      class: 'StringArray',
+      class: 'Array',
       name: 'defaultColumns',
       factory: null,
       expression: function(of) {

--- a/src/foam/u2/view/ArrayView.js
+++ b/src/foam/u2/view/ArrayView.js
@@ -16,6 +16,7 @@ foam.CLASS({
   ],
 
   exports: [
+    'enableRemoving',
     'mode',
     'updateData'
   ],
@@ -29,6 +30,16 @@ foam.CLASS({
     {
       name: 'defaultNewItem',
       value: ''
+    },
+    {
+      class: 'Boolean',
+      name: 'enableAdding',
+      value: true
+    },
+    {
+      class: 'Boolean',
+      name: 'enableRemoving',
+      value: true
     }
   ],
 
@@ -36,8 +47,8 @@ foam.CLASS({
     {
       name: 'addRow',
       label: 'Add',
-      isAvailable: function(mode) {
-        return mode === foam.u2.DisplayMode.RW;
+      isAvailable: function(mode, enableAdding) {
+        return enableAdding && mode === foam.u2.DisplayMode.RW;
       },
       code: function() {
         var newItem = this.defaultNewItem;
@@ -55,6 +66,7 @@ foam.CLASS({
       name: 'Row',
       imports: [ 
         'data',
+        'enableRemoving',
         'mode',
         'updateData'
       ],
@@ -75,8 +87,8 @@ foam.CLASS({
         {
           name: 'remove',
           label: '',
-          isAvailable: function(mode) {
-            return mode === foam.u2.DisplayMode.RW;
+          isAvailable: function(enableRemoving, mode) {
+            return enableRemoving && mode === foam.u2.DisplayMode.RW;
           },
           code: function() {
             this.data.splice(this.index, 1);

--- a/src/foam/u2/view/ColumnConfigView.js
+++ b/src/foam/u2/view/ColumnConfigView.js
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.u2.view',
+  name: 'ColumnConfigView',
+  extends: 'foam.u2.View',
+
+  documentation: 'A view for configuring table columns.',
+
+  requires: [
+    'foam.u2.md.CheckBox'
+  ],
+
+  css: `
+    ^ {
+      padding: 8px 0;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+    }
+    ^ > * {
+      align-self: center;
+    }
+  `,
+
+  methods: [
+    function initE() {
+      this.SUPER();
+      this
+        .addClass(this.myClass())
+        .start('span').call(this.data.axiom.tableHeaderFormatter, [this.data.axiom]).end()
+        .tag(this.data.VISIBILITY);
+    }
+  ]
+});

--- a/src/foam/u2/view/EditColumnsView.js
+++ b/src/foam/u2/view/EditColumnsView.js
@@ -100,8 +100,10 @@ foam.CLASS({
       name: 'columns',
       view: {
         class: 'foam.u2.view.FObjectArrayView',
-        mode: 'RO'
         valueView: { class: 'foam.u2.view.ColumnConfigView' },
+        mode: 'RO',
+        enableAdding: false,
+        enableRemoving: false
       },
       factory: function() {
         var rtn = this.allColumns.map(([axiomName, overridesMap]) => {

--- a/src/foam/u2/view/EditColumnsView.js
+++ b/src/foam/u2/view/EditColumnsView.js
@@ -100,18 +100,23 @@ foam.CLASS({
       name: 'columns',
       view: {
         class: 'foam.u2.view.FObjectArrayView',
-        valueView: {
-          class: 'foam.u2.detail.SectionView',
-          sectionName: '_defaultSection'
-        },
         mode: 'RO'
+        valueView: { class: 'foam.u2.view.ColumnConfigView' },
       },
       factory: function() {
-        return this.allColumns.map(([axiomName, overridesMap]) => {
+        var rtn = this.allColumns.map(([axiomName, overridesMap]) => {
           const axiom = this.of.getAxiomByName(axiomName);
           if ( overridesMap ) axiom = axiom.clone().copyFrom(overridesMap);
           return this.ColumnConfig.create({ of: this.of, axiom: axiom });
         });
+
+        // Sort columns alphabetically. This doesn't quite work since what we
+        // actually display is up to tableHeaderFormatter, which works directly
+        // with the view instead of returning a String, so there's no way for
+        // us to actually know what the user is going to see.
+        rtn.sort((l, r) => l.label < r.label ? -1 : 1);
+
+        return rtn;
       }
     },
     {

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -72,7 +72,7 @@ foam.CLASS({
           var v = this.ColumnConfig.create({ of: of, axiom : (typeof c[0] === 'string' ? of.getAxiomByName(c[0]) : c[0]) }).visibility;
           return v == this.ColumnVisibility.ALWAYS_HIDE ? false :
                  v == this.ColumnVisibility.ALWAYS_SHOW ? true :
-                 columns.find(c2 => c[0] == c2[0])  ? true : false;
+                 columns.some(c2 => c[0] == c2[0]);
         });
       },
     },


### PR DESCRIPTION
## Changes

* Fixed an incorrect type that wasn't letting us specify table columns with axiom property overrides for the newer DAO controller
* UX improvements while editing columns
  * Hide buttons for adding and removing rows, since they don't make sense in this context
  * Vertically center the axiom labels and add a bit of vertical padding
  * Sort alphabetically by label

## Screenshots

### Old
<img width="1663" alt="Screen Shot 2020-01-31 at 11 42 35 AM" src="https://user-images.githubusercontent.com/4259165/73557201-cb601200-441e-11ea-9fec-a31f43450230.png">


### New (with flags set to false to hide remove and add)
<img width="1656" alt="Screen Shot 2020-01-31 at 11 22 36 AM" src="https://user-images.githubusercontent.com/4259165/73557118-a8cdf900-441e-11ea-8fcd-118a3cb95ac7.png">
