### PR TITLE
Permit those with permission to read notification

### DIFF
--- a/src/foam/nanos/notification/Notification.js
+++ b/src/foam/nanos/notification/Notification.js
@@ -160,7 +160,7 @@ foam.CLASS({
       name: 'authorizeOnRead',
       javaCode: `
       AuthService auth = (AuthService) x.get("auth");
-      if ( ! checkOwnership(x) ) throw new AuthorizationException("You don't have permission to read notifications you do not own.");
+      if ( ! checkOwnership(x) && ! auth.check(x, createPermission("read")) ) throw new AuthorizationException("You don't have permission to read notifications you do not own.");
       `
     },
     {


### PR DESCRIPTION
Users with admin permissions were unable to access notification causing scripts to run incorrectly. Added a condition checking for whether user is permitted to view notification based on permission.