### PR TITLE
[CPF-3729] Remove package name warning

### DIFF
--- a/src/foam/foamlink/FoamlinkExec.js
+++ b/src/foam/foamlink/FoamlinkExec.js
@@ -121,10 +121,14 @@ foam.CLASS({
           if (
             !(id === expectedPackage || id.startsWith(expectedPackage+'.'))
           ) {
+            /*
+             This warning can be made useful with some amount of effort,
+             but presently it is incorrect most of the time.
             console.warn(tag + w +
               'Package name does not match file path: ' +
               '"' + id + '" is outside of "' + expectedPackage + '".'
             );
+            */
           }
         }
 


### PR DESCRIPTION
This will make the foamlink script from genjava less verbose. Right now it displays a warning about package names, but for most cases it's not useful; for example:

```
Package name does not match file path: "foam.String" is outside of "foam.core".
```

In the future this could be improved so the warning only appears in helpful cases, so it has been commented out instead of deleted.