### PR TITLE
[CPF-2616] Add capabilityCategoryDAO

### DIFF
--- a/src/foam/nanos/crunch/Capability.js
+++ b/src/foam/nanos/crunch/Capability.js
@@ -89,6 +89,10 @@ foam.CLASS({
       class: 'StringArray'
     },
     {
+      name: 'category',
+      class: 'String'
+    },
+    {
       name: 'version',
       class: 'String'
     },

--- a/src/foam/nanos/crunch/Capability.js
+++ b/src/foam/nanos/crunch/Capability.js
@@ -89,10 +89,6 @@ foam.CLASS({
       class: 'StringArray'
     },
     {
-      name: 'category',
-      class: 'String'
-    },
-    {
       name: 'version',
       class: 'String'
     },

--- a/src/foam/nanos/crunch/CapabilityCategory.js
+++ b/src/foam/nanos/crunch/CapabilityCategory.js
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+foam.CLASS({
+  package: 'foam.nanos.crunch',
+  name: 'CapabilityCategory',
+
+  documentation: `
+    models a category to which a capability can be associated.
+  `,
+
+  properties: [
+    {
+      name: 'id',
+      class: 'String'
+    },
+    {
+      name: 'name',
+      class: 'String'
+    },
+    {
+      name: 'description',
+      documentation: `Description of category`,
+      class: 'String'
+    }
+  ]
+});
+
+foam.RELATIONSHIP({
+  package: 'foam.nanos.crunch',
+  sourceModel: 'foam.nanos.crunch.CapabilityCategory',
+  targetModel: 'foam.nanos.crunch.Capability',
+  cardinality: '*:*',
+  forwardName: 'capabilities',
+  inverseName: 'categories'
+});

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -268,6 +268,7 @@ FOAM_FILES([
   { name: "foam/nanos/crunch/crunchtest/FakeTestObject" },
   // models
   { name: "foam/nanos/crunch/Capability" },
+  { name: "foam/nanos/crunch/CapabilityCategory" },
   { name: "foam/nanos/crunch/CapabilityJunctionStatus" },
   { name: "foam/nanos/crunch/UserCapabilityJunctionRefine" },
   //daos

--- a/src/services
+++ b/src/services
@@ -735,10 +735,10 @@ p({
       .setAuthorize(true)
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
       .setJournalName("capabilityCategories")
-      .setOf(foam.nanos.crunch.Capability.getOwnClassInfo())
+      .setOf(foam.nanos.crunch.CapabilityCategory.getOwnClassInfo())
       .build();
   """,
-  "client":"{\"of\":\"foam.nanos.crunch.Capability\"}"
+  "client":"{\"of\":\"foam.nanos.crunch.CapabilityCategory\"}"
 })
 
 p({
@@ -766,7 +766,7 @@ p({
   "serviceScript": """
     return new foam.dao.EasyDAO.Builder(x)
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
-      .setJournalName(\"capabilityCategoryCapabilityJunction\")
+      .setJournalName("capabilityCategoryCapabilityJunction")
       .setOf(foam.nanos.crunch.CapabilityCategoryCapabilityJunction.getOwnClassInfo())
       .build();
   """,

--- a/src/services
+++ b/src/services
@@ -727,6 +727,22 @@ p({
 
 p({
   "class":"foam.nanos.boot.NSpec",
+  "name":"capabilityCategoryDAO",
+  "lazy":true,
+  "serve":true,
+  "serviceScript":"""
+    return new foam.dao.EasyDAO.Builder(x)
+      .setAuthorize(true)
+      .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
+      .setJournalName("capabilityCategories")
+      .setOf(foam.nanos.crunch.Capability.getOwnClassInfo())
+      .build();
+  """,
+  "client":"{\"of\":\"foam.nanos.crunch.Capability\"}"
+})
+
+p({
+  "class":"foam.nanos.boot.NSpec",
   "name":"capabilityDAO",
   "lazy":true,
   "serve":true,
@@ -739,6 +755,22 @@ p({
     .build();
   """,
   "client":"{\"of\":\"foam.nanos.crunch.Capability\"}"
+})
+
+p({
+  "class": "foam.nanos.boot.NSpec",
+  "name": "capabilityCategoryCapabilityJunctionDAO",
+  "lazy": true,
+  "serve": true,
+  "description": "DAO responsible for storing capabilities' categories.",
+  "serviceScript": """
+    return new foam.dao.EasyDAO.Builder(x)
+      .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
+      .setJournalName(\"capabilityCategoryCapabilityJunction\")
+      .setOf(foam.nanos.crunch.CapabilityCategoryCapabilityJunction.getOwnClassInfo())
+      .build();
+  """,
+  "client": "{\"of\":\"foam.nanos.crunch.CapabilityCategoryCapabilityJunction\", \"remoteListenerSupport\": false}"
 })
 
 p({

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -514,6 +514,8 @@ var classes = [
   'foam.nanos.crunch.crunchtest.FakeTestObject',
   //models
   'foam.nanos.crunch.Capability',
+  'foam.nanos.crunch.CapabilityCategory',
+  'foam.nanos.crunch.CapabilityCategoryCapabilityJunction',
   'foam.nanos.crunch.CapabilityJunctionStatus',
   'foam.nanos.crunch.UserCapabilityJunction',
   'foam.nanos.crunch.CapabilityCapabilityJunction',


### PR DESCRIPTION
This PR adds the `CapabilityCategory` model, `capabilityCategoryDAO`, and `capabilityCategoryCapabilityJunctionDAO`. Capability categories will be displayed in the capability store after a future PR.