### PR TITLE
Remove explicit height. Reders best without it. And the current value…

### DIFF
--- a/src/foam/u2/Tabs.js
+++ b/src/foam/u2/Tabs.js
@@ -34,7 +34,6 @@ foam.CLASS({
   extends: 'foam.u2.UnstyledTabs',
   css: `
     ^tabRow {
-      height: 48px;
       border-bottom: 1px solid #e7eaec;
       background-color: white;
     }


### PR DESCRIPTION
… is too small for tab selection indicator.

before: 

