### PR TITLE
PropertyHasValue rule predicate

### DIFF
--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -249,6 +249,7 @@ FOAM_FILES([
   { name: "foam/nanos/ruler/predicate/PropertyEQProperty" },
   { name: "foam/nanos/ruler/Relationships" },
   { name: "foam/nanos/ruler/action/SendNotification" },
+  { name: "foam/nanos/ruler/predicate/PropertyHasValue" },
   { name: "foam/nanos/ruler/predicate/PropertyEQValue" },
   { name: "foam/nanos/ruler/predicate/PropertyNEQValue" },
   { name: "foam/nanos/ruler/predicate/NewEqOld" },

--- a/src/foam/nanos/ruler/predicate/PropertyHasValue.js
+++ b/src/foam/nanos/ruler/predicate/PropertyHasValue.js
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2019 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.nanos.ruler.predicate',
+  name: 'PropertyHasValue',
+
+  documentation: `A predicate that returns true when a specific property has a value.
+  user can choose the new or old object for evaluation.`,
+
+  extends: 'foam.mlang.predicate.AbstractPredicate',
+  implements: ['foam.core.Serializable'],
+
+  javaImports: [
+    'foam.core.FObject',
+    'static foam.mlang.MLang.*'
+  ],
+  properties: [
+    {
+      class: 'String',
+      name: 'propName'
+    },
+    {
+      class: 'Boolean',
+      name: 'isNew',
+      value: true
+    }
+  ],
+
+  methods: [
+    {
+      name: 'f',
+      javaCode: `
+        if ( getIsNew() ) {
+          FObject nu  = (FObject) NEW_OBJ.f(obj);
+          return HAS(nu.getClassInfo().getAxiomByName(getPropName())).f(nu);
+        }
+        FObject old = (FObject) OLD_OBJ.f(obj);
+        if ( old != null ) {
+          return HAS(old.getClassInfo().getAxiomByName(getPropName())).f(old);
+        }
+        return false;
+      `
+    }
+  ]
+});

--- a/src/foam/nanos/ruler/predicate/PropertyHasValue.js
+++ b/src/foam/nanos/ruler/predicate/PropertyHasValue.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2019 The FOAM Authors. All Rights Reserved.
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
@@ -9,7 +9,7 @@ foam.CLASS({
   name: 'PropertyHasValue',
 
   documentation: `A predicate that returns true when a specific property has a value.
-  user can choose the new or old object for evaluation.`,
+      user can choose the new or old object for evaluation.`,
 
   extends: 'foam.mlang.predicate.AbstractPredicate',
   implements: ['foam.core.Serializable'],

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -456,6 +456,7 @@ var classes = [
   'foam.nanos.ruler.UpdateRulesListSink',
   'foam.nanos.ruler.predicate.PropertyChangePredicate',
   'foam.nanos.ruler.action.SendNotification',
+  'foam.nanos.ruler.predicate.PropertyHasValue',
   'foam.nanos.ruler.predicate.PropertyEQValue',
   'foam.nanos.ruler.predicate.PropertyNEQValue',
   'foam.nanos.ruler.predicate.PropertyEQProperty',


### PR DESCRIPTION
Implemented a PropertyHasValue rule predicate to make defining has predicates on rules easier.
Predicate will check if prop has a value.

Example of use within rule entry:
```javascript
  "predicate": {
    "class":"foam.mlang.predicate.And",
    "args":[
      {
        "class":"foam.nanos.ruler.predicate.PropertyHasValue",
        "propName":"paymentId"
      },
      {
        "class":"foam.mlang.predicate.Not",
        "arg1": {
          "class":"foam.nanos.ruler.predicate.PropertyHasValue",
          "propName":"paymentId",
          "isNew":false
        }
      }
    ]
  },
```