### PR TITLE
change authorization for capabilitycategory

### DIFF
--- a/src/foam/nanos/crunch/CapabilityCategory.js
+++ b/src/foam/nanos/crunch/CapabilityCategory.js
@@ -7,9 +7,18 @@ foam.CLASS({
   package: 'foam.nanos.crunch',
   name: 'CapabilityCategory',
 
+  implements: [
+    'foam.nanos.auth.Authorizable'
+  ],
+
   documentation: `
     This models a category to which a Capability can be associated.
   `,
+
+  javaImports: [
+    'foam.nanos.auth.AuthorizationException',
+    'foam.nanos.auth.Authorizer'
+  ],
 
   properties: [
     {
@@ -30,6 +39,73 @@ foam.CLASS({
       class: 'Boolean',
       documentation: 'categories are being used for UI display and also predicate rules on UCJDAO',
       value: true
+    },
+    {
+      name: 'visibilityCondition',
+      class: 'foam.mlang.predicate.PredicateProperty',
+      readVisibility: 'HIDDEN'
+    },
+    {
+      name: 'defaultAuthorizer',
+      class: 'Object',
+      javaType: 'foam.nanos.auth.Authorizer',
+      javaFactory: `
+        return new foam.nanos.auth.StandardAuthorizer(getClass().getSimpleName().toLowerCase());
+      `,
+      readVisibility: true
+    }
+  ],
+  
+  methods: [
+    {
+      name: 'authorizeOnCreate',
+      args: [
+        { name: 'x', type: 'Context' }
+      ],
+      javaThrows: ['AuthorizationException'],
+      javaCode: `
+        ( getDefaultAuthorizer()).authorizeOnCreate(x, this);
+      `
+    },
+    {
+      name: 'authorizeOnRead',
+      args: [
+        { name: 'x', type: 'Context' }
+      ],
+      javaThrows: ['AuthorizationException'],
+      javaCode: `
+        if ( getVisibilityCondition() == null ) {
+          ( getDefaultAuthorizer()).authorizeOnRead(x, this);
+          return;
+        }
+        try {
+          if ( getVisibilityCondition().f(x) ) return;
+          throw new AuthorizationException();
+        } catch ( AuthorizationException e ) {
+          throw new AuthorizationException("You do not have permission to view this capabilitycategory");
+        }
+      `
+    },
+    {
+      name: 'authorizeOnUpdate',
+      args: [
+        { name: 'x', type: 'Context' },
+        { name: 'oldObj', type: 'foam.core.FObject' }
+      ],
+      javaThrows: ['AuthorizationException'],
+      javaCode: `
+        ( getDefaultAuthorizer()).authorizeOnUpdate(x, oldObj, this);
+      `
+    },
+    {
+      name: 'authorizeOnDelete',
+      args: [
+        { name: 'x', type: 'Context' }
+      ],
+      javaThrows: ['AuthorizationException'],
+      javaCode: `
+        ( getDefaultAuthorizer()).authorizeOnDelete(x, this);
+      `
     }
   ]
 });

--- a/src/foam/nanos/crunch/CapabilityCategory.js
+++ b/src/foam/nanos/crunch/CapabilityCategory.js
@@ -52,7 +52,7 @@ foam.CLASS({
       javaFactory: `
         return new foam.nanos.auth.StandardAuthorizer(getClass().getSimpleName().toLowerCase());
       `,
-      readVisibility: true
+      readVisibility: 'HIDDEN'
     }
   ],
   

--- a/src/foam/nanos/crunch/services.jrl
+++ b/src/foam/nanos/crunch/services.jrl
@@ -5,7 +5,6 @@ p({
   "serve":true,
   "serviceScript":"""
     return new foam.dao.EasyDAO.Builder(x)
-      .setAuthorizer(new foam.nanos.auth.GlobalReadAuthorizer("prerequisiteCapabilityJunction"))
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
       .setJournalName("capabilityCategories")
       .setOf(foam.nanos.crunch.CapabilityCategory.getOwnClassInfo())


### PR DESCRIPTION
authorize read for capabilitycategory depending on given predicate

example usage
```
p({
  "class": "foam.nanos.crunch.CapabilityCategory",
  "id": "signingOfficerOnboarding",
  "name": "Onboarding A Signing Officer",
  "visible": true,
  "visibilityCondition": 
         {"class":"net.nanopay.crunch.onboardingModels.UserIsSigningOfficerOfBusiness"}
})
```
any capability under the `signingofficeronboarding` category will be visible if the visibilitycondition returns true