### PR TITLE
SearchFilterDAO + Predicate Fix

### DIFF
--- a/src/foam/comics/v2/DAOBrowserView.js
+++ b/src/foam/comics/v2/DAOBrowserView.js
@@ -249,6 +249,7 @@ foam.CLASS({
                       })
                       .callIf(self.config.searchMode === self.SearchMode.FULL, function() {
                         this.tag(self.FilterView, {
+                          dao$: self.searchFilterDAO$,
                           data$: self.searchPredicate$
                         });
                       })

--- a/src/foam/u2/filter/FilterController.js
+++ b/src/foam/u2/filter/FilterController.js
@@ -93,7 +93,7 @@ foam.CLASS({
 
     function and(predicates) {
       return this.And.create({
-        args: Object.values(predicates).filter(function(predicate) { return predicate !== undefined })
+        args: Object.values(predicates).filter((predicate) => { return predicate !== undefined; })
       }).partialEval();
     },
 
@@ -263,7 +263,7 @@ foam.CLASS({
       // There could be a case where the view's data is for reconstruction
       // Therefore, there won't be a method called clear
       if ( criterias[criteria].views[name].clear ) criterias[criteria].views[name].clear();
-      criterias[criteria].predicates[name] = {};
+      criterias[criteria].predicates[name] = this.TRUE;
       if ( remove ) {
         // There could be a case where the view's data is for reconstruction
         // Therefore, there won't be any subs

--- a/src/foam/u2/filter/FilterView.js
+++ b/src/foam/u2/filter/FilterView.js
@@ -27,7 +27,6 @@ foam.CLASS({
   ],
 
   imports: [
-    'dao',
     'searchColumns'
   ],
 
@@ -169,6 +168,9 @@ foam.CLASS({
     {
       class: 'Class',
       name: 'of'
+    },
+    {
+      name: 'dao'
     },
     {
       name: 'data'


### PR DESCRIPTION
# Fixes
- Made the filter properly use `searchFilterDAO` that is made in DAOBrowserView which accounts for canned queries
- Fixed an issue where the filter breaks on clearing.