### PR TITLE
Filter refix and approval request bugs

### DIFF
--- a/src/foam/nanos/approval/ApprovalRequest.js
+++ b/src/foam/nanos/approval/ApprovalRequest.js
@@ -126,7 +126,6 @@
     {
       class: 'String',
       name: 'daoKey',
-      readPermissionRequired: true,
       writePermissionRequired: true,
       documentation: `Used internally in approvalDAO to point where requested object can be found.
       Should not be used to retrieve approval requests for a given objects

--- a/src/foam/nanos/approval/ApprovalRequest.js
+++ b/src/foam/nanos/approval/ApprovalRequest.js
@@ -102,7 +102,6 @@
       class: 'Object',
       javaType: 'Object',
       name: 'objId',
-      readPermissionRequired: true,
       writePermissionRequired: true,
       documentation: 'id of the object that needs approval.',
       tableWidth: 150,

--- a/src/foam/u2/filter/FilterSearch.js
+++ b/src/foam/u2/filter/FilterSearch.js
@@ -222,12 +222,14 @@ foam.CLASS({
             .forEach(filters, function(f) {
               var axiom = self.dao.of.getAxiomByName(f);
 
-              this.start(self.FilterViewController, {
-                searchView: axiom.searchView,
-                property: axiom,
-                dao$: self.dao$
-              })
-              .end();
+              if ( axiom ){
+                this.start(self.FilterViewController, {
+                  searchView: axiom.searchView,
+                  property: axiom,
+                  dao$: self.dao$
+                })
+                .end();
+              }
             })
           .end()
           .start('p')


### PR DESCRIPTION
Basically 3 things are being fixed:
1. https://github.com/foam-framework/foam2/pull/3243 accidentally overrode the null check for axiom

2. Removed **readPermissionRequired: true** for **daoKey** because otherwise approval requests won't load in the table and you will get the following error.

<img width="1680" alt="Screen Shot 2020-03-02 at 5 21 52 PM" src="https://user-images.githubusercontent.com/26717171/75739531-147fdc00-5cd3-11ea-8779-bc932470c14a.png">

 This is because the **referenceObj_** property has an expression which requires this.daoKey, therefore the readPermissionRequired: true property should be removed since it will prevent basic functionality of just viewing requests in the table

3. Removed **readPermissionRequired: true** for **objId** because otherwise approvalRequest summary view will fail due to this following error. Not entirely sure how it is related:

<img width="1680" alt="Screen Shot 2020-03-02 at 10 06 59 PM" src="https://user-images.githubusercontent.com/26717171/75739655-77717300-5cd3-11ea-987b-2b7e73f02828.png">

But I can trace it to the **viewReference** action having an isAvailable method on it which slots **referenceObj_**. My guess is that theres some logic in isAvailable rendering portion of **ActionView** which passes in a null context or something when theres a permission break.

But nevertheless for now, the readPermissionRequired: true property should be removed since it will prevent basic functionality of just viewing the summary view of a request.