### PR TITLE
Configure json parser for DAOMenu.detailView

### DIFF
--- a/src/foam/nanos/menu/DAOMenu.js
+++ b/src/foam/nanos/menu/DAOMenu.js
@@ -65,7 +65,13 @@ foam.CLASS({
     {
       class: 'foam.u2.ViewSpec',
       name: 'detailView',
-      displayWidth: 80
+      type: 'foam.lib.json.UnknownFObject',
+      javaInfoType: 'foam.core.AbstractFObjectPropertyInfo',
+      javaJSONParser: 'new foam.lib.json.UnknownFObjectParser()',
+      // TODO: remove next line when permanently fixed in ViewSpec
+      fromJSON: function fromJSON(value, ctx, prop, json) {
+        return value;
+      }
     },
     {
       class: 'String',


### PR DESCRIPTION
Use UnknownFObjectParser as the json parser for DAOMenu.detailView so that it can be stored in the journal.