### PR TITLE
Java Import Rework

### DIFF
--- a/src/foam/blob/Blob.js
+++ b/src/foam/blob/Blob.js
@@ -348,7 +348,7 @@ foam.CLASS({
   extends: 'foam.blob.ProxyBlob',
 
   imports: [
-    'blobStore?',
+    'BlobStore blobStore?',
     'blobService'
   ],
 

--- a/src/foam/box/CheckAuthenticationBox.js
+++ b/src/foam/box/CheckAuthenticationBox.js
@@ -21,7 +21,11 @@ foam.CLASS({
   extends: 'foam.box.ProxyBox',
 
   imports: [
-    'tokenVerifier'
+    'TokenVerifier tokenVerifier'
+  ],
+
+  javaImports: [
+    'com.google.auth.TokenVerifier'
   ],
 
   methods: [

--- a/src/foam/core/ImportsExports.js
+++ b/src/foam/core/ImportsExports.js
@@ -250,11 +250,16 @@ foam.CLASS({
       name: 'imports',
       adaptArrayElement: function(o) {
         if ( typeof o === 'string' ) {
-          var a        = o.split(' as ');
-          var key      = a[0];
+          // Matches strings in the form [(javatype)] (name[?]) [as (name)]
+          // Where [] is optional and () is a capture group
+          let res = /(?:(?:([\w.$]+)\s+)(?!as))?([\w$?]+)(?:\s+as\s+([\w$]+))?/g.exec(o);
+          let javaType = res[1];
+          let key = res[2];
+          let name = res[3];
+
           var optional = key.endsWith('?');
           if ( optional ) key = key.slice(0, key.length-1);
-          return foam.core.Import.create({name: a[1] || key, key: key, required: ! optional});
+          return foam.core.Import.create({name: name || key, key: key, required: ! optional, javaType: javaType || 'null'});
         }
 
         return foam.core.Import.create(o);

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -971,6 +971,7 @@ foam.CLASS({
 
   methods: [
     function buildJavaClass(cls) {
+      if ( this.javaType == 'null' ) return;
       cls.method({
         type: this.javaType,
         name: 'get' + foam.String.capitalize(this.name),

--- a/src/foam/nanos/approval/ApprovalRequest.js
+++ b/src/foam/nanos/approval/ApprovalRequest.js
@@ -42,7 +42,7 @@
   ],
 
   imports: [
-    'approvalRequestDAO',
+    'DAO approvalRequestDAO',
     'ctrl',
     'currentMenu',
     'stack',

--- a/src/foam/nanos/auth/Group.js
+++ b/src/foam/nanos/auth/Group.js
@@ -354,9 +354,14 @@ foam.CLASS({
     it.
   `,
 
-  imports: ['auth'],
+  imports: [
+    'AuthService auth'
+  ],
 
-  javaImports: ['foam.dao.DAO'],
+  javaImports: [
+    'foam.dao.DAO',
+    'foam.nanos.auth.AuthService'
+  ],
 
   messages: [
     {

--- a/src/foam/nanos/auth/PasswordExpiryAuthService.js
+++ b/src/foam/nanos/auth/PasswordExpiryAuthService.js
@@ -16,7 +16,7 @@ foam.CLASS({
   ],
 
   imports: [
-    'localUserDAO'
+    'DAO localUserDAO'
   ],
 
   javaImports: [

--- a/src/foam/nanos/auth/UserAndGroupAuthService.js
+++ b/src/foam/nanos/auth/UserAndGroupAuthService.js
@@ -26,9 +26,9 @@ foam.CLASS({
   ],
 
   imports: [
-    'localGroupDAO',
-    'localSessionDAO',
-    'localUserDAO'
+    'DAO localGroupDAO',
+    'DAO localSessionDAO',
+    'DAO localUserDAO'
   ],
 
   javaImports: [

--- a/src/foam/nanos/auth/email/EmailDocService.js
+++ b/src/foam/nanos/auth/email/EmailDocService.js
@@ -19,8 +19,8 @@ foam.CLASS({
     'email',
     'localUserDAO',
     'tokenDAO',
-    'htmlDocDAO',
-    'logger'
+    'DAO htmlDocDAO',
+    'Logger logger'
   ],
 
   javaImports: [

--- a/src/foam/nanos/auth/resetPassword/ResetPasswordTokenService.js
+++ b/src/foam/nanos/auth/resetPassword/ResetPasswordTokenService.js
@@ -13,9 +13,9 @@ foam.CLASS({
 
   imports: [
     'appConfig',
-    'email',
-    'localUserDAO',
-    'tokenDAO'
+    'Email email',
+    'DAO localUserDAO',
+    'DAO tokenDAO'
   ],
 
   javaImports: [

--- a/src/foam/nanos/notification/email/EmailServiceDAO.js
+++ b/src/foam/nanos/notification/email/EmailServiceDAO.js
@@ -15,7 +15,7 @@ foam.CLASS({
   ],
 
   imports: [
-    'email?'
+    'EmailService email?'
   ],
 
   properties: [

--- a/src/foam/nanos/session/SimpleSessionService.js
+++ b/src/foam/nanos/session/SimpleSessionService.js
@@ -17,9 +17,9 @@ foam.CLASS({
   implements: ['foam.nanos.session.SessionService'],
 
   imports: [
-    'auth',
-    'localSessionDAO',
-    'localUserDAO'
+    'AuthService auth',
+    'DAO localSessionDAO',
+    'DAO localUserDAO'
   ],
 
   javaImports: [

--- a/src/foam/strategy/BasicStrategizer.js
+++ b/src/foam/strategy/BasicStrategizer.js
@@ -15,7 +15,7 @@ foam.CLASS({
   ],
 
   imports: [
-    'strategyDAO'
+    'DAO strategyDAO'
   ],
 
   javaImports: [


### PR DESCRIPTION
Made it so imports are only generated for java when a java type is specified, changed all occurrences where an import was used in java but a java type wasn't specified to have a specified java type

Breaking change, https://github.com/nanoPayinc/NANOPAY/pull/9912 will need to be merged at the same time