### PR TITLE
Add constantize to MessageAxiom

### DIFF
--- a/src/foam/i18n/Messages.js
+++ b/src/foam/i18n/Messages.js
@@ -73,7 +73,7 @@ foam.CLASS({
       var name = this.name;
       Object.defineProperty(
         proto,
-        this.name,
+        foam.String.constantize(this.name),
         {
           get: function() { return this.cls_[name] },
           configurable: false


### PR DESCRIPTION
This PR constantizes the property added by MessageAxiom for consistency with other axioms like Property.

For example, a message with name `someMessage` would be added to an instance as `SOME_MESSAGE` instead, and be called with `this.SOME_MESSAGE`.