### PR TITLE
set short names to false in http box

### DIFF
--- a/src/foam/box/HTTPBox.js
+++ b/src/foam/box/HTTPBox.js
@@ -163,7 +163,7 @@ foam.CLASS({
     protected foam.lib.formatter.JSONFObjectFormatter initialValue() {
       foam.lib.formatter.JSONFObjectFormatter formatter = new foam.lib.formatter.JSONFObjectFormatter();
       formatter.setQuoteKeys(true);
-      formatter.setOutputShortNames(true);
+      formatter.setOutputShortNames(false);
       formatter.setPropertyPredicate(new foam.lib.AndPropertyPredicate(new foam.lib.PropertyPredicate[] {new foam.lib.NetworkPropertyPredicate(), new foam.lib.PermissionedPropertyPredicate()}));
       return formatter;
     }

--- a/src/foam/box/HTTPReplyBox.js
+++ b/src/foam/box/HTTPReplyBox.js
@@ -36,7 +36,7 @@ foam.CLASS({
     protected foam.lib.formatter.JSONFObjectFormatter initialValue() {
       foam.lib.formatter.JSONFObjectFormatter formatter = new foam.lib.formatter.JSONFObjectFormatter();
       formatter.setQuoteKeys(true);
-      formatter.setOutputShortNames(true);
+      formatter.setOutputShortNames(false);
       formatter.setPropertyPredicate(new foam.lib.AndPropertyPredicate(new foam.lib.PropertyPredicate[] {new foam.lib.NetworkPropertyPredicate(), new foam.lib.PermissionedPropertyPredicate()}));
       return formatter;
     }


### PR DESCRIPTION
Not sure how this was reverted but setting it back to false.