### PR TITLE
Add HTTP Authorization Type support - Bearer Token

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -395,6 +395,7 @@ FOAM_FILES([
   { name: "foam/box/BoxService" },
   { name: "foam/box/HTTPReplyBox" },
   { name: "foam/box/AuthenticatedBox" },
+  { name: "foam/box/HTTPAuthorizationType" },
   { name: "foam/box/HTTPBox" },
   { name: "foam/box/MessagePortBox" },
   { name: "foam/box/ForwardedMessage" },

--- a/src/foam/box/HTTPAuthorizationType.js
+++ b/src/foam/box/HTTPAuthorizationType.js
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2019 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.ENUM({
+  package: 'foam.box',
+  name: 'HTTPAuthorizationType',
+
+  documentation: 'Types of HTTP Athorization',
+
+  values: [
+    {
+      name: 'NONE',
+      label: 'None',
+      ordinal: 0
+    },
+    // {
+    //   name: 'BASIC',
+    //   label: 'Basic',
+    //   ordinal: 1
+    // },
+    {
+      name: 'BEARER',
+      label: 'Bearer',
+      ordinal: 2
+    }
+  ]
+});

--- a/src/foam/box/HTTPBox.js
+++ b/src/foam/box/HTTPBox.js
@@ -45,6 +45,10 @@ foam.CLASS({
     'foam.box.Message',
   ],
 
+  javaImports: [
+    'javax.servlet.http.HttpServletRequest'
+  ],
+
   imports: [
     'creationContext',
     {
@@ -87,6 +91,27 @@ foam.CLASS({
       value: 'POST'
     },
     {
+      documentation: 'Calling http url, used when explicitly making cross site requests.',
+      name: 'origin',
+      class: 'String',
+      factory: function() {
+        return this.window && this.window.location.origin;
+      },
+      javaFactory: `
+      HttpServletRequest req = getX().get(HttpServletRequest.class);
+      if ( req != null ) {
+        return req.getScheme()+"://"+req.getServerName();
+      }
+      return null;
+      `
+    },
+    {
+      class: 'Enum',
+      of: 'foam.box.HTTPAuthorizationType',
+      name: 'authorizationType',
+      value: foam.box.HTTPAuthorizationType.NONE
+    },
+    {
       class: 'FObjectProperty',
       of: 'foam.json.Parser',
       swiftType: 'foam_swift_parse_json_FObjectParser',
@@ -113,7 +138,20 @@ foam.CLASS({
       swiftFactory: 'return SwiftOutputter_create()',
       factory: function() {
         return this.Outputter.create().copyFrom(foam.json.Network);
-      }
+      },
+      // javaFactory: `
+      // return foam.lib.json.Outputter outputter = new Outputter(getX());
+      // `
+    },
+    {
+      class: 'Int',
+      name: 'connectTimeout',
+      value: 0
+    },
+    {
+      class: 'Int',
+      name: 'readTimeout',
+      value: 0
     }
   ],
 
@@ -172,19 +210,26 @@ protected class ResponseThread implements Runnable {
         // instead we will mutate replyBox and put it back after.
         var replyBox = msg.attributes.replyBox;
 
-        msg.attributes.replyBox = this.HTTPReplyBox.create();
+        msg.attributes.replyBox = this.getReplyBox();
 
         var payload = this.outputter.stringify(msg);
 
         msg.attributes.replyBox = replyBox;
 
+        var headers = {
+          'Content-Type': 'application/json; charset=utf-8',
+          'Origin': this.origin
+        };
+
+        if ( this.authorizationType === foam.box.HTTPAuthorizationType.BEARER ) {
+          headers['Authorization'] = 'BEARER ' + this.sessionID;
+        }
+
         var req = this.HTTPRequest.create({
           url:     this.prepareURL(this.url),
-          method:  this.method,
+          method: this.method,
           payload: payload,
-          headers: {
-            'Content-Type': 'application/json; charset=utf-8'
-          },
+          headers: headers
         }).send();
 
         req.then(function(resp) {
@@ -200,7 +245,7 @@ protected class ResponseThread implements Runnable {
       swiftCode: function() {/*
 let msg = msg!
 let replyBox = msg.attributes["replyBox"] as? foam_box_Box
-msg.attributes["replyBox"] = HTTPReplyBox_create()
+msg.attributes["replyBox"] = getReplyBox()
 
 var request = URLRequest(url: Foundation.URL(string: self.url)!)
 request.httpMethod = "POST"
@@ -225,70 +270,108 @@ let task = URLSession.shared.dataTask(with: request) { data, response, error in
 task.resume()
       */},
       javaCode: `
-// TODO: Go async and make request in a separate thread.
-java.net.HttpURLConnection conn;
-foam.box.Box replyBox = (foam.box.Box)msg.getAttributes().get("replyBox");
+      // TODO: Go async and make request in a separate thread.
 
-try {
-  java.net.URL url = new java.net.URL(getUrl());
-  conn = (java.net.HttpURLConnection)url.openConnection();
-  conn.setDoOutput(true);
-  conn.setRequestMethod("POST");
-  conn.setRequestProperty("Accept", "application/json");
-  conn.setRequestProperty("Content-Type", "application/json");
+      java.net.HttpURLConnection conn;
+      foam.box.Box replyBox = (foam.box.Box)msg.getAttributes().get("replyBox");
 
-  java.io.OutputStreamWriter output = new java.io.OutputStreamWriter(conn.getOutputStream(),
-                                                                     java.nio.charset.StandardCharsets.UTF_8);
+      try {
+        conn = getConnection();
+        java.io.OutputStreamWriter output =
+          new java.io.OutputStreamWriter(conn.getOutputStream(),
+                                            java.nio.charset.StandardCharsets.UTF_8);
 
+        // TODO: Clone message or something when it clones safely.
+        msg.getAttributes().put("replyBox", getReplyBox());
 
-  // TODO: Clone message or something when it clones safely.
-  msg.getAttributes().put("replyBox", getX().create(foam.box.HTTPReplyBox.class));
+        output.write(new Outputter(getX()).stringify(msg));
 
+        msg.getAttributes().put("replyBox", replyBox);
+        output.close();
 
-  foam.lib.json.Outputter outputter = new foam.lib.json.Outputter(getX()).setPropertyPredicate(new foam.lib.NetworkPropertyPredicate());
-  output.write(outputter.stringify(msg));
+        replyBox.send((foam.box.Message)getResponseMessage(conn));
 
-  msg.getAttributes().put("replyBox", replyBox);
+      } catch(java.io.IOException e) {
+        foam.box.Message replyMessage = getX().create(foam.box.Message.class);
+        replyMessage.setObject(e);
+        replyBox.send(replyMessage);
+      }
+      `
+    },
+    {
+      name: 'getReplyBox',
+      type: 'foam.box.Box',
+      code: function() {
+        return this.HTTPReplyBox.create();
+      },
+      swiftCode: function() {/*
+      return HTTPReplyBox_create()
+                             */},
+      javaCode: `
+        return getX().create(foam.box.HTTPReplyBox.class);
+      `
+    },
+    {
+      name: 'getConnection',
+      javaType: 'java.net.HttpURLConnection',
+      javaThrows: ['java.io.IOException'],
+      javaCode: `
+      java.net.URL url = new java.net.URL(getUrl());
+      java.net.HttpURLConnection conn = (java.net.HttpURLConnection) url.openConnection();
+      conn.setDoOutput(true);
+      conn.setRequestMethod("POST");
+      conn.setRequestProperty("Accept", "application/json");
+      conn.setRequestProperty("Content-Type", "application/json");
+      if ( getOrigin() != null ) {
+        conn.setRequestProperty("Origin", getOrigin());
+      }
+      if ( getAuthorizationType() == HTTPAuthorizationType.BEARER ) {
+        conn.setRequestProperty("Authorization", "BEARER "+getSessionID());
+      }
+      conn.setConnectTimeout(getConnectTimeout());
+      conn.setReadTimeout(getReadTimeout());
+      return conn;
+      `
+    },
+    {
+      name: 'getResponseMessage',
+      args: [
+        {
+          name: 'conn',
+          type: 'java.net.HttpURLConnection'
+        }
+      ],
+      javaType: 'foam.core.FObject',
+      javaThrows: ['java.io.IOException'],
+      javaCode: `
+      // TODO: Switch to ReaderPStream when https://github.com/foam-framework/foam2/issues/745 is fixed.
+      byte[] buf = new byte[8388608];
+      java.io.InputStream input = conn.getInputStream();
 
-  output.close();
+      int off = 0;
+      int len = buf.length;
+      int read = -1;
+      while ( len != 0 && ( read = input.read(buf, off, len) ) != -1 ) {
+        off += read;
+        len -= read;
+      }
 
-// TODO: Switch to ReaderPStream when https://github.com/foam-framework/foam2/issues/745 is fixed.
-byte[] buf = new byte[8388608];
-java.io.InputStream input = conn.getInputStream();
+      if ( len == 0 && read != -1 ) {
+        throw new RuntimeException("Message too large.");
+      }
 
-int off = 0;
-int len = buf.length;
-int read = -1;
-while ( len != 0 && ( read = input.read(buf, off, len) ) != -1 ) {
-  off += read;
-  len -= read;
-}
+      String str = new String(buf, 0, off, java.nio.charset.StandardCharsets.UTF_8);
+      foam.core.FObject responseMessage = getX().create(foam.lib.json.JSONParser.class).parseString(str);
 
-if ( len == 0 && read != -1 ) {
-  throw new RuntimeException("Message too large.");
-}
-
-String str = new String(buf, 0, off, java.nio.charset.StandardCharsets.UTF_8);
-
-foam.core.FObject responseMessage = getX().create(foam.lib.json.JSONParser.class).parseString(str);
-
-if ( responseMessage == null ) {
-  throw new RuntimeException("Error parsing response.");
-}
-
-if ( ! ( responseMessage instanceof foam.box.Message ) ) {
-  throw new RuntimeException("Invalid response type: " + responseMessage.getClass().getName() + " expected foam.box.Message.");
-}
-
-
-replyBox.send((foam.box.Message)responseMessage);
-
-} catch(java.io.IOException e) {
-  foam.box.Message replyMessage = getX().create(foam.box.Message.class);
-  replyMessage.setObject(e);
-  replyBox.send(replyMessage);
-}
-`
+      if ( responseMessage == null ) {
+        ((foam.nanos.logger.Logger) getX().get("logger")).error("HTTPBox", "Error parsing response.", str);
+        throw new RuntimeException("Error parsing response.");
+      }
+      if ( ! ( responseMessage instanceof foam.box.Message ) ) {
+        throw new RuntimeException("Invalid response type: " + responseMessage.getClass().getName() + " expected foam.box.Message.");
+      }
+      return responseMessage;
+      `
     }
   ]
 });

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -86,6 +86,7 @@ var classes = [
   'foam.box.SubBoxMessage',
   'foam.box.SubscribeMessage',
   'foam.box.NamedBox',
+  'foam.box.HTTPAuthorizationType',
   'foam.box.HTTPBox',
   'foam.box.HTTPReplyBox',
   'foam.box.AuthServiceClientBox',


### PR DESCRIPTION
Add Authorization Types such a BEARER in HTTPBox.
Part of Medusa, but required earlier to test Medusa Nodes from pre-Medusa instances.
Also involves a refactoring of HTTPBox to allow for subclasses to override operations such as getReplyBox. 