### PR TITLE
Let TableView handle narrow screens a bit better

### DIFF
--- a/src/foam/u2/view/TableView.js
+++ b/src/foam/u2/view/TableView.js
@@ -17,6 +17,7 @@ foam.CLASS({
       border-bottom: 1px solid /*%GREY4%*/ #e7eaec;
       display: flex;
       height: 48px;
+      box-sizing: border-box;
     }
 
     ^tbody > ^tr:hover {

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -40,6 +40,19 @@ foam.CLASS({
     'stack?'
   ],
 
+  constants: [
+    {
+      type: 'Int',
+      name: 'MIN_COLUMN_WIDTH_FALLBACK',
+      value: 100
+    },
+    {
+      type: 'Int',
+      name: 'EDIT_COLUMNS_BUTTON_CONTAINER_WIDTH',
+      value: 60
+    }
+  ],
+
   properties: [
     {
       class: 'Class',
@@ -188,6 +201,17 @@ foam.CLASS({
       class: 'Boolean',
       name: 'allCheckBoxesEnabled_',
       documentation: 'Used internally to denote when the user has pressed the checkbox in the header to enable all checkboxes.'
+    },
+    {
+      class: 'Int',
+      name: 'tableWidth_',
+      documentation: 'Width of the whole table. Used to get proper scrolling on narrow screens.',
+      expression: function(of, columns_) {
+        return columns_.reduce((acc, col) => {
+          const axiom = typeof col[0] === 'string' ? of.getAxiomByName(col[0]) : col[0];
+          return acc + (axiom.tableWidth || this.MIN_COLUMN_WIDTH_FALLBACK);
+        }, this.EDIT_COLUMNS_BUTTON_CONTAINER_WIDTH) + 'px';
+      }
     }
   ],
 
@@ -213,6 +237,7 @@ foam.CLASS({
         addClass(this.myClass(this.of.id.replace(/\./g, '-'))).
         start().
           addClass(this.myClass('thead')).
+          style({ 'min-width': this.tableWidth_$ }).
           show(this.showHeader$).
           add(this.slot(function(columns_) {
             return this.E().
@@ -288,7 +313,7 @@ foam.CLASS({
               call(function() {
                 this.start().
                   addClass(view.myClass('th')).
-                  style({ flex: '0 0 60px' }).
+                  style({ flex: `0 0 ${this.EDIT_COLUMNS_BUTTON_CONTAINER_WIDTH}px` }).
                   callIf(view.editColumnsEnabled, function() {
                     this.addClass(view.myClass('th-editColumns')).
                     on('click', function(e) {
@@ -370,6 +395,7 @@ foam.CLASS({
                       view.myClass('selected') : '';
                 })).
                 addClass(view.myClass('row')).
+                style({ 'min-width': view.tableWidth_$ }).
 
                 // If the multi-select feature is enabled, then we render a
                 // Checkbox in the first cell of each row.
@@ -464,7 +490,7 @@ foam.CLASS({
                 start().
                   addClass(view.myClass('td')).
                   attrs({ name: 'contextMenuCell' }).
-                  style({ flex: '0 0 60px' }).
+                  style({ flex: `0 0 ${this.EDIT_COLUMNS_BUTTON_CONTAINER_WIDTH}px` }).
                   tag(view.OverlayActionListView, {
                     data: actions,
                     obj: obj


### PR DESCRIPTION
Specifies a minimum width of 150 pixels for each column if not already specified by `tableWidth`. Makes it possible to still use tables when the screen isn't wide enough to effectively display all of the information.