### PR TITLE
Moving approvable DAO after setting of ID

### DIFF
--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -173,6 +173,16 @@ foam.CLASS({
           build();
         }
 
+        if ( getApprovableAware() ) {
+          delegate = new foam.nanos.approval.ApprovableAwareDAO
+          .Builder(getX())
+          .setDaoKey(getName())
+          .setOf(getOf())
+          .setDelegate(delegate)
+          .setIsEnabled(getApprovableAwareEnabled())
+          .build();
+        }
+        
         if ( getGuid() )
           delegate = new foam.dao.GUIDDAO.Builder(getX()).setDelegate(delegate).build();
 
@@ -227,16 +237,6 @@ foam.CLASS({
 
         if ( getLastModifiedByAware() )
           delegate = new foam.nanos.auth.LastModifiedByAwareDAO.Builder(getX()).setDelegate(delegate).build();
-
-        if ( getApprovableAware() ) {
-          delegate = new foam.nanos.approval.ApprovableAwareDAO
-          .Builder(getX())
-          .setDaoKey(getName())
-          .setOf(getOf())
-          .setDelegate(delegate)
-          .setIsEnabled(getApprovableAwareEnabled())
-          .build();
-        }
 
         if ( getContextualize() ) {
           delegate = new foam.dao.ContextualizingDAO.Builder(getX()).


### PR DESCRIPTION
The ID on the entity needs to be set before the ApprovableAwareDAO creates the approval requests, so in the EasyDAO, we need to create the ApprovableAwareDAO before we create the SeqNo or GUID DAOs.