### PR TITLE
[DO_NOT_MERGE] [CPF-3038] Add require() to AuthService

### DIFF
--- a/src/foam/nanos/auth/AbstractAuthService.js
+++ b/src/foam/nanos/auth/AbstractAuthService.js
@@ -1,0 +1,21 @@
+foam.CLASS({
+  package: 'foam.nanos.auth',
+  name: 'AbstractAuthService',
+  abstract: true,
+
+  implements: [
+    'foam.nanos.auth.AuthService'
+  ],
+  
+  methods: [
+    {
+      name: 'require',
+      javaCode: `
+        if ( ! check(x, permission) ) {
+          if ( exception != null ) throw exception;
+          throw new AuthorizationException();
+        }
+      `
+    }
+  ]
+});

--- a/src/foam/nanos/auth/AuthService.js
+++ b/src/foam/nanos/auth/AuthService.js
@@ -151,6 +151,8 @@ foam.INTERFACE({
       name: 'check',
       documentation: `
         Check if a user in the given context has the given permission.
+        The require method should be used instead if the intent is to throw an
+        exception.
       `,
       async: true,
       type: 'Boolean',
@@ -163,6 +165,42 @@ foam.INTERFACE({
         {
           name: 'permission',
           type: 'String',
+        }
+      ]
+    },
+    {
+      name: 'require',
+      documentation: `
+        Requires that a user in the given context has the given permission.
+        Throws AuthorizationException is the permission is not granted.
+      `,
+      /*
+        Note: there is no requireUser method; a new context should be created
+          if it's necessary to throw an exception on a permission for a
+          different user.
+      */
+      async: true,
+      type: 'Void',
+      javaThrows: ['foam.nanos.auth.AuthorizationException'],
+      swiftThrows: true,
+      args: [
+        {
+          name: 'x',
+          type: 'Context'
+        },
+        {
+          name: 'permission',
+          type: 'String',
+        },
+        {
+          name: 'exception',
+          type: 'foam.nanos.auth.AuthorizationException',
+          documentation: `
+            A custom AuthorizationException to throw, or null. Default
+            behaviour is to create an exception with the message
+            "Permission Denied"; this argument is useful if a different
+            exception message is desired.
+          `
         }
       ]
     },

--- a/src/foam/nanos/auth/ProxyAuthService.js
+++ b/src/foam/nanos/auth/ProxyAuthService.js
@@ -28,5 +28,17 @@ foam.CLASS({
       of: 'foam.nanos.auth.AuthService',
       name: 'delegate'
     }
+  ],
+
+  methods: [
+    {
+      name: 'require',
+      javaCode: `
+        if ( ! check(x, permission) ) {
+          if ( exception != null ) throw exception;
+          throw new AuthorizationException();
+        }
+      `
+    }
   ]
 });

--- a/src/foam/nanos/auth/StandardAuthorizer.java
+++ b/src/foam/nanos/auth/StandardAuthorizer.java
@@ -35,9 +35,7 @@ public class StandardAuthorizer implements Authorizer {
 
     String permission = createPermission("create");
     AuthService authService = (AuthService) x.get("auth");
-    if ( ! authService.check(x, permission) ) {
-      throw new AuthorizationException();
-    }
+    authService.require(x, permission, null);
   }
 
   public void authorizeOnRead(X x, FObject obj) throws AuthorizationException {
@@ -45,9 +43,7 @@ public class StandardAuthorizer implements Authorizer {
     String permission = createPermission("read", obj.getProperty("id"));
     AuthService authService = (AuthService) x.get("auth");
 
-    if ( ! authService.check(x, permission) ) {
-      throw new AuthorizationException();
-    }
+    authService.require(x, permission, null);
   }
 
   public void authorizeOnUpdate(X x, FObject oldObj, FObject obj) throws AuthorizationException {
@@ -55,9 +51,7 @@ public class StandardAuthorizer implements Authorizer {
     String permission = createPermission("update", obj.getProperty("id"));
     AuthService authService = (AuthService) x.get("auth");
 
-    if ( ! authService.check(x, permission) ) {
-      throw new AuthorizationException();
-    }
+    authService.require(x, permission, null);
   }
 
   public void authorizeOnDelete(X x, FObject obj) throws AuthorizationException {
@@ -65,9 +59,7 @@ public class StandardAuthorizer implements Authorizer {
     String permission  = createPermission("remove", obj.getProperty("id"));
     AuthService authService = (AuthService) x.get("auth");
 
-    if ( ! authService.check(x, permission) ) {
-      throw new AuthorizationException();
-    }
+    authService.require(x, permission, null);
   }
 
   public boolean checkGlobalRead(X x, Predicate predicate) {

--- a/src/foam/nanos/auth/UserAndGroupAuthService.js
+++ b/src/foam/nanos/auth/UserAndGroupAuthService.js
@@ -18,6 +18,7 @@
 foam.CLASS({
   package: 'foam.nanos.auth',
   name: 'UserAndGroupAuthService',
+  extends: 'foam.nanos.auth.AbstractAuthService',
   flags: ['java'],
 
   implements: [


### PR DESCRIPTION
In development of Capability intercepts for CRUNCH, I realized that there is currently no way for an AuthService in the chain to add new information about the failed authorization check. This is because `check()` returns a boolean rather than throwing an exception.

If AuthService throws an exception instead of returning a boolean, an AuthService in the chain can add additional information to the AuthorizationException as it falls down. In the case of CRUNCH, a list of capabilities that can grant the permission can be added to AuthorizationException.