### PR TITLE
[NP-1475] Un-oops the LiveScriptBundler

### DIFF
--- a/src/foam/nanos/http/LiveScriptBundler.java
+++ b/src/foam/nanos/http/LiveScriptBundler.java
@@ -100,7 +100,7 @@ public class LiveScriptBundler
         }
         try {
           // Since each directory has a watcher thread, 1/100ms is sufficiently frequent
-          Thread.sleep(100);
+          Thread.sleep(500);
         } catch (InterruptedException e) {
           return;
         }

--- a/src/foam/nanos/http/LiveScriptBundler.java
+++ b/src/foam/nanos/http/LiveScriptBundler.java
@@ -98,6 +98,12 @@ public class LiveScriptBundler
 
           if ( ! key.reset() ) break;
         }
+        try {
+          // Since each directory has a watcher thread, 1/100ms is sufficiently frequent
+          Thread.sleep(100);
+        } catch (InterruptedException e) {
+          return;
+        }
       }
     }
   }


### PR DESCRIPTION
I missed an important instruction for the `pollEvents` method in Java's file watcher api
> Note that this method does not wait if there are no events pending.

This PR fixes LiveScriptBusyloop by adding a sleep interval.