### PR TITLE
Added object id specific permissions for permission predicate

### DIFF
--- a/src/foam/comics/v2/DAOSummaryView.js
+++ b/src/foam/comics/v2/DAOSummaryView.js
@@ -111,9 +111,9 @@ foam.CLASS({
   actions: [
     {
       name: 'edit',
-      isAvailable: function(config) {
+      isAvailable: function(config, data$id) {
         try {
-          return config.editPredicate.f();
+          return config.editPredicate.f(data$id);
         } catch(e) {
           return false;
         }
@@ -130,9 +130,9 @@ foam.CLASS({
     },
     {
       name: 'delete',
-      isAvailable: function(config) {
+      isAvailable: function(config, data$id) {
         try {
-          return config.deletePredicate.f();
+          return config.deletePredicate.f(data$id);
         } catch(e) {
           return false;
         }

--- a/src/foam/lib/PermissionPredicate.js
+++ b/src/foam/lib/PermissionPredicate.js
@@ -27,9 +27,8 @@ foam.CLASS({
     {
       name: 'f',
       javaCode: `
-        X x = (X) obj;
-        AuthService auth = (AuthService) x.get("auth");
-        return auth.check(x, permission_);
+        // java side is only needed for rules which is handled in the RulePermissionPredicate
+        throw new RuntimeException( new UnsupportedOperationException() );
       `,
       code: async function(objId) {    
         /**

--- a/src/foam/lib/PermissionPredicate.js
+++ b/src/foam/lib/PermissionPredicate.js
@@ -31,7 +31,15 @@ foam.CLASS({
         AuthService auth = (AuthService) x.get("auth");
         return auth.check(x, permission_);
       `,
-      code: async function() {
+      code: async function(objId) {    
+        /**
+         * % is a character gets replaced in the permission string with 
+         * the object id of the object you are trying to view    
+         */
+        if ( this.permission.includes('.%') && objId ){
+          var permissionForObject = this.permission.replace('.%', '.' + objId);
+          return await this.auth.check(null, permissionForObject);
+        }
         return await this.auth.check(null, this.permission);
       }
     }

--- a/src/foam/nanos/ruler/Operations.js
+++ b/src/foam/nanos/ruler/Operations.js
@@ -29,6 +29,11 @@ foam.ENUM({
       name: 'CREATE_OR_UPDATE',
       label: 'Create/Update',
       documentation: 'Operation applied on dao.put'
+    },
+    {
+      name: 'READ',
+      label: 'Read',
+      documentation: 'Operation applied on dao.read.'
     }
   ]
 });


### PR DESCRIPTION
Basically allow handling a permission defined in the PermissionPredicate such as the following example.

If I want the permission checked for each id individually for each object such as:
"account.make.1234",
"account.make.1",
"account.make.456"
...
"account.make.921"

All I have to pass into the PermissionPredicate is just the first two portions of the permission string with a '%' character at the end instead of the actual id
"account.make.%"