### PR TITLE
Approval Request View Reference Fix

### DIFF
--- a/src/foam/nanos/approval/ApprovalRequest.js
+++ b/src/foam/nanos/approval/ApprovalRequest.js
@@ -390,15 +390,10 @@
         var X = this.ctrl.__subContext__;
 
         if ( ! X[key] ) {
-          // if DAO doesn't exist in context, change daoKey from localMyDAO
-          // (server-side) to myDAO (accessible on front-end)
-          for ( var i = 0 ; i < key.length ; i++ ) {
-            if ( key.charAt(i) == key.charAt(i).toUpperCase() ) {
-              key = key.substring(i);
-              break;
-            }
+          if ( key.startsWith('local') ) {
+            key = key.replace('local', '');
+            key = key.charAt(0).toLowerCase() + key.slice(1);
           }
-          key = key.charAt(0).toLowerCase() + key.slice(1);
         }
         return key;
       }

--- a/src/foam/nanos/approval/ApprovalRequest.js
+++ b/src/foam/nanos/approval/ApprovalRequest.js
@@ -388,11 +388,18 @@
       factory: function(o, n) {
         var key = this.daoKey;
         var X = this.ctrl.__subContext__;
+        
         // FIXME: change to a better implementation
         if ( ! X[key] ) {
           // if DAO doesn't exist in context, change daoKey from localMyDAO
           // (server-side) to myDAO (accessible on front-end)
-          key = key.substring(5, 6).toLowerCase() + key.substring(6);
+          for ( var i = 0 ; i < key.length ; i++ ) {
+            if ( key.charAt(i) == key.charAt(i).toUpperCase() ) {
+              key = key.substring(i);
+              break;
+            }
+          }
+          key = key.charAt(0).toLowerCase() + key.slice(1);
         }
         return key;
       }

--- a/src/foam/nanos/approval/ApprovalRequest.js
+++ b/src/foam/nanos/approval/ApprovalRequest.js
@@ -388,8 +388,7 @@
       factory: function(o, n) {
         var key = this.daoKey;
         var X = this.ctrl.__subContext__;
-        
-        // FIXME: change to a better implementation
+
         if ( ! X[key] ) {
           // if DAO doesn't exist in context, change daoKey from localMyDAO
           // (server-side) to myDAO (accessible on front-end)


### PR DESCRIPTION
In the Approval Request model we use a propety in the viewReference action called 'daoKey_' which is a formatted string that converts a daoKey string from 'localMyDAO' to 'myDAO' if the 'daoKey' property does not exist in the context. The previous implementation was breaking as it only took into account 'local' DAO strings. In the case of a user the DAO was 'bareUserDAO' and was being formatted to 'serDAO' which was breaking the viewReference action. I have now implemented functionality to format the string by removing the initial substring before the first capital letter in the daoKey. Which in turn would return the correct daoKey if it does not exist in the context.

Ticket: https://nanopay.atlassian.net/browse/NP-560