### PR TITLE
Fix visual bug where empty space would show between pages in ScrollTableView

### DIFF
--- a/src/foam/u2/view/TableView.js
+++ b/src/foam/u2/view/TableView.js
@@ -12,12 +12,14 @@ foam.CLASS({
   css: `
     ^tr {
       background: white;
+      display: flex;
+      height: 48px;
+    }
+
+    ^tbody > ^tr {
       border-left: 1px solid /*%GREY4%*/ #e7eaec;
       border-right: 1px solid /*%GREY4%*/ #e7eaec;
       border-bottom: 1px solid /*%GREY4%*/ #e7eaec;
-      display: flex;
-      height: 48px;
-      box-sizing: border-box;
     }
 
     ^tbody > ^tr:hover {
@@ -26,6 +28,7 @@ foam.CLASS({
     }
 
     ^thead {
+      border: 1px solid /*%GREY4%*/ #e7eaec;
       border-radius: 5px;
       box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.08);
       overflow: hidden;

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -313,7 +313,7 @@ foam.CLASS({
               call(function() {
                 this.start().
                   addClass(view.myClass('th')).
-                  style({ flex: `0 0 ${this.EDIT_COLUMNS_BUTTON_CONTAINER_WIDTH}px` }).
+                  style({ flex: `0 0 ${view.EDIT_COLUMNS_BUTTON_CONTAINER_WIDTH}px` }).
                   callIf(view.editColumnsEnabled, function() {
                     this.addClass(view.myClass('th-editColumns')).
                     on('click', function(e) {
@@ -490,7 +490,7 @@ foam.CLASS({
                 start().
                   addClass(view.myClass('td')).
                   attrs({ name: 'contextMenuCell' }).
-                  style({ flex: `0 0 ${this.EDIT_COLUMNS_BUTTON_CONTAINER_WIDTH}px` }).
+                  style({ flex: `0 0 ${view.EDIT_COLUMNS_BUTTON_CONTAINER_WIDTH}px` }).
                   tag(view.OverlayActionListView, {
                     data: actions,
                     obj: obj


### PR DESCRIPTION
FYI @tharmaman 

Also fixes a regression introduced a few weeks ago where the top-border stopped showing on the table header.

Also fixes a bug where the width of the context menu column was getting set to undefined.