### PR TITLE
Add validation to alias and shortName

### DIFF
--- a/src/com/foamdev/demos/validateAliasShortname/Controller.js
+++ b/src/com/foamdev/demos/validateAliasShortname/Controller.js
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'com.foamdev.demos.validateAliasShortname',
+  name: 'Controller',
+  extends: 'foam.u2.Controller',
+
+  css: `
+    h1 { color: #aaa; }
+    body, input[text] { color: #888; font-family: Cambria, Georgia; }
+  `,
+
+  properties: [
+    {
+      class: 'String',
+      name: 'yourName',
+      shortName: 'yourName',
+      value: 'Jane Doe',
+      view: {
+        class: 'foam.u2.TextField',
+        onKey: true,
+        placeholder: 'Your name please'
+      },
+      aliases: [ 'fname', 'fn', 'first' ]
+    },
+    {
+      class: 'String',
+      name: 'yourName1',
+      shortName: 'yourName1', //'fname',
+      value: 'Jane Doe',
+      view: {
+        class: 'foam.u2.TextField',
+        onKey: true,
+        placeholder: 'Your name please'
+      },
+      aliases: [ 'fname1', 'fn1', 'first1', 'yourName2' ]
+    }
+  ],
+
+  methods: [
+    function initE() {
+      this.start('div').add('Name:').end().start('div').add(this.YOUR_NAME).end().
+        start('h1').add('Hello ').add(this.yourName$).add('!').end();
+    }
+  ]
+});

--- a/src/com/foamdev/demos/validateAliasShortname/index.html
+++ b/src/com/foamdev/demos/validateAliasShortname/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+<head>
+  <script language="javascript" src="../../../../foam.js"></script>
+  <script language="javascript" src="Controller.js"></script>
+</head>
+<body>
+  <foam class="com.foamdev.demos.validateAliasShortname.Controller"></foam>
+</body>
+</html>

--- a/src/foam/core/debug.js
+++ b/src/foam/core/debug.js
@@ -182,7 +182,9 @@ foam.SCRIPT({
     var superInstallModel = foam.core.FObject.installModel;
 
     return function(m) {
-      var names = {};
+      var names      = {};
+      var shortNames = {};
+      var aliases    = {};
 
       for ( var i = 0 ; i < m.axioms_.length ; i++ ) {
         var a = m.axioms_[i];
@@ -190,6 +192,28 @@ foam.SCRIPT({
         foam.assert(
           ! names.hasOwnProperty(a.name),
           'Axiom name conflict in', m.id || m.refines, ':', a.name);
+
+        if ( a.shortName ) {
+          foam.assert(
+            ! shortNames.hasOwnProperty(a.shortName),
+            'Axiom shortName conflict in', m.id || m.refines, ':', a.shortName);
+          foam.assert(
+            ! aliases.hasOwnProperty(a.shortName),
+            'Axiom shortName conflict with aliases in', m.id || m.refines, ':', a.shortName);
+          shortNames[a.shortName] = a;
+        }
+
+        if ( a.aliases && a.aliases.length > 0 ) {
+          a.aliases.map(x => {
+            foam.assert(
+              ! aliases.hasOwnProperty(x),
+              'Axiom aliases conflict in', m.id || m.refines, ':', x);
+            foam.assert(
+              ! shortNames.hasOwnProperty(x),
+              'Axiom aliases conflict with shortName in', m.id || m.refines, ':', x);
+            aliases[x] = a;
+          });
+        }
 
         var prevA    = this.getAxiomByName(a.name);
         var Property = foam.core.Property;


### PR DESCRIPTION
Add validation to make sure that models don't have two properties with
the same alias or shortname.