### PR TITLE
Accounted For Approving And Rejecting Modal When Using Table

### DIFF
--- a/src/foam/nanos/approval/ApprovalRequest.js
+++ b/src/foam/nanos/approval/ApprovalRequest.js
@@ -47,6 +47,7 @@
     'ctrl',
     'currentMenu',
     'stack',
+    'summaryView?',
     'objectSummaryView?'
   ],
 
@@ -580,7 +581,9 @@
         return ! isTrackingRequest;
       },
       code: function(X) {
-        this.objectSummaryView.add(this.Popup.create({ backgroundColor: 'transparent' }).tag({
+        var objToAdd = X.objectSummaryView ? X.objectSummaryView : X.summaryView;
+
+        objToAdd.add(this.Popup.create({ backgroundColor: 'transparent' }).tag({
           class: "foam.u2.MemoModal",
           onExecute: this.approveWithMemo.bind(this)
         }));
@@ -600,7 +603,9 @@
         return ! isTrackingRequest;
       },
       code: function(X) {
-        this.objectSummaryView.add(this.Popup.create({ backgroundColor: 'transparent' }).tag({
+        var objToAdd = X.objectSummaryView ? X.objectSummaryView : X.summaryView;
+
+        objToAdd.add(this.Popup.create({ backgroundColor: 'transparent' }).tag({
           class: "foam.u2.MemoModal",
           onExecute: this.rejectWithMemo.bind(this),
           isMemoRequired: true

--- a/src/foam/u2/view/ScrollTableView.js
+++ b/src/foam/u2/view/ScrollTableView.js
@@ -9,6 +9,10 @@
   name: 'ScrollTableView',
   extends: 'foam.u2.Element',
 
+  exports: [
+    'as summaryView'
+  ],
+
   requires: [
     'foam.dao.FnSink',
     'foam.mlang.sink.Count',


### PR DESCRIPTION
We already previously exported the summaryView to handle the GroupDAOList being accessible by the NotificationRowView for notifications. Here we also added it to the ScrollTableView (the default summaryView) so that the view is accessible from the ApprovalRequest object.