### PR TITLE
invalidateDependencies branch rebased manually

### DIFF
--- a/src/foam/nanos/crunch/InvalidateDependenciesIfPrerequisiteInvalidated.js
+++ b/src/foam/nanos/crunch/InvalidateDependenciesIfPrerequisiteInvalidated.js
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.nanos.crunch',
+  name: 'InvalidateDependenciesIfPrerequisiteInvalidated',
+
+  documentation: `When a ucj falls out of GRANTED status, also invalidate any ucjs
+    that depend on the first one.
+  `,
+
+  implements: [
+    'foam.nanos.ruler.RuleAction'
+  ],
+
+  javaImports: [
+    'foam.core.ContextAgent',
+    'foam.core.X',
+    'foam.dao.ArraySink',
+    'foam.dao.DAO',
+    'foam.mlang.predicate.AbstractPredicate',
+    'foam.nanos.auth.User',
+    'java.util.List',
+    'static foam.mlang.MLang.*'
+  ],
+
+  methods: [
+    {
+      name: 'applyAction',
+      javaCode: `
+        agency.submit(x, new ContextAgent() {
+          @Override
+          public void execute(X x) {
+            UserCapabilityJunction ucj = (UserCapabilityJunction) obj;
+            CapabilityJunctionStatus invalidatedStatus = ucj.getStatus();
+            
+            DAO userCapabilityJunctionDAO = (DAO) x.get("userCapabilityJunctionDAO");
+            DAO filteredUserCapabilityJunctionDAO = (DAO) userCapabilityJunctionDAO.where((EQ(UserCapabilityJunction.SOURCE_ID, ucj.getSourceId())));
+            DAO filteredPrerequisiteCapabilityJunctionDAO = (DAO) ((DAO) x.get("prerequisiteCapabilityJunctionDAO"))
+              .where(EQ(CapabilityCapabilityJunction.TARGET_ID, ucj.getTargetId()));
+            
+            AbstractPredicate predicate = new AbstractPredicate(x) {
+              @Override
+              public boolean f(Object obj) {
+                UserCapabilityJunction ucjToCheck = (UserCapabilityJunction) obj;
+                CapabilityCapabilityJunctionId id = new CapabilityCapabilityJunctionId.Builder(x)
+                  .setSourceId(ucjToCheck.getTargetId())
+                  .setTargetId(ucj.getTargetId())
+                  .build();
+                CapabilityCapabilityJunction prereqJunction = null;
+                try {
+                  prereqJunction = (CapabilityCapabilityJunction) filteredPrerequisiteCapabilityJunctionDAO.find(id);
+                } catch (Exception e) {
+                  return false;
+                }
+                return prereqJunction != null;
+              }
+            };
+
+            List<UserCapabilityJunction> ucjsToInvalidate = (List<UserCapabilityJunction>) ((ArraySink) filteredUserCapabilityJunctionDAO
+              .where(predicate)
+              .select(new ArraySink()))
+              .getArray();
+              
+            for ( UserCapabilityJunction invalidatedUcj : ucjsToInvalidate ) {
+              invalidatedUcj.setStatus(invalidatedStatus);
+              userCapabilityJunctionDAO.put(invalidatedUcj);
+            }
+          }
+        }, "Remove dependencies on prerequisite ucj removal");
+      `
+    }
+  ]
+});

