### PR TITLE
[DO_NOT_MERGE] User View Reference Quick Fix

### DIFF
--- a/src/foam/nanos/approval/ApprovalRequest.js
+++ b/src/foam/nanos/approval/ApprovalRequest.js
@@ -390,6 +390,9 @@
         var X = this.ctrl.__subContext__;
 
         if ( ! X[key] ) {
+          if ( key == 'bareUserDAO' ) {
+            key = 'userDAO';
+          }
           if ( key.startsWith('local') ) {
             key = key.replace('local', '');
             key = key.charAt(0).toLowerCase() + key.slice(1);

--- a/src/foam/nanos/approval/ApprovalRequest.js
+++ b/src/foam/nanos/approval/ApprovalRequest.js
@@ -390,8 +390,10 @@
         var X = this.ctrl.__subContext__;
 
         if ( ! X[key] ) {
-          if ( key == 'bareUserDAO' ) {
-            key = 'userDAO';
+          // TODO: Remove check for bareUserDAO when it is removed and replaced with localUserDAO
+          if ( key.startsWith('bare') ) {
+            key = key.replace('bare', '');
+            key = key.charAt(0).toLowerCase() + key.slice(1);
           }
           if ( key.startsWith('local') ) {
             key = key.replace('local', '');


### PR DESCRIPTION
Added check for bareUserDAO in daoKey property of ApprovalRequest model to shorten it to the client side userDAO for the View Reference action to work.

This check can be removed when bug is fixed to remove ‘bare’ userDAO and keep ‘local’ as the lowest level.