### PR TITLE
Add foam.realfoam for foamlink code injections

### DIFF
--- a/src/foam/foamlink/lib.js
+++ b/src/foam/foamlink/lib.js
@@ -51,6 +51,9 @@ foam.LIB({
           idsPresent[m.name] = {type: 'LIB'}
         };
 
+        // Allow access to real FOAM variable (used for injections only)
+        context.foam_.realfoam = foam;
+
         var srcMeta = `
           //@ sourceURL=filename_unknown.js
         `


### PR DESCRIPTION
**background context**
In order for the `genjava` script to do partial builds, a file walker was added to detect changes. These files need to be processed in order to determine what model IDs they contain, since genjava iterates over class names and doesn't care about file names. Because some Javascript files may try to access objects prior to calling `foam.CLASS`, a `foamlink.js` manifest file is able to specify code to inject before processing the file for model IDs.

**this PR**
This PR exposes the `foam` variable to foamlink code injections. This makes them more useful because standard library functions like `foam.String` can easily be exposed to otherwise problematic files.