--- a/src/foam/nanos/crunch/UserCapabilityJunctionDAO.js
+++ b/src/foam/nanos/crunch/UserCapabilityJunctionDAO.js
@@ -107,9 +107,9 @@ foam.CLASS({
 
         checkOwnership(x, ucJunction);
 
-        // if the junction is being updated from GRANTED to EXPIRED, put the updated ucj,
+        // if the junction is being updated from GRANTED to something else, put the updated ucj,
         // then try to reput the ucj as new ucj
-        if ( old != null && old.getStatus() == CapabilityJunctionStatus.GRANTED && ucJunction.getStatus() == CapabilityJunctionStatus.EXPIRED ) {
+        if ( old != null && old.getStatus() == CapabilityJunctionStatus.GRANTED && ucJunction.getStatus() != CapabilityJunctionStatus.GRANTED ) {
           getDelegate().put_(x, ucJunction);
           old = null;
         }
@@ -377,15 +377,13 @@ foam.CLASS({
     {
       name: 'remove_',
       javaCode: `
-        checkOwnership(x, (UserCapabilityJunction) obj);
-        return super.remove_(x, obj);
+        throw new UnsupportedOperationException("UserCapabilityJunctions should be disabled via status change.");
       `
     },
     {
       name: 'removeAll_',
       javaCode: `
-        DAO dao = getFilteredDAO(x);
-        dao.removeAll_(x, skip, limit, order, predicate);
+        throw new UnsupportedOperationException("UserCapabilityJunctions should be disabled via status change.");
       `
     },
     {

--- a/src/foam/nanos/crunch/rules.jrl
+++ b/src/foam/nanos/crunch/rules.jrl
@@ -1,6 +1,6 @@
 p({
   "class":"foam.nanos.ruler.Rule",
-  "id":"68afcf0c-c718-98f8-0841-75e97a3ad16d2",
+  "id":"68afcf0c-c718-98f8-0841-75e9-crunch0",
   "name":"Notify User On Top Level Capability Status Update",
   "priority":100,
   "ruleGroup":"crunch",
@@ -13,11 +13,10 @@ p({
   "predicate":{"class":"foam.nanos.crunch.IsUserCapabilityJunctionStatusUpdate"},
   "action":{"class":"foam.nanos.crunch.SendNotificationOnTopLevelCapabilityStatusUpdate"},
   "lifecycleState":1
-});
-
+})
 p({
   "class":"foam.nanos.ruler.Rule",
-  "id":"68afcf0c-c718-98f8-0841-75e97a3ad16d3",
+  "id":"68afcf0c-c718-98f8-0841-75e9-crunch1",
   "name":"Remove UserCapabilityJunctions on User Deletion",
   "priority":100,
   "ruleGroup":"crunch",
@@ -28,4 +27,41 @@ p({
   "saveHistory":false,
   "action":{"class":"foam.nanos.crunch.RemoveJunctionsOnUserRemoval"},
   "lifecycleState":1
-});
+})
+p({
+  "class":"foam.nanos.ruler.Rule",
+  "id":"68afcf0c-c718-98f8-0841-75e9-crunch2",
+  "name":"Invalidate Dependencies If Prerequisite Invalidated",
+  "priority":1000,
+  "ruleGroup":"crunch",
+  "documentation":"When a ucj falls out of GRANTED status, also invalidate any ucjs that depend on the first one.",
+  "daoKey":"userCapabilityJunctionDAO",
+  "operation":1,
+  "after":false,
+  "saveHistory":false,
+  "enabled":true,
+  "predicate":{
+    "class":"foam.mlang.predicate.And",
+    "args":[
+      {
+        "class":"foam.nanos.ruler.predicate.PropertyEQValue",
+        "propName":"status",
+        "propValue":{
+          "class":"foam.nanos.crunch.CapabilityJunctionStatus",
+          "ordinal":1
+        },
+        "isNew":false
+      },
+      {
+        "class":"foam.nanos.ruler.predicate.PropertyNEQValue",
+        "propName":"status",
+        "propValue":{
+          "class":"foam.nanos.crunch.CapabilityJunctionStatus",
+          "ordinal":1
+        }
+      }
+    ]
+  },
+  "action":{"class":"foam.nanos.crunch.InvalidateDependenciesIfPrerequisiteInvalidated"},
+  "lifecycleState":1
+})

--- a/src/foam/nanos/crunch/services.jrl
+++ b/src/foam/nanos/crunch/services.jrl
@@ -55,7 +55,7 @@ p({
   "description": "DAO responsible for storing capabilities' categories.",
   "serviceScript": """
     return new foam.dao.EasyDAO.Builder(x)
-      .setAuthorizer(new foam.nanos.auth.GlobalReadAuthorizer("prerequisiteCapabilityJunction"))
+      .setAuthorizer(new foam.nanos.auth.GlobalReadAuthorizer("capabilityCategoryCapabilityJunction"))
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
       .setJournalName("capabilityCategoryCapabilityJunction")
       .setOf(foam.nanos.crunch.CapabilityCategoryCapabilityJunction.getOwnClassInfo())

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -320,6 +320,7 @@ FOAM_FILES([
   { name: "foam/nanos/crunch/SendNotificationOnTopLevelCapabilityStatusUpdate" },
   { name: "foam/nanos/crunch/IsUserCapabilityJunctionStatusUpdate" },
   { name: "foam/nanos/crunch/RemoveJunctionsOnUserRemoval" },
+  { name: "foam/nanos/crunch/InvalidateDependenciesIfPrerequisiteInvalidated" },
 
   // approval
   { name: 'foam/nanos/approval/ApprovalRequest' },

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -583,6 +583,7 @@ var classes = [
   'foam.nanos.crunch.SendNotificationOnTopLevelCapabilityStatusUpdate',
   'foam.nanos.crunch.IsUserCapabilityJunctionStatusUpdate',
   'foam.nanos.crunch.RemoveJunctionsOnUserRemoval',
+  'foam.nanos.crunch.InvalidateDependenciesIfPrerequisiteInvalidated',
   //authservice
   'foam.nanos.auth.CapabilityAuthService',
   // userQueryService


### PR DESCRIPTION
- prevent removal of ucjs, instead they should be invalidated thru status change
- when a ucj with dependencies is invalidated, those dependencies also should be

rebased this to foam-framework:master - https://github.com/Nauna/foam2/pull/89