### PR TITLE
Added a limit of 25 generating class name prints

### DIFF
--- a/tools/genjava.js
+++ b/tools/genjava.js
@@ -305,10 +305,18 @@ var addDepsToClasses = function() {
     function collectDeps() {
       var classMap = {};
       var classQueue = classes.slice(0);
+      const PRINT_LIMIT = 25;
+      let printCounter = 0;
       while ( classQueue.length ) {
         var cls = classQueue.pop();
         if ( ! classMap[cls] && ! blacklist[cls] ) {
-          console.log('generating', cls);
+          if ( printCounter < PRINT_LIMIT ) {
+            console.log('generating', cls);
+            printCounter = printCounter + 1;
+          } else if ( printCounter == PRINT_LIMIT ) {
+            console.log('generating ...');
+            printCounter = printCounter + 1;
+          }
           cls = foam.lookup(cls);
           if ( ! checkFlags(cls.model_) ) continue;
           classMap[cls.id] = true;


### PR DESCRIPTION
If there's more than 25 classes being generated, it most likely means that it's doing a full rebuild, and the excessive prints just shadows potentially important build information that could come before. 