### PR TITLE
Fix bug regarding TabbedDetailView width

### DIFF
--- a/src/foam/u2/detail/SectionedDetailPropertyView.js
+++ b/src/foam/u2/detail/SectionedDetailPropertyView.js
@@ -250,7 +250,7 @@ foam.CLASS({
               .start()
                 .style({ 'position': 'relative', 'display': 'inline-flex', 'width': '100%' })
                 .start()
-                  .style({ 'flex-grow': 1 })
+                  .style({ 'flex-grow': 1, 'max-width': '100%' })
                   .tag(prop, { mode$: this.mode$ })
                   .callIf(prop.validationStyleEnabled, function() {
                     this.enableClass(self.myClass('error'), errorSlot);


### PR DESCRIPTION
If there were a enough tabs to overflow the container, then the whole
detail view would become wide enough to fit all of the tabs in one row.
This had the unfortunate side effect of making the content of the tab
overly wide as well, which means the content was getting cut off when
TabbedDetailView is used in the DAO controller.

This commit fixes that issue by making it so that only the row of tabs
is scrollable. The content doesn't expand to match it.

## Before
<img width="1038" alt="Screen Shot 2020-02-12 at 11 33 16 AM" src="https://user-images.githubusercontent.com/4259165/74356376-3e0cae00-4d8c-11ea-902d-46dbf6736c82.png">

## After
<img width="1038" alt="Screen Shot 2020-02-12 at 11 09 27 AM" src="https://user-images.githubusercontent.com/4259165/74356378-3f3ddb00-4d8c-11ea-895e-8b21731f1a63.png">