### PR TITLE
Ported exportDriverRegistryDAO creation to EasyDAO and added GlobalReadAuthorizer to it

### DIFF
--- a/src/services
+++ b/src/services
@@ -383,8 +383,24 @@ p({
 })
 p({"class":"foam.nanos.boot.NSpec", "name":"regionService",                      "serve":true, "serviceClass":"foam.nanos.auth.RegionService"})
 
-//p({"class":"foam.nanos.boot.NSpec", "name":"exportDriverRegistryDAO",            "serve":true,  "serviceScript":"return new foam.dao.EasyDAO.Builder(x).setPm(true).setJournalType(foam.dao.JournalType.SINGLE_JOURNAL).setJournalName(\"exportDriverRegistrys\").setOf(foam.nanos.export.ExportDriverRegistry.getOwnClassInfo()).build();", "client":"{\"of\":\"foam.nanos.export.ExportDriverRegistry\"}"})
-p({"class":"foam.nanos.boot.NSpec", "name":"exportDriverRegistryDAO",            "serve":true,  "serviceScript":"return new foam.dao.PMDAO(x, new foam.dao.java.JDAO(x, foam.nanos.export.ExportDriverRegistry.getOwnClassInfo(), \"exportDriverRegistrys\"));","client":"{\"of\":\"foam.nanos.export.ExportDriverRegistry\"}"})
+p({
+  "class":"foam.nanos.boot.NSpec",
+  "name":"exportDriverRegistryDAO",
+  "description": "DAO which provides a reference to data type drivers which are used to export data in various types",
+  "serve":true,
+  "serviceScript":
+  """
+    return new foam.dao.EasyDAO.Builder(x)
+      .setPm(true)
+      .setAuthorize(true)
+      .setAuthorizer(new foam.nanos.auth.GlobalReadAuthorizer("exportDriverRegistry"))
+      .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
+      .setJournalName("exportDriverRegistrys")
+      .setOf(foam.nanos.export.ExportDriverRegistry.getOwnClassInfo())
+      .build();
+  """,
+  "client":"{\"of\":\"foam.nanos.export.ExportDriverRegistry\"}"
+})
 
 p({
   "class":"foam.nanos.boot.NSpec",


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/CPF-2821
exportDriverRegistryDAO uses EasyDAO to be created
GlobalReadAuthorizer added to exportDriverRegistryDAO so that only admin user can perform create, update, and delete operations on DAO. Everyone can read.