### PR TITLE
Fix the old android string localization demo

### DIFF
--- a/demos/android/gen_xml.js
+++ b/demos/android/gen_xml.js
@@ -3,10 +3,15 @@
 var dir = __dirname;
 var root = dir + '/../..';
 
+global.FOAM_FLAGS = {
+  'android': true
+};
+
 require(root + '/src/foam.js');
 require(root + '/src/foam/classloader/OrDAO.js');
 require(root + '/src/foam/classloader/NodeModelFileDAO.js');
 require(root + '/src/foam/classloader/NodeJsModelExecutor.js');
+require(root + '/src/foam/android/tools/GenStrings.js');
 
 var execSync = require('child_process').execSync
 execSync('rm -rf ' + dir + '/gen');

--- a/src/foam/android/tools/GenResources.js
+++ b/src/foam/android/tools/GenResources.js
@@ -20,7 +20,7 @@ foam.CLASS({
   name: 'GenResources',
 
   imports: [
-    'arequire',
+    'classloader',
   ],
 
   properties: [
@@ -47,7 +47,7 @@ foam.CLASS({
       }
       var promises = [];
       for (var i = 0; i < this.models.length; i++) {
-        promises.push(this.arequire(this.models[i]));
+        promises.push(this.classloader.load(this.models[i]));
       }
       return Promise.all(promises).then(function() {
         var resources = [];


### PR DESCRIPTION
Hassene was asking me about this and I noticed that it was broken so here's a fix for it. Not sure this stuff is really valuable though. Might want to remove it all at some point.

This demo can be run with: `node demos/android/gen_xml.js`
It will result in two files:
```
demos/android/gen/strings.xml
demos/android/gen/strings-fr.xml
```
Those files contain android xml for localization. One for french and another for english. The strings come from the model found in `demos/android/js/nodetooldemo/Test.js`