### PR TITLE
change email arg link to appLink due to link is occupayed

### DIFF
--- a/src/foam/util/Emails/EmailsUtility.java
+++ b/src/foam/util/Emails/EmailsUtility.java
@@ -63,7 +63,7 @@ public class EmailsUtility {
       templateArgs.put("supportAddress", address == null ? "" : address.toSummary());
       templateArgs.put("appName", (theme.getAppName()));
       templateArgs.put("logo", (theme.getLogo()));
-      templateArgs.put("link", (appConfig.getUrl()));
+      templateArgs.put("appLink", (appConfig.getUrl()));
       emailMessage.setTemplateArguments(templateArgs);
     }
 


### PR DESCRIPTION
nanopay side: https://github.com/nanoPayinc/NANOPAY/pull/9756
note: `link` has been occupied in email template such as token and verifying email. we need come up with other names.Current I'm using `appLink` to indicate the app page