### PR TITLE
[NP-1556] Fix 2fa bug

### DIFF
--- a/src/foam/nanos/auth/twofactor/GoogleTOTPAuthService.js
+++ b/src/foam/nanos/auth/twofactor/GoogleTOTPAuthService.js
@@ -131,7 +131,6 @@ foam.CLASS({
           // fetch user from DAO and set two factor secret to null
           user = (User) userDAO.find(user.getId()).fclone();
           user.setTwoFactorEnabled(false);
-          user.setTwoFactorSecret(null);
           userDAO.put_(x, user);
 
           return true;


### PR DESCRIPTION
addresses: https://nanopay.atlassian.net/projects/NP/issues/NP-1556

- Setting user's secret key to null causes an unexpected behaviour - if you disable 2fa on a user and rebuild the system, user's twoFactorEnabled is set to true making the user to authenticate via 2fa. In fact, we don't even need to clear user's secret key when disabling because new secret key that is generated when the user goes to personal settings overwrites user's old secret key.