### PR TITLE
[NP-107] Add CheckUserAuthService

### DIFF
--- a/src/foam/nanos/auth/CheckUserAuthService.js
+++ b/src/foam/nanos/auth/CheckUserAuthService.js
@@ -1,0 +1,27 @@
+foam.CLASS({
+  package: 'foam.nanos.auth',
+  name: 'CheckUserAuthService',
+  extends: 'foam.nanos.auth.ProxyAuthService',
+  documentation: `
+  AuthService to prevent calling checkUser if the context user does not have
+  permission to check permissions for other users.
+  `,
+
+  constants: [
+    {
+      name: 'CHECK_USER_PERMISSION',
+      type: 'String',
+      value: 'service.auth.checkUser'
+    }
+  ],
+
+  methods: [
+    {
+      name: 'checkUser',
+      javaCode: `
+        if ( ! check(x, CHECK_USER_PERMISSION) ) throw new AuthorizationException();
+        return getDelegate().checkUser(x, user, permission);
+      `
+    }
+  ]
+});

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -90,6 +90,7 @@ FOAM_FILES([
   { name: "foam/nanos/auth/twofactor/TwoFactorSignInView" },
   { name: "foam/nanos/auth/twofactor/refinements" },
   { name: "foam/nanos/auth/UserAndGroupAuthService" },
+  { name: "foam/nanos/auth/CheckUserAuthService" },
   { name: "foam/nanos/auth/UserQueryService" },
   { name: "foam/nanos/auth/SimpleUserQueryService" },
   { name: "foam/nanos/bench/Benchmark" },

--- a/src/services
+++ b/src/services
@@ -50,6 +50,9 @@ p({
       .setDelegate(auth)
       .build();
     return auth;
+    auth = new foam.nanos.auth.CheckUserAuthService.Builder(x)
+      .setDelegate(auth)
+      .build();
     auth = new foam.nanos.auth.SystemAuthService.Builder(x)
       .setDelegate(auth)
       .build();


### PR DESCRIPTION
This fixes a vulnerability that becomes active when an AuthService implementor other than UserAndGroupAuthService grants permissions.

If a user doesn't have permission to check permissions for other users (`service.auth.checkUser`), they are still able to provided the permission was granted by an AuthService implementor other than UserAndGroupAuthService.