### PR TITLE
Added strategizer predicate on query & Add persistantData to FObject

### DIFF
--- a/src/foam/strategy/BasicStrategizer.js
+++ b/src/foam/strategy/BasicStrategizer.js
@@ -50,6 +50,10 @@ foam.CLASS({
               )
             );
 
+        if ( strategyPredicate != null  ) {
+          predicate = (Predicate) strategyPredicate;
+        }
+
         DAO strategyDAO = ((DAO) getStrategyDAO()).inX(x);
         List refs = ((ArraySink) strategyDAO
           .where(predicate)

--- a/src/foam/strategy/StrategizerService.js
+++ b/src/foam/strategy/StrategizerService.js
@@ -45,6 +45,10 @@ foam.INTERFACE({
           type: 'String',
           name: 'target',
           documentation: 'Optional. If specified, the Strategizer will include StrategyReferences that are not generally applicable, but are applicable to the target.'
+        },
+        {
+          name: 'strategyPredicate',
+          documentation: 'Provide a unique predicate to strategizer query. Useful when omitting or extending entries based on class types.'
         }
       ]
     }

--- a/src/foam/strategy/StrategizerService.js
+++ b/src/foam/strategy/StrategizerService.js
@@ -24,6 +24,25 @@ foam.INTERFACE({
     Hence, a StrategizerService will give you references to strategies for
     something you want, which we refer to as the "desired model". The desired
     model might be an interface, abstract base class, or a concrete class.
+
+    Example of use of Strategizer on FObjectView:
+
+    name: 'exampleProp',
+    view: function(_, X) {
+      let predicate = expr.AND(
+          expr.EQ(foam.strategy.StrategyReference.DESIRED_MODEL_ID, 'foam.nanos.auth.User'),
+          expr.IN(foam.strategy.StrategyReference.STRATEGY, [foam.lookup('foam.nanos.auth.SomeUserClass'), foam.lookup('foam.nanos.auth.AnotherUserClass') ])
+      );
+      return foam.u2.view.FObjectView.create({
+        data: myData,
+        of: foam.nanos.auth.User,
+        persistantData: { website: X.data.user.website },
+        predicate: predicate
+      }, X);
+    }
+
+    - The FObjectView will persist X.data.user.website throughout any class selections.
+    - Strategizer class options will include SomeUserClass and AnotherUserClass excluding all other user subclasses. Granted the user has permissions to the strategies and if those classes exist.
   `,
 
   methods: [

--- a/src/foam/strategy/StrategizerService.js
+++ b/src/foam/strategy/StrategizerService.js
@@ -34,7 +34,7 @@ foam.INTERFACE({
           expr.IN(foam.strategy.StrategyReference.STRATEGY, [foam.lookup('foam.nanos.auth.SomeUserClass'), foam.lookup('foam.nanos.auth.AnotherUserClass') ])
       );
       return foam.u2.view.FObjectView.create({
-        data: myData,
+        data: X.data.exampleProp,
         of: foam.nanos.auth.User,
         persistantData: { website: X.data.user.website },
         predicate: predicate

--- a/src/foam/strategy/StrategyReference.js
+++ b/src/foam/strategy/StrategyReference.js
@@ -16,7 +16,6 @@ foam.CLASS({
   tableColumns: [
     'desiredModelId',
     'target',
-    'strategyPredicate',
     'strategy'
   ],
 

--- a/src/foam/strategy/StrategyReference.js
+++ b/src/foam/strategy/StrategyReference.js
@@ -16,6 +16,7 @@ foam.CLASS({
   tableColumns: [
     'desiredModelId',
     'target',
+    'strategyPredicate',
     'strategy'
   ],
 

--- a/src/foam/u2/view/FObjectView.js
+++ b/src/foam/u2/view/FObjectView.js
@@ -39,9 +39,7 @@ foam.CLASS({
           if ( this.data && this.data.cls_.id === newValue ) return;
           var m = this.__context__.lookup(newValue, true);
           if ( m ) {
-            this.data = this.persistData ?
-                m.create(null, this).copyFrom(this.data) :
-                m.create(null, this);
+            this.data = m.create(this.persistantData, this);
           }
         }
       }
@@ -89,9 +87,13 @@ foam.CLASS({
       value: true
     },
     {
-      class: 'Boolean',
-      name: 'persistData',
-      documentation: 'Allows data to persist to selected class instances.'
+      class: 'Object',
+      name: 'persistantData',
+      documentation: 'Allows passed in data to persist to selected class instances.'
+    },
+    {
+      name: 'predicate',
+      documentation: 'Unique predicate to pass into strategizer query request.'
     }
   ],
 
@@ -114,10 +116,11 @@ foam.CLASS({
       // populate the list of choices using models related to 'of' via the
       // implements and extends relations.
       if ( this.strategizer != null ) {
-        this.strategizer.query(null, this.of.id).then((strategyReferences) => {
+        this.strategizer.query(null, this.of.id, null, this.predicate).then((strategyReferences) => {
           // 'found' is set to true if the current data's objectClass is one
           // of the valid choices. If it isn't, then the objectClass is set
           // to the first choice to cause a new 'data' to be created.
+
           var found = false;
           var data = this.data;
 


### PR DESCRIPTION
- Enables strategizer query to utilize custom predicate. Useful for limiting strategies based on existing data. Ex. (IN(this.StrategyReference.STRATEGY, this.classInfoArray))

- Add persistantData to FObjectView to persist data through strategizer class selection. 
Solves both use cases mentioned in https://github.com/foam-framework/foam2/pull/2838. Data continues to persist and default values of selected classes will be applied.