### PR TITLE
changes to validation for accounting for autocomplete

### DIFF
--- a/src/foam/nanos/u2/navigation/SignIn.js
+++ b/src/foam/nanos/u2/navigation/SignIn.js
@@ -19,8 +19,7 @@ foam.CLASS({
     { name: 'FOOTER_TXT', message: 'Not a user yet?' },
     { name: 'FOOTER_LINK', message: 'Create an account' },
     { name: 'SUB_FOOTER_LINK', message: 'Forgot password?' },
-    { name: 'ERROR_MSG1', message: 'There was an issue with logging in.' },
-    { name: 'ERROR_MSG2', message: 'Please check email and password, and try again.' }
+    { name: 'ERROR_MSG1', message: 'There was an issue with logging in.' }
   ],
 
   properties: [
@@ -105,19 +104,10 @@ foam.CLASS({
     {
       name: 'login',
       label: 'Sign in',
+      isEnabled: function(errors_) {
+        return ! errors_;
+      },
       code: async function(X) {
-        if ( this.errors_ ) {
-          // Format an error msg for users
-          let errMsg = '';
-          for ( i = 0; i < this.errors_.length; i++ ) {
-            if ( ! this.errors_[i] ) continue;
-            errMsg += this.errors_[i].length == 2 ?
-              `${i+1}) ${this.errors_[i][0].name} input is not correct: ${this.errors_[i][1]} ` :
-              `${i+1}) Input error: ${this.errors_[i]} `;
-          }
-          this.notify(errMsg || this.ERROR_MSG2, 'error');
-          return;
-        }
         this.auth.loginByEmail(X, this.email, this.password).then(
           (logedInUser) => {
             if ( ! logedInUser ) return;


### PR DESCRIPTION
addresses: https://nanopay.atlassian.net/browse/CPF-4571

Went through options with design to handle auto-validation, and so:

decided that it's best to ignore that the button is reading an error, since selecting 'Sign In' still functions as a user action, and works correctly as soon as that happens.