### PR TITLE
Add LifecycleAwareDAO Select to include all objects without LifecycleAware Interface in DAO as well

### DIFF
--- a/src/foam/nanos/auth/LifecycleAwareDAO.js
+++ b/src/foam/nanos/auth/LifecycleAwareDAO.js
@@ -89,6 +89,10 @@ foam.CLASS({
     {
       name: 'select_',
       javaCode: `
+        // TODO: See CPF-4875 for more info
+        // Will need to figure out if the DAO OF is not lifecycleAware, 
+        // but a subclass entry may be lifecycleAware
+
         boolean userCanReadDeleted = canReadDeleted(x);
         boolean userCanReadRejected = canReadRejected(x);
 
@@ -120,12 +124,17 @@ foam.CLASS({
         getDelegate().select_(x, sink, skip, limit, order, predicate) :
         getDelegate()
           .where(
-            MLang.NOT(
               MLang.OR(
-                predicateArray
+                MLang.NOT(
+                  MLang.INSTANCE_OF(LifecycleAware.class)
+                ),
+                MLang.NOT(
+                  MLang.OR(
+                    predicateArray
+                  )
+                )
               )
             )
-          )
           .select_(x, sink, skip, limit, order, predicate);
       `
     },


### PR DESCRIPTION
As such is the case with the ruleDAO, where the OF is of class Rule which is not lifecycleAware. But BusinessRules, which are a subclass of Rule, are lifecycleAware. 

We would want the select to include all non lifecycleAware items PLUS those which are lifecycleAware given your permissions to view DELETED and REJECTED states.

More work needs to be done however to determine the permissioning checks for DELETED and REJECTED states because if the OF class is not lifecycleAware, then it will skip these checks even if the obj is a subclass which is in fact lifecycleAware.

Solution for the above is discussed in the following: @nanoscott https://nanopay.atlassian.net/browse/CPF-4877