### PR TITLE
[DO_NOT_MERGE] [CPF-4715] Add ViewCapability interface for visible capabilities

### DIFF
--- a/src/foam/nanos/crunch/types/ViewCapability.js
+++ b/src/foam/nanos/crunch/types/ViewCapability.js
@@ -1,0 +1,50 @@
+foam.CLASS({
+  package: 'foam.nanos.crunch.types',
+  name: 'CapabilityViewMeta',
+
+  /*
+    Interesting note: since this class is only used by the
+      interface below, this would never fail in the
+      classloader even if one-model-per-file was implemented.
+  */
+
+  properties: [
+    {
+      name: 'label',
+      class: 'String',
+      documentation: `
+        A label for this capability when it is displayed to a user.
+      `
+    },
+    {
+      name: 'isFeatured',
+      class: 'Boolean'
+    },
+    {
+      name: 'isNew',
+      class: 'Date',
+      documentation: `
+        Date before which this capability should be displayed as
+        "new", or null for no indicator.
+      `
+    }
+  ]
+});
+
+foam.INTERFACE({
+  package: 'foam.nanos.crunch.types',
+  name: 'ViewCapability',
+
+  properties: [
+    {
+      name: 'viewMeta',
+      class: 'FObjectProperty',
+      of: 'CapabilityViewMeta',
+      documentation: `
+        To prevent cluttering the axiom namespace of a Capability
+        subclass, all ViewCapability properties go in a single
+        property of type CapabilityViewMeta.
+      `
+    }
+  ]
+});


### PR DESCRIPTION
This PR adds view information to capabilities
- Capabilities that are visible to the user need additional properties such as a label, `isFeatured`, `isNew`, and possibly others in the future.
- It is not ideal to store these properties for all capabilities as more granular capabilities in the future will result in many hidden capabilities (for which these properties don't apply)
- https://nanopay.atlassian.net/browse/CPF-4715

The proposed solution is to have a ViewCapability interface. Any `visible` capability should also implement `ViewCapability` which will add this meta information. 