### PR TITLE
revert the inline block changes made in ModeAltView

### DIFF
--- a/src/foam/u2/view/ModeAltView.js
+++ b/src/foam/u2/view/ModeAltView.js
@@ -23,7 +23,6 @@ foam.CLASS({
     'contextData as data'
   ],
 
-  css: '^ { display: inline-block; }',
 
   properties: [
     {


### PR DESCRIPTION
address: https://nanopay.atlassian.net/browse/CPF-4881

if we made `ModeAltView` display  `inline-block`,  the views use  ModeAltView will not have fixed width.

suggest: we should using separated  views for those we want it inline-block(display units on same line) or block(display units on different line)

Or I can make the width 100% to those textfields that want display units on different line 