### PR TITLE
order prereqs & remove duplicate capabilities found

### DIFF
--- a/src/foam/nanos/crunch/services.jrl
+++ b/src/foam/nanos/crunch/services.jrl
@@ -107,6 +107,7 @@ p({
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
       .setJournalName("prerequisiteCapabilityJunctions")
       .setOf(foam.nanos.crunch.CapabilityCapabilityJunction.getOwnClassInfo())
+      .setOrder(new foam.core.PropertyInfo[] {foam.nanos.crunch.CapabilityCapabilityJunction.PRIORITY})
       .build();
   """,
   "client":"{\"of\":\"foam.nanos.crunch.CapabilityCapabilityJunction\", \"remoteListenerSupport\": false}"

--- a/src/foam/u2/crunch/CrunchController.js
+++ b/src/foam/u2/crunch/CrunchController.js
@@ -67,7 +67,7 @@ foam.CLASS({
       // Using Pre-Order here will cause the wizard to display
       // dependancies in a logical order.
       tcRecurse = (sourceId, seen) => {
-        seen = seen ? seen.map((pcj) => pcj.targetId) : [];
+        if ( ! seen ) seen = [];
         return this.prerequisiteCapabilityJunctionDAO.where(this.AND(
           this.EQ(this.CapabilityCapabilityJunction.SOURCE_ID, sourceId),
           this.NOT(this.IN(this.CapabilityCapabilityJunction.TARGET_ID, seen))
@@ -80,13 +80,13 @@ foam.CLASS({
           }
 
           return arry.reduce(
-            (p, pcj) => p.then(() => tcRecurse(pcj.targetId, arry)),
+            (p, pcj) => p.then(() => tcRecurse(pcj.targetId, seen.concat(arry.map((pcj) => pcj.targetId)))),
             Promise.resolve()
           ).then(() => tcList.push(sourceId));
         });
       };
 
-      return tcRecurse(capabilityId, []).then(() => tcList);
+      return tcRecurse(capabilityId, []).then(() => [...new Set(tcList)]);
     },
     function getCapabilities(capabilityId) {
       return this.getTC(capabilityId).then(

--- a/src/foam/u2/crunch/CrunchController.js
+++ b/src/foam/u2/crunch/CrunchController.js
@@ -84,7 +84,7 @@ foam.CLASS({
         });
       };
 
-      return tcRecurse(capabilityId).then(() => tcList);
+      return tcRecurse(capabilityId).then(() => [...new Set(tcList)]);
     },
     function getCapabilities(capabilityId) {
       return this.getTC(capabilityId).then(


### PR DESCRIPTION
preserve priority of prerequisites and filter out duplicates when generating list of prerequisite capabilities in crunchController