### PR TITLE
Change 'Failed to Read' to 'File not found' when reporting missing fi…

### DIFF
--- a/src/foam/dao/AbstractFileJournal.js
+++ b/src/foam/dao/AbstractFileJournal.js
@@ -127,7 +127,7 @@ foam.CLASS({
 try {
   InputStream is = getX().get(foam.nanos.fs.Storage.class).getInputStream(getFilename());
   if ( is == null ) {
-    getLogger().error("Failed to read from resource journal: " + getFilename());
+    getLogger().error("File not found - journal: " + getFilename());
   }
   return (is == null) ? null : new BufferedReader(new InputStreamReader(is));
 } catch ( Throwable t ) {
@@ -145,7 +145,7 @@ try {
 try {
   OutputStream os = getX().get(foam.nanos.fs.Storage.class).getOutputStream(getFilename());
   if ( os == null ) {
-    getLogger().error("Failed to read from resource journal: " + getFilename());
+    getLogger().error("File not found - journal: " + getFilename());
   }
   return (os == null) ? null : new BufferedWriter(new OutputStreamWriter(os));
 } catch ( Throwable t ) {


### PR DESCRIPTION
…les to distinguish from real file reading failures in the logs.