### PR TITLE
Filter Search detail options are no longer opened by default

### DIFF
--- a/src/foam/u2/filter/FilterSearch.js
+++ b/src/foam/u2/filter/FilterSearch.js
@@ -158,8 +158,7 @@ foam.CLASS({
     },
     {
       class: 'Boolean',
-      name: 'isOpen',
-      value: false
+      name: 'isOpen'
     },
     {
       class: 'Boolean',

--- a/src/foam/u2/filter/FilterSearch.js
+++ b/src/foam/u2/filter/FilterSearch.js
@@ -184,7 +184,9 @@ foam.CLASS({
     {
       class: 'String',
       name: 'iconPath',
-      value: 'images/expand-less.svg'
+      expression: function(isOpen) {
+        return isOpen ? 'images/expand-less.svg' : 'images/expand-more.svg';
+      }
     }
   ],
 
@@ -288,7 +290,6 @@ foam.CLASS({
       name: 'toggleDrawer',
       code: function() {
         this.isOpen = ! this.isOpen;
-        this.iconPath = this.isOpen ? 'images/expand-less.svg' : 'images/expand-more.svg';
       }
     }
   ]

--- a/src/foam/u2/filter/FilterSearch.js
+++ b/src/foam/u2/filter/FilterSearch.js
@@ -159,7 +159,7 @@ foam.CLASS({
     {
       class: 'Boolean',
       name: 'isOpen',
-      value: true
+      value: false
     },
     {
       class: 'Boolean',


### PR DESCRIPTION
Noticed default value of expand search options is toggled to be open. Changed the value to collapse expand search option by default.

Previous Default: 
<img width="1006" alt="Screen Shot 2020-03-04 at 2 12 18 PM" src="https://user-images.githubusercontent.com/15328924/75914134-39369980-5e22-11ea-8006-ace74523018d.png">

PR Default:
<img width="997" alt="Screen Shot 2020-03-04 at 2 12 12 PM" src="https://user-images.githubusercontent.com/15328924/75914117-3176f500-5e22-11ea-9212-214f0d2333ea.png">
