### PR TITLE
[NP-1524] Add foam.String.applyFormat

### DIFF
--- a/src/foam/core/stdlib.js
+++ b/src/foam/core/stdlib.js
@@ -649,13 +649,13 @@ foam.LIB({
         return map[val] || (map[val] = val.toString());
       };
     })(),
-    function applyMask(string, mask, placeholder, escapeChar) {
+    function applyFormat(string, formatString, placeholder, escapeChar) {
       placeholder = placeholder || 'x';
       escapeChar = escapeChar || '\\';
       var newString = '';
       var escaping = false;
       var safe = true;
-      mask.split('').forEach(chr => {
+      formatString.split('').forEach(chr => {
         if ( escaping ) {
           newString += chr;
           escaping = false;

--- a/src/foam/core/stdlib.js
+++ b/src/foam/core/stdlib.js
@@ -661,11 +661,11 @@ foam.LIB({
           escaping = false;
           return;
         }
-        if ( chr == '\\' ) {
+        if ( chr == escapeChar ) {
           escaping = true;
           return;
         }
-        if ( chr == 'x' ) {
+        if ( chr == placeholder ) {
           if ( string.length < 1 ) {
             safe = false;
             return;

--- a/src/foam/core/stdlib.js
+++ b/src/foam/core/stdlib.js
@@ -649,6 +649,38 @@ foam.LIB({
         return map[val] || (map[val] = val.toString());
       };
     })(),
+    function applyMask(string, mask, placeholder, escapeChar) {
+      placeholder = placeholder || 'x';
+      escapeChar = escapeChar || '\\';
+      var newString = '';
+      var escaping = false;
+      var safe = true;
+      mask.split('').forEach(chr => {
+        if ( escaping ) {
+          newString += chr;
+          escaping = false;
+          return;
+        }
+        if ( chr == '\\' ) {
+          escaping = true;
+          return;
+        }
+        if ( chr == 'x' ) {
+          if ( string.length < 1 ) {
+            safe = false;
+            return;
+          }
+          newString += string[0];
+          string = string.slice(1);
+          return;
+        }
+        newString += chr;
+      })
+      safe = safe && string.length == 0;
+      if ( ! safe ) console.warn(
+        'performed foam.String.applyMask with unsafe inputs');
+      return newString;
+    }
   ]
 });
 


### PR DESCRIPTION
foam.String.applyMask formats a string based on some template.

For example, `foam.String.applyMask("20200623", "xxxx-xx-xx")` produces `2020-06-23`.

The placeholder and escape character may be specified, allowing such functionality as:
```
foam.String.applyMask("12345678", "dd-dd-dd!d-dd", 'd', '!'); // 12-34-56d-78
```

Default placeholder is `x`, and default escape character is `\`.