### PR TITLE
add / between url and logo

### DIFF
--- a/src/foam/util/Emails/EmailsUtility.java
+++ b/src/foam/util/Emails/EmailsUtility.java
@@ -64,7 +64,7 @@ public class EmailsUtility {
       foam.nanos.auth.Address address = theme.getSupportAddress();
       templateArgs.put("supportAddress", address == null ? "" : address.toSummary());
       templateArgs.put("appName", (theme.getAppName()));
-      templateArgs.put("logo", (appConfig.getUrl() + theme.getLogo()));
+      templateArgs.put("logo", (appConfig.getUrl() + "/" + theme.getLogo()));
       templateArgs.put("appLink", (appConfig.getUrl()));
       emailMessage.setTemplateArguments(templateArgs);
     }


### PR DESCRIPTION
Email logo broken due to src = http://staging.ablii.comimages/ablii-logo.svg, need add "/" between .com and images.
Also, seems like gmail do not accept svg. will test it and making further changes on nanopay side