### PR TITLE
Table Filter Loading Fix

### DIFF
--- a/src/foam/u2/filter/ReferenceFilterView.js
+++ b/src/foam/u2/filter/ReferenceFilterView.js
@@ -269,7 +269,7 @@ foam.CLASS({
                 .add(self.LABEL_LOADING)
               .end();
           }
-          if ( filteredOptions.length == 0 ) {
+          if ( filteredOptions.length === 0 ) {
             return element
               .start('p').addClass(self.myClass('label-loading'))
                 .add(self.LABEL_NO_OPTIONS)

--- a/src/foam/u2/filter/ReferenceFilterView.js
+++ b/src/foam/u2/filter/ReferenceFilterView.js
@@ -153,7 +153,10 @@ foam.CLASS({
     {
       name: 'filteredOptions',
       expression: function(property, daoContents, idToStringDisplayMap, search, selectedOptions) {
-        if ( ! daoContents || daoContents.length === 0 || ! idToStringDisplayMap ) return [];
+        if ( ! daoContents || daoContents.length === 0 || ! idToStringDisplayMap ) {
+          this.isLoading = false;
+          return [];
+        }
         var options = Object.values(idToStringDisplayMap);
         // Filter out search
         if ( search ) {
@@ -210,6 +213,7 @@ foam.CLASS({
   messages: [
     { name: 'LABEL_PLACEHOLDER', message: 'Search' },
     { name: 'LABEL_LOADING', message: '- LOADING OPTIONS -' },
+    { name: 'LABEL_NO_OPTIONS', message: '- NO OPTIONS AVAILABLE -' },
     { name: 'LABEL_SELECTED', message: 'SELECTED OPTIONS' },
     { name: 'LABEL_FILTERED', message: 'OPTIONS' }
   ],
@@ -264,6 +268,11 @@ foam.CLASS({
             return element
               .start('p').addClass(self.myClass('label-loading'))
                 .add(self.LABEL_LOADING)
+              .end();
+          } else if ( filteredOptions.length == 0 ) {
+            return element
+              .start('p').addClass(self.myClass('label-loading'))
+                .add(self.LABEL_NO_OPTIONS)
               .end();
           }
           return element

--- a/src/foam/u2/filter/ReferenceFilterView.js
+++ b/src/foam/u2/filter/ReferenceFilterView.js
@@ -153,10 +153,8 @@ foam.CLASS({
     {
       name: 'filteredOptions',
       expression: function(property, daoContents, idToStringDisplayMap, search, selectedOptions) {
-        if ( ! daoContents || daoContents.length === 0 || ! idToStringDisplayMap ) {
-          this.isLoading = false;
-          return [];
-        }
+        if ( ! daoContents || daoContents.length === 0 || ! idToStringDisplayMap ) return [];
+
         var options = Object.values(idToStringDisplayMap);
         // Filter out search
         if ( search ) {
@@ -227,6 +225,7 @@ foam.CLASS({
       this.onDetach(this.setOfReferenceIds$.sub(this.updateReferenceObjectsArray));
       this.dao.select(this.GROUP_BY(this.property, this.COUNT())).then(function(result) {
         self.daoContents = result.groupKeys; //  gets contents from the source dao
+        self.isLoading = false;
       });
       this
         .addClass(this.myClass())
@@ -269,7 +268,8 @@ foam.CLASS({
               .start('p').addClass(self.myClass('label-loading'))
                 .add(self.LABEL_LOADING)
               .end();
-          } else if ( filteredOptions.length == 0 ) {
+          }
+          if ( filteredOptions.length == 0 ) {
             return element
               .start('p').addClass(self.myClass('label-loading'))
                 .add(self.LABEL_NO_OPTIONS)

--- a/src/foam/u2/filter/StringFilterView.js
+++ b/src/foam/u2/filter/StringFilterView.js
@@ -100,6 +100,7 @@ foam.CLASS({
   messages: [
     { name: 'LABEL_PLACEHOLDER', message: 'Search' },
     { name: 'LABEL_LOADING', message: '- LOADING OPTIONS -' },
+    { name: 'LABEL_NO_OPTIONS', message: '- NO OPTIONS AVAILABLE -' },
     { name: 'LABEL_SELECTED', message: 'SELECTED OPTIONS' },
     { name: 'LABEL_FILTERED', message: 'OPTIONS' },
     { name: 'LABEL_EMPTY', message: '- Not Defined -' }
@@ -141,7 +142,10 @@ foam.CLASS({
     {
       name: 'filteredOptions',
       expression: function(daoContents, selectedOptions) {
-        if ( ! daoContents || daoContents.length === 0 ) return [];
+        if ( ! daoContents || daoContents.length === 0 ) {
+          this.isLoading = false;
+          return [];
+        }
 
         var options = daoContents.map((obj) => obj.trim());
 
@@ -232,6 +236,11 @@ foam.CLASS({
               return element
                 .start('p').addClass(self.myClass('label-loading'))
                   .add(self.LABEL_LOADING)
+                .end();
+            } else if ( filteredOptions.length == 0 ) {
+              return element
+                .start('p').addClass(self.myClass('label-loading'))
+                  .add(self.LABEL_NO_OPTIONS)
                 .end();
             }
             return element

--- a/src/foam/u2/filter/StringFilterView.js
+++ b/src/foam/u2/filter/StringFilterView.js
@@ -142,10 +142,7 @@ foam.CLASS({
     {
       name: 'filteredOptions',
       expression: function(daoContents, selectedOptions) {
-        if ( ! daoContents || daoContents.length === 0 ) {
-          this.isLoading = false;
-          return [];
-        }
+        if ( ! daoContents || daoContents.length === 0 ) return [];
 
         var options = daoContents.map((obj) => obj.trim());
 
@@ -156,7 +153,6 @@ foam.CLASS({
           });
         });
 
-        this.isLoading = false;
         return options;
       }
     },
@@ -193,6 +189,7 @@ foam.CLASS({
         arg2: this.Count.create()
       })).then((results) => {
         this.daoContents = results.groupKeys;
+        this.isLoading = false;
       });
 
       var self = this;
@@ -237,7 +234,8 @@ foam.CLASS({
                 .start('p').addClass(self.myClass('label-loading'))
                   .add(self.LABEL_LOADING)
                 .end();
-            } else if ( filteredOptions.length == 0 ) {
+            }
+            if ( filteredOptions.length == 0 ) {
               return element
                 .start('p').addClass(self.myClass('label-loading'))
                   .add(self.LABEL_NO_OPTIONS)

--- a/src/foam/u2/filter/StringFilterView.js
+++ b/src/foam/u2/filter/StringFilterView.js
@@ -235,7 +235,7 @@ foam.CLASS({
                   .add(self.LABEL_LOADING)
                 .end();
             }
-            if ( filteredOptions.length == 0 ) {
+            if ( filteredOptions.length === 0 ) {
               return element
                 .start('p').addClass(self.myClass('label-loading'))
                   .add(self.LABEL_NO_OPTIONS)


### PR DESCRIPTION
If a table property filter returns an empty array in the filter view, a message is displayed "- NO OPTIONS AVAILABLE -" instead of always showing "- LOADING OPTIONS -" even though no data is returned.