### PR TITLE
Detailed Action Boolean View

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -428,6 +428,7 @@ FOAM_FILES([
   { name: "foam/u2/IntView", flags: ['web'] },
   { name: "foam/u2/FloatView", flags: ['web'] },
   { name: "foam/u2/CurrencyView", flags: ['web'] },
+  { name: "foam/u2/DetailedActionBooleanView", flags: ['web'] },
   { name: "foam/u2/CheckBox", flags: ['web'] },
   { name: "foam/u2/md/CheckBox", flags: ['web'] },
   { name: "foam/u2/CitationView", flags: ['web'] },

--- a/src/foam/u2/DetailedActionBooleanView.js
+++ b/src/foam/u2/DetailedActionBooleanView.js
@@ -79,9 +79,7 @@ foam.CLASS({
     {
       name: 'updateObject',
       isEnabled: function(mode) {
-        if ( mode ) {
-          return mode.name === 'RW';
-        }
+        return mode ? mode.name === 'RW' : null;
       },
       code: async function(X) {
         var dao = X[this.targetDAOKey];

--- a/src/foam/u2/DetailedActionBooleanView.js
+++ b/src/foam/u2/DetailedActionBooleanView.js
@@ -1,0 +1,100 @@
+foam.CLASS({
+  package: 'foam.u2',
+  name: 'DetailedActionBooleanView',
+  extends: 'foam.u2.View',
+
+  documentation: `
+    Displays two labels and description that are visible based on the state of the boolean value.
+    Along with the dynamics labels, an action is provided to put the provided data object
+    into the targetDAO provided.
+  `,
+
+  imports: [
+    'notify'
+  ],
+
+  css: `
+    ^ {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    ^ .foam-u2-DetailedActionBooleanView-text{
+      width: 50%;
+      white-space: pre-wrap;
+    }
+  `,
+
+  properties: [
+    'trueLabel',
+    'falseLabel',
+    'trueActionLabel',
+    'falseActionLabel',
+    'targetDAOKey',
+    'property',
+    {
+      class: 'String',
+      name: 'dynamicLabel',
+      expression: function(data) {
+        return data ? this.trueLabel : this.falseLabel;
+      }
+    },
+    {
+      class: 'String',
+      name: 'dynamicActionLabel',
+      expression: function(data) {
+        return data ? this.trueActionLabel : this.falseActionLabel;
+      }
+    }
+  ],
+
+  messages: [
+    { name: 'BOOLEAN_ERROR', message: 'There was an issue updating' },
+    { name: 'BOOLEAN_SUCCESS', message: 'was successfully updated.' }
+  ],
+
+  methods: [
+    function initE() {
+      this.start().addClass(this.myClass())
+        .start().addClass(this.myClass('text'))
+          .add(this.dynamicLabel$)
+        .end()
+        .startContext({ data: this })
+          .start().addClass(this.myClass('btn-box'))
+            .tag(this.UPDATE_OBJECT, {
+              label$: this.dynamicActionLabel$,
+              buttonStyle: 'SECONDARY'
+            })
+          .end()
+        .endContext()
+      .end();
+    },
+    function fromProperty(property) {
+      this.SUPER(property);
+      this.property = property;
+    }
+  ],
+
+  actions: [
+    {
+      name: 'updateObject',
+      isEnabled: function(mode) {
+        if ( mode ) {
+          return mode.name === 'RW';
+        }
+      },
+      code: async function(X) {
+        var dao = X[this.targetDAOKey];
+        this.data = ! this.data;
+        try {
+          dao.put(this.__context__.data);
+        } catch (e) {
+          console.error(`${ this.BOOLEAN_ERROR } ${ this.property.label } of ${ this.__context__.cls_.name }`);
+          this.notify(`${ this.BOOLEAN_ERROR } ${ this.property.label }`);
+          return;
+        }
+        this.notify(`${ this.property.label } ${ this.BOOLEAN_SUCCESS }`);
+      }
+    }
+  ]
+});

--- a/src/foam/u2/DetailedActionBooleanView.js
+++ b/src/foam/u2/DetailedActionBooleanView.js
@@ -26,6 +26,7 @@ foam.CLASS({
   `,
 
   properties: [
+    ['showAction', true],
     'trueLabel',
     'falseLabel',
     'trueActionLabel',
@@ -60,13 +61,19 @@ foam.CLASS({
           .add(this.dynamicLabel$)
         .end()
         .startContext({ data: this })
-          .start().addClass(this.myClass('btn-box'))
+          .start().show(this.showAction$).addClass(this.myClass('btn-box'))
             .tag(this.UPDATE_OBJECT, {
               label$: this.dynamicActionLabel$,
               buttonStyle: 'SECONDARY'
             })
           .end()
         .endContext()
+        .start('input').hide(this.showAction$).setAttribute('type', 'checkbox')
+            .on('click', (e) => {
+              if ( this.mode === foam.u2.DisplayMode.RO ) return e.preventDefault();
+              this.data = ! this.data;
+            })
+        .end()
       .end();
     },
     function fromProperty(property) {
@@ -79,7 +86,7 @@ foam.CLASS({
     {
       name: 'updateObject',
       isEnabled: function(mode) {
-        return mode ? mode.name === 'RW' : null;
+        return mode === foam.u2.DisplayMode.RW;
       },
       code: async function(X) {
         var dao = X[this.targetDAOKey];

--- a/src/foam/u2/DetailedActionBooleanView.js
+++ b/src/foam/u2/DetailedActionBooleanView.js
@@ -23,16 +23,22 @@ foam.CLASS({
     ^ {
       display: flex;
       align-items: center;
-      justify-content: space-between;
     }
     ^ .foam-u2-DetailedActionBooleanView-text{
       width: 50%;
       white-space: pre-wrap;
     }
+    ^show-action {
+      justify-content: space-between;
+    }
+    ^ input {
+      margin-right: 15px;
+    }
   `,
 
   properties: [
     ['showAction', true],
+    ['autoSave', true],
     'trueLabel',
     'falseLabel',
     'trueActionLabel',
@@ -62,7 +68,14 @@ foam.CLASS({
 
   methods: [
     function initE() {
-      this.start().addClass(this.myClass())
+      this.start().addClass(this.myClass()).enableClass(this.myClass('show-action'), this.showAction$)
+        .start('input').hide(this.showAction$).setAttribute('type', 'checkbox')
+          .attrs({ 'checked': this.data$, 'disabled': this.mode !== foam.u2.DisplayMode.RW })
+          .on('click', (e) => {
+            if ( this.mode === foam.u2.DisplayMode.RO ) return e.preventDefault();
+            this.data = ! this.data;
+          })
+        .end()
         .start().addClass(this.myClass('text'))
           .add(this.dynamicLabel$)
         .end()
@@ -74,12 +87,6 @@ foam.CLASS({
             })
           .end()
         .endContext()
-        .start('input').hide(this.showAction$).setAttribute('type', 'checkbox')
-            .on('click', (e) => {
-              if ( this.mode === foam.u2.DisplayMode.RO ) return e.preventDefault();
-              this.data = ! this.data;
-            })
-        .end()
       .end();
     },
     function fromProperty(property) {
@@ -97,6 +104,7 @@ foam.CLASS({
       code: async function(X) {
         var dao = X[this.targetDAOKey];
         this.data = ! this.data;
+        if ( ! this.autoSave ) return;
         try {
           dao.put(this.__context__.data);
         } catch (e) {

--- a/src/foam/u2/DetailedActionBooleanView.js
+++ b/src/foam/u2/DetailedActionBooleanView.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 foam.CLASS({
   package: 'foam.u2',
   name: 'DetailedActionBooleanView',


### PR DESCRIPTION
Detailed Action Boolean View provides boolean values a view that dynamically changes labels depending on the boolean state. An additional action is provided to allow updates to the data provided and put to the defined targetDAO. Boolean value labels and actions labels are provided when defining the view at a property level.

Ex: 
```javascript
{
  class: 'Boolean',
  name: 'myBoolean',
  view: {
    class: 'foam.u2.DetailedActionBooleanView',
    trueLabel: 'this label will display when prop value is true',
    falseLabel: 'this label will display when prop value is false',
    trueActionLabel: 'switch to false',
    falseActionLabel: 'switch to true',
    targetDAOKey: 'myDAO'
  }
}
``` 
To omit the action and display a checkbox that doesn't not update the data object, you can define showAction as false. This will update the property value but will require a put to a desired DAO.

Below is a screenshot of the view (Ablii  theme applied):

<img width="570" alt="Screen Shot 2020-02-27 at 2 58 29 PM" src="https://user-images.githubusercontent.com/15328924/75482140-30e9e480-5972-11ea-96ed-2f95b28ff7f5.png">

Action is aware of display mode 'RW' (Connect theme applied):

<img width="943" alt="Screen Shot 2020-02-27 at 2 57 19 PM" src="https://user-images.githubusercontent.com/15328924/75482153-36dfc580-5972-11ea-9557-ff4619dba2e4.png">

Setting autoSave to true on view will put the object to the targetDAO on action click. Otherwise the action will set the property value to a new value.


