### PR TITLE
Only allow 'close' action if Ticket has been created (id > 0).

### DIFF
--- a/src/foam/nanos/ticket/Ticket.js
+++ b/src/foam/nanos/ticket/Ticket.js
@@ -23,7 +23,7 @@ foam.CLASS({
   ],
 
   javaImports: [
-    'java.util.Date',
+    'java.util.Date'
   ],
 
   imports: [
@@ -271,8 +271,9 @@ foam.CLASS({
       name: 'close',
       tableWidth: 70,
       confirmationRequired: true,
-      isAvailable: function(status) {
-        return status != 'CLOSED';
+      isAvailable: function(status, id) {
+        return status != 'CLOSED' &&
+               id > 0;
       },
       code: function() {
         this.status = 'CLOSED';


### PR DESCRIPTION
This is a stop gap measure until we can determine why the unavailable
'close' action button, which is hidden, is being invoked by click
on hidden button.