### PR TITLE
[NP-188] Add missing check for class type to refinements.js `.compareTo()`

### DIFF
--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -603,9 +603,14 @@ foam.LIB({
             name: 'compareTo',
             type: 'int',
             args:[{ name: 'o', type: 'Object' }],
-            body: [cls.name+' o2 = ('+ cls.name + ') o;\n'
-              +'if ( o2 == null ) return 1;'
-              +'if ( o2 == this ) return 0;'
+            body: [''
+              +'if ( o == null ) return 1;'
+              +'if ( o == this ) return 0;'
+              +'if ( ! ( o instanceof foam.core.FObject ) ) return 1;'
+              +'if ( getClass() != o.getClass() ) {'
+                +'return getClassInfo().getId().compareTo(((foam.core.FObject)o).getClassInfo().getId());'
+              +'}'
+              +cls.name+' o2 = ('+ cls.name + ') o;\n'
               +'int cmp;\n'].concat(props.map(function(f) {
                 return 'cmp = foam.util.SafetyUtil.compare(get'+foam.String.capitalize(f.name)+'(), o2.get'+foam.String.capitalize(f.name)+'());\n'
                   +'if ( cmp != 0 ) return cmp;';


### PR DESCRIPTION
FObject.compareTo as implemented in refinements.js was causing an error when a property of some FObject is changed to a different subclass. (For example, CronSchedule being replaced with IntervalSchedule)