### PR TITLE
Support function section title and subtitle

### DIFF
--- a/src/foam/layout/Section.js
+++ b/src/foam/layout/Section.js
@@ -8,6 +8,42 @@ foam.CLASS({
   package: 'foam.layout',
   name: 'Section',
 
+  documentation: `
+    Provides model data sectioned viewing when using the Section Views.
+    Iterates over models sections and displays each section and it's associated properties.
+
+    Example:
+    foam.CLASS({
+      name: 'myModel',
+      sections: [
+        {
+          name: 'mainSection'
+          title: function(myProp) {
+            return myProp ? 'Set this title if myProp true' : 'Set this title if myProp false';
+          }
+          isAvailable: function(myProp) {
+            return ! myProp;
+          }
+        }
+      ],
+      properties: [
+        {
+          class: 'Boolean',
+          name: 'myProp',
+          section: 'mainSection'
+        }
+      ]
+    });
+
+    Displaying this model in foam.u2.detail.SectionView will section properties and display
+    the sections title and subtitles. Sections are capable of being available based on instance data
+    and support dynamic titles and subtitles.
+
+    In the example above the mainSection section and it's properties will not be displayed if myProp is false.
+    Title will change based on the value of myProp.
+
+  `,
+
   requires: [
     'foam.core.Action',
     'foam.core.Property'
@@ -15,9 +51,11 @@ foam.CLASS({
 
   properties: [
     {
+      // Accepts function and string
       name: 'title'
     },
     {
+      // Accepts function and string
       name: 'subTitle'
     },
     {

--- a/src/foam/layout/Section.js
+++ b/src/foam/layout/Section.js
@@ -15,11 +15,9 @@ foam.CLASS({
 
   properties: [
     {
-      class: 'String',
       name: 'title'
     },
     {
-      class: 'String',
       name: 'subTitle'
     },
     {
@@ -27,7 +25,7 @@ foam.CLASS({
       name: 'help'
     },
     {
-      class:  'FObjectArray',
+      class: 'FObjectArray',
       of: 'foam.core.Property',
       name: 'properties'
     },

--- a/src/foam/layout/Section.js
+++ b/src/foam/layout/Section.js
@@ -9,8 +9,8 @@ foam.CLASS({
   name: 'Section',
 
   documentation: `
-    Provides model data sectioned viewing when using the Section Views.
-    Iterates over models sections and displays each section and it's associated properties.
+    Provides model data sectioned viewing when using section views.
+    Used for sectioning/grouping model properties and actions.
 
     Example:
     foam.CLASS({
@@ -36,12 +36,8 @@ foam.CLASS({
     });
 
     Displaying this model in foam.u2.detail.SectionView will section properties and display
-    the sections title and subtitles. Sections are capable of being available based on instance data
+    the sections title, subtitle, and help. Sections are capable of being available based on instance data
     and support dynamic titles and subtitles.
-
-    In the example above the mainSection section and it's properties will not be displayed if myProp is false.
-    Title will change based on the value of myProp.
-
   `,
 
   requires: [

--- a/src/foam/layout/SectionAxiom.js
+++ b/src/foam/layout/SectionAxiom.js
@@ -14,7 +14,6 @@ foam.CLASS({
       name: 'name'
     },
     {
-      class: 'String',
       name: 'title',
       expression: function(name) {
         if ( name === '_defaultSection' ) return '';
@@ -22,7 +21,6 @@ foam.CLASS({
       }
     },
     {
-      class: 'String',
       name: 'subTitle'
     },
     {

--- a/src/foam/u2/detail/SectionView.js
+++ b/src/foam/u2/detail/SectionView.js
@@ -62,15 +62,25 @@ foam.CLASS({
 
       self
         .addClass(self.myClass())
-        .add(self.slot(function(section, showTitle, section$title, section$subTitle) {
+        .add(self.slot(function(section, showTitle, section$subTitle) {
           if ( ! section ) return;
           return self.Rows.create()
             .show(section.createIsAvailableFor(self.data$))
-            .callIf(showTitle && section$title, function() {
-              this.start('h2').add(section$title).end();
+            .callIf(showTitle, function() {
+              var slot$ = typeof self.section.title === 'function' ?
+                foam.core.ExpressionSlot.create({
+                  obj$: self.data$,
+                  code: section.title
+                }) : section.title$;
+              this.start('h2').add(slot$).end();
             })
             .callIf(section$subTitle, function() {
-              this.start().addClass('subtitle').add(section$subTitle).end();
+              var slot$ = typeof self.section.subTitle === 'function' ?
+              foam.core.ExpressionSlot.create({
+                obj$: self.data$,
+                code: section.subTitle
+              }) : section.subTitle$;
+              this.start().addClass('subtitle').add(slot$).end();
             })
             .start(self.Grid)
               .forEach(section.properties, function(p, index) {

--- a/src/foam/u2/detail/SectionView.js
+++ b/src/foam/u2/detail/SectionView.js
@@ -67,7 +67,7 @@ foam.CLASS({
           return self.Rows.create()
             .show(section.createIsAvailableFor(self.data$))
             .callIf(showTitle, function() {
-              var slot$ = typeof self.section.title === 'function' ?
+              var slot$ = foam.Function.isInstance(self.section.title) ?
                 foam.core.ExpressionSlot.create({
                   obj$: self.data$,
                   code: section.title
@@ -75,7 +75,7 @@ foam.CLASS({
               this.start('h2').add(slot$).end();
             })
             .callIf(section$subTitle, function() {
-              var slot$ = typeof self.section.subTitle === 'function' ?
+              var slot$ = foam.Function.isInstance(self.section.subTitle) ?
               foam.core.ExpressionSlot.create({
                 obj$: self.data$,
                 code: section.subTitle

--- a/src/foam/u2/detail/SectionedDetailView.js
+++ b/src/foam/u2/detail/SectionedDetailView.js
@@ -62,11 +62,19 @@ foam.CLASS({
                 // grid doesn't add whitespace around it.
                 if ( ! isAvailable ) return self.E().style({ display: 'none' });
 
+                // Support string titles and functions
+                var title$ = typeof s.title === 'function' ?
+                foam.core.ExpressionSlot.create({
+                  obj$: self.data$,
+                  code: s.title
+                }) :
+                s.title$;
+
                 return self.GUnit.create({ columns: s.gridColumns })
                   .addClass(self.myClass('card-container'))
                   .start('h2')
-                    .add(s.title$)
-                    .show(s.title$)
+                    .add(title$)
+                    .show(title$)
                   .end()
                   .start(self.border)
                     .addClass('inner-card')

--- a/src/foam/u2/detail/SectionedDetailView.js
+++ b/src/foam/u2/detail/SectionedDetailView.js
@@ -63,7 +63,7 @@ foam.CLASS({
                 if ( ! isAvailable ) return self.E().style({ display: 'none' });
 
                 // Support string titles and functions
-                var title$ = typeof s.title === 'function' ?
+                var title$ = foam.Function.isInstance(s.title) ?
                 foam.core.ExpressionSlot.create({
                   obj$: self.data$,
                   code: s.title


### PR DESCRIPTION
Enables dynamic section titles and subtitles. Functions placed on title and subtitle will account for data changes using expression slots. Applied if function is implied on section property. String titles and subtitles will continue to behave as expected.

Example: 
```javascript
sections: [
 {
    name: 'mySection',
    title: function(propData) {
      return propData ? 'Set this title if propData true' : 'Set this title if propData false';
    }
 }
]
```