### PR TITLE
Don't show serviceClass or boxClass to unauthorized users

### DIFF
--- a/src/foam/nanos/boot/NSpec.js
+++ b/src/foam/nanos/boot/NSpec.js
@@ -124,12 +124,16 @@ foam.CLASS({
     {
       class: 'String',
       name: 'serviceClass',
-      displayWidth: 80
+      displayWidth: 80,
+      readPermissionRequired: true,
+      writePermissionRequired: true
     },
     {
       class: 'String',
       name: 'boxClass',
-      displayWidth: 80
+      displayWidth: 80,
+      readPermissionRequired: true,
+      writePermissionRequired: true
     },
     {
       class: 'Code',


### PR DESCRIPTION
`serviceScript` is already `readPermissionRequired` and `writePermissionRequired`, which is most important. Might as well do the same for these two though.