### PR TITLE
[NP-1473] Add theme glyphs and use for checkmark

### DIFF
--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -106,6 +106,7 @@ FOAM_FILES([
   { name: "foam/nanos/auth/UserQueryService" },
   { name: "foam/nanos/auth/SimpleUserQueryService" },
   { name: "foam/nanos/theme/Theme" },
+  { name: "foam/nanos/theme/ThemeGlyphs" },
   { name: "foam/nanos/theme/ThemeDomain" },
   { name: "foam/nanos/theme/ThemeDomainsDAO" },
   { name: "foam/nanos/theme/Themes" },

--- a/src/foam/nanos/theme/Theme.js
+++ b/src/foam/nanos/theme/Theme.js
@@ -23,6 +23,10 @@ foam.CLASS({
 //    'foam.nanos.auth.LastModifiedByAware'
   ],
 
+  requires: [
+    'foam.nanos.theme.ThemeGlyphs'
+  ],
+
   tableColumns: [
     'enabled',
     'name',
@@ -198,6 +202,18 @@ foam.CLASS({
       name: 'logoBackgroundColour',
       documentation: 'The logo background colour to display in the application.',
       section: 'images'
+    },
+    {
+      class: 'FObjectProperty',
+      of: 'foam.nanos.theme.ThemeGlyphs',
+      name: 'glyphs',
+      documentation: `
+        Glyphs are simple vectors which can be used as menu items
+        or indicators.
+      `.replace('\n',' ').trim(),
+      factory: function () {
+        return this.ThemeGlyphs.create();
+      }
     },
     {
       class: 'String',

--- a/src/foam/nanos/theme/ThemeGlyphs.js
+++ b/src/foam/nanos/theme/ThemeGlyphs.js
@@ -1,0 +1,74 @@
+foam.CLASS({
+  package: 'foam.nanos.theme',
+  name: 'Glyph',
+  documentation: `
+    A glyph is a vector that can be passed colour parameters
+  `,
+
+  properties: [
+    {
+      name: 'template',
+      class: 'String'
+    },
+    {
+      name: 'previewUrl',
+      class: 'Image',
+      expression: function (template) {
+        //
+      }
+    }
+  ],
+
+  methods: [
+    function expandSVG(values) {
+      var val = this.template;
+      for ( k in values ) if ( values.hasOwnProperty(k) ) {
+        let K = k.toUpperCase();
+        val = val.replace(
+          new RegExp('%' + K + '%(?!\\*/)', 'g'),
+          values[k]
+        );
+      }
+      return val;
+    },
+    function getDataUrl(values)  {
+      var svgText = this.expandSVG(values);
+      return 'data:image/svg+xml;base64,' +
+        btoa(svgText.replace(/\n/g, '').trim());
+    }
+  ]
+});
+
+foam.CLASS({
+  package: 'foam.nanos.theme',
+  name: 'ThemeGlyphs',
+
+  requires: [
+    'foam.nanos.theme.Glyph'
+  ],
+
+  properties: [
+    {
+      name: 'checkmark',
+      class: 'FObjectProperty',
+      of: 'foam.nanos.theme.Glyph',
+      factory: function () {
+        return this.Glyph.create({
+          template: `
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="40px" height="40px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="icon/complete/48x48" transform="translate(-4.000000, -4.000000)">
+            <g id="round-check_circle-24px">
+                <polygon id="Path" points="0 0 48 0 48 48 0 48"></polygon>
+                <path d="M18.58,32.58 L11.4,25.4 C10.62,24.62 10.62,23.36 11.4,22.58 C12.18,21.8 13.44,21.8 14.22,22.58 L20,28.34 L33.76,14.58 C34.54,13.8 35.8,13.8 36.58,14.58 C37.36,15.36 37.36,16.62 36.58,17.4 L21.4,32.58 C20.64,33.36 19.36,33.36 18.58,32.58 Z" id="Shape" fill="%FILL%" fill-rule="nonzero"></path>
+            </g>
+        </g>
+    </g>
+</svg>
+          `
+        });
+      }
+    }
+  ]
+});

--- a/src/foam/nanos/theme/ThemeGlyphs.js
+++ b/src/foam/nanos/theme/ThemeGlyphs.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 foam.CLASS({
   package: 'foam.nanos.theme',
   name: 'Glyph',

--- a/src/foam/u2/dialog/NotificationMessage.js
+++ b/src/foam/u2/dialog/NotificationMessage.js
@@ -25,6 +25,14 @@ foam.CLASS({
     feedback. Notification messages are only visible for a few seconds.
   `,
 
+  requires: [
+    'foam.u2.tag.CircleIndicator'
+  ],
+
+  imports: [
+    'theme'
+  ],
+
   css: `
     ^ {
       display: flex;
@@ -148,13 +156,26 @@ foam.CLASS({
     function initE() {
       var self = this;
 
-      var img;
+      var indicator;
       if ( this.type === 'error' ) {
-        img = 'images/round-error-red.svg';
+        indicator = {
+          size: 18,
+          icon: 'images/round-error-red.svg'
+        };
       } else if ( this.type === 'warning' ) {
-        img = 'images/baseline-warning-yellow.svg';
+        indicator = {
+          size: 18,
+          icon: 'images/baseline-warning-yellow.svg'
+        };
       } else {
-        img = 'images/round-check-circle-green.svg';
+        indicator = {
+          size: 18,
+          backgroundColor: this.theme.approval3,
+          borderColor: this.theme.approval3,
+          icon: this.theme.glyphs.checkmark.getDataUrl({
+            fill: this.theme.white
+          })
+        };
       }
       this
         .addClass(this.myClass())
@@ -166,9 +187,8 @@ foam.CLASS({
             .enableClass(this.myClass('warning-banner'), this.type === 'warning')
           .end()
           .start()
-            .start('img')
+            .start(this.CircleIndicator, indicator)
               .addClass(this.myClass('status-icon'))
-              .attrs({ src: img })
             .end()
             .start().addClass(this.myClass('content'))
               .enableClass(this.myClass('error-content'), this.type === 'error')

--- a/src/foam/u2/tag/CircleIndicator.js
+++ b/src/foam/u2/tag/CircleIndicator.js
@@ -22,13 +22,13 @@ foam.CLASS({
       border-radius: 50%;
       text-align: center;
       display: inline-block;
+      overflow: hidden;
     }
     ^ > img {
       position: absolute;
       top: 0;
-      bottom: 0;
+      left: 0;
       pointer-events: none;
-      z-index: -1;
     }
   `,
 

--- a/src/foam/u2/wizard/StepWizardletStepsView.js
+++ b/src/foam/u2/wizard/StepWizardletStepsView.js
@@ -62,19 +62,23 @@ foam.CLASS({
                 .addClass(self.myClass('item'))
 
                 // Render circle indicator
-                .start(this.CircleIndicator,
-                  isCurrent ? {
-                    ...baseCircleIndicator,
+                .start(this.CircleIndicator, {
+                  ...baseCircleIndicator,
+                  ...(isCurrent ? {
                     borderColor: this.theme.primary1
                   } : afterCurrent ? {
-                    ...baseCircleIndicator,
                     borderColor: this.theme.grey2,
+                  } : wizardlet.validate() ? {
+                    borderColor: this.theme.approval3,
+                    backgroundColor: this.theme.approval3,
+                    icon: this.theme.glyphs.checkmark.getDataUrl({
+                      fill: this.theme.white
+                    }),
+                    label: ''
                   } : {
-                    ...baseCircleIndicator,
-                    borderColor: wizardlet.validate()
-                      ? this.theme.approval2 : this.theme.warning2
-                  }
-                )
+                    borderColor: this.theme.warning2
+                  })
+                })
                   .addClass('circle')
                 .end()
 


### PR DESCRIPTION
This PR adds "glyphs" to themes, allowing re-use of the SVG icons in different situations.

Examples:
- if you want a white checkmark in a green circle, you can put a white checkmark glyph inside a CircleIndicator with the theme's `approval3` colour.
- if you want a green checkmark, you can use the checkmark glyph with the theme's `approval3` colour

```
        .tag(this.CircleIndicator, {
          size: 18,
          backgroundColor: this.theme.approval3,
          borderColor: this.theme.approval3,
          icon: this.theme.glyphs.checkmark.getDataUrl({
            fill: this.theme.white
          })
        });
```