### PR TITLE
[CPF-4574] Add assertion to 'of' of DAOProperty

### DIFF
--- a/src/foam/dao/DAOProperty.js
+++ b/src/foam/dao/DAOProperty.js
@@ -41,7 +41,19 @@ foam.CLASS({
       value: 'HIDDEN'
     },
     ['transient', true],
-    ['of', 'foam.dao.DAO'],
+    {
+      class: 'Class',
+      name: 'of',
+      value: 'foam.dao.DAO',
+      assertValue: function(ofValue) {
+        var type = foam.lookup(ofValue);
+        foam.assert(foam.dao.DAO.isSubClass(type),
+          `DAOProperty's type (specified by 'of') must be a ` +
+          `subclass of DAO, but the ` +
+          `type for '${this.name}' is '${ofValue}'. ` +
+          `(that's not a DAO)`);
+      }
+    },
     {
       name: 'javaInfoType',
       flags: ['java'],


### PR DESCRIPTION
Adds an assertion in case `of` of DAOProperty has the wrong value.

Example - The following code looks okay because for DAOs `of` is supposed to the the class stored by the DAO:
```
  properties: [
    {
      name: 'featuredCapabilities',
      class: 'foam.dao.DAOProperty',
      of: 'foam.nanos.crunch.Capability',
      documentation: `
        DAO Property to find four capabilities to feature.
      `,
      factory: function () {
        return this.capabilityDAO;
      }
    },
  ],
```

This is incorrect because DAOProperty extends FObjectProperty, and it follows that `of` is the class of the DAO and should be `foam.dao.DAO` literally or a subclass. The error currently displayed when this happens is `Cannot instantiate an Interface`, which does not indicate the real problem.

This is the new error message (assertion error) added by this PR:
```
Assertion failed: DAOProperty's type (specified by 'of') must be a subclass of DAO, but the type for 'featuredCapabilities' is 'foam.nanos.crunch.Capability'. (that's not a DAO)
```