### PR TITLE
Fix map property methods

### DIFF
--- a/src/foam/core/types.js
+++ b/src/foam/core/types.js
@@ -610,7 +610,8 @@ foam.CLASS({
             // Force property update
             this.propertyChange.pub(self.name, this.slot(self.name));
           }
-        }
+        },
+        configurable: true
       });
       Object.defineProperty(proto, self.name + '$remove', {
         get: function mapRemove() {
@@ -620,7 +621,8 @@ foam.CLASS({
             // Force property update
             this.propertyChange.pub(self.name, this.slot(self.name));
           }
-        }
+        },
+        configurable: true
       })
     }
   ]


### PR DESCRIPTION
Fixes genjava error caused by redefining a non-configurable property.

The `installInProto` method for properties is called more than once on the same `proto`. This caused genjava to fail because I didn't add `configurable: true` to the `$set` and `$remove` property methods for `Map`.