### PR TITLE
Date view browser support fix

### DIFF
--- a/src/foam/u2/DateView.js
+++ b/src/foam/u2/DateView.js
@@ -39,7 +39,7 @@ foam.CLASS({
       name: 'onBlur',
       isFramed: true,
       code: function() {
-        if ( ! this.el() ) return;
+        if ( ! this.el() || ! this.data ) return;
         this.el().value = this.dataToInput(this.data);
       }
     }


### PR DESCRIPTION
Check for data value prior to resolving date.

Input was resolving to undefined, displaying an undefined value in date view input on various browsers.