### PR TITLE
Fix approval request setIsFulfilled update

### DIFF
--- a/src/foam/nanos/approval/ApprovableAwareDAO.js
+++ b/src/foam/nanos/approval/ApprovableAwareDAO.js
@@ -207,7 +207,7 @@ foam.CLASS({
           ApprovalRequest fulfilledRequest = (ApprovalRequest) approvedObjRemoveRequests.get(0);
           fulfilledRequest.setIsFulfilled(true);
 
-          approvalRequestDAO.put_(x, fulfilledRequest);
+          approvalRequestDAO.put_(getX(), fulfilledRequest);
 
           if ( fulfilledRequest.getStatus() == ApprovalStatus.APPROVED ) {
             return super.put_(x,obj);

--- a/src/foam/nanos/approval/ApprovableAwareDAO.js
+++ b/src/foam/nanos/approval/ApprovableAwareDAO.js
@@ -257,7 +257,7 @@ foam.CLASS({
             ApprovalRequest fulfilledRequest = (ApprovalRequest) approvedObjCreateRequests.get(0);
             fulfilledRequest.setIsFulfilled(true);
 
-            approvalRequestDAO.put_(x, fulfilledRequest);
+            approvalRequestDAO.put_(getX(), fulfilledRequest);
 
             if ( fulfilledRequest.getStatus() == ApprovalStatus.APPROVED ) {
               lifecycleObj.setLifecycleState(LifecycleState.ACTIVE);
@@ -356,7 +356,7 @@ foam.CLASS({
           ApprovalRequest fulfilledRequest = (ApprovalRequest) approvedObjUpdateRequests.get(0);
           fulfilledRequest.setIsFulfilled(true);
 
-          approvalRequestDAO.put_(x, fulfilledRequest);
+          approvalRequestDAO.put_(getX(), fulfilledRequest);
 
           if ( fulfilledRequest.getStatus() == ApprovalStatus.APPROVED ) {
             return super.put_(x,obj);

--- a/src/foam/nanos/approval/ApprovableAwareDAO.js
+++ b/src/foam/nanos/approval/ApprovableAwareDAO.js
@@ -207,7 +207,8 @@ foam.CLASS({
           ApprovalRequest fulfilledRequest = (ApprovalRequest) approvedObjRemoveRequests.get(0);
           fulfilledRequest.setIsFulfilled(true);
 
-          approvalRequestDAO.put_(getX(), fulfilledRequest);
+          X approvalX = getX().put("user", new User.Builder(x).setId(fulfilledRequest.getLastModifiedBy()).build());
+          approvalRequestDAO.put_(approvalX, fulfilledRequest);
 
           if ( fulfilledRequest.getStatus() == ApprovalStatus.APPROVED ) {
             return super.put_(x,obj);
@@ -257,7 +258,8 @@ foam.CLASS({
             ApprovalRequest fulfilledRequest = (ApprovalRequest) approvedObjCreateRequests.get(0);
             fulfilledRequest.setIsFulfilled(true);
 
-            approvalRequestDAO.put_(getX(), fulfilledRequest);
+            X approvalX = getX().put("user", new User.Builder(x).setId(fulfilledRequest.getLastModifiedBy()).build());
+            approvalRequestDAO.put_(approvalX, fulfilledRequest);
 
             if ( fulfilledRequest.getStatus() == ApprovalStatus.APPROVED ) {
               lifecycleObj.setLifecycleState(LifecycleState.ACTIVE);
@@ -356,7 +358,8 @@ foam.CLASS({
           ApprovalRequest fulfilledRequest = (ApprovalRequest) approvedObjUpdateRequests.get(0);
           fulfilledRequest.setIsFulfilled(true);
 
-          approvalRequestDAO.put_(getX(), fulfilledRequest);
+          X approvalX = getX().put("user", new User.Builder(x).setId(fulfilledRequest.getLastModifiedBy()).build());
+          approvalRequestDAO.put_(approvalX, fulfilledRequest);
 
           if ( fulfilledRequest.getStatus() == ApprovalStatus.APPROVED ) {
             return super.put_(x,obj);


### PR DESCRIPTION
Approval requests can't be approved because the code to setIsFulfilled is causing an authorization exception. We need to elevate to the system context in order to complete this update.