### PR TITLE
Handle zeros in division expression 

### DIFF
--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -3795,12 +3795,19 @@ foam.CLASS({
     {
       name: 'f',
       javaCode: `
-        var result = 0.0;
+        Double result = null;
         for ( int i = 0; i < getArgs().length; i++) {
           var current = getArgs()[i].f(obj);
           if ( current instanceof Number ) {
+            var oldResult = result;
             var value = ((Number) current).doubleValue();
-            result = result == 0.0 ? value : reduce(result, value);
+            result = result == null ? value : reduce(result, value);
+
+            if ( ! Double.isFinite(result) ) {
+              var formula = getClass().getSimpleName() + "(" + oldResult + ", " + value + ")";
+              throw new RuntimeException("Failed to evaluate formula:" +
+                formula + ", result:" + result);
+            }
           }
         }
         return result;


### PR DESCRIPTION
## Changes
- Throw on `DIV(non_zero, 0)` and `DIV(0, 0)`
- Fix `DIV(0, 1)` to returns 0

## Note
- Java doesn't throw when divided by 0.0 but instead returns Infinity, also 0.0 divide by non zero would return NaN.