### PR TITLE
Add FragmentedTextField

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -463,6 +463,7 @@ FOAM_FILES([
   { name: "foam/u2/view/PreView", flags: ['web'] },
   { name: "foam/u2/view/TableCellFormatterReadView", flags: ['web'] },
   { name: "foam/u2/view/MultiBoxInputView", flags: ['web'] },
+  { name: "foam/u2/FragmentedTextField", flags: ['web'] },
   { name: "foam/u2/view/FObjectView", flags: ['web'] },
   { name: "foam/u2/view/CollapseableDetailView", flags: ['web'] },
   { name: "foam/u2/view/ReadReferenceView", flags: ['web'] },

--- a/src/foam/u2/FragmentedTextField.js
+++ b/src/foam/u2/FragmentedTextField.js
@@ -20,7 +20,6 @@ foam.CLASS({
       margin-left: -1px;
       margin-right: -1px;
       line-height: 100%;
-      z-index: -1;
 
       /* TODO: get from theme when available */
       padding-left: 8px;

--- a/src/foam/u2/FragmentedTextField.js
+++ b/src/foam/u2/FragmentedTextField.js
@@ -1,0 +1,75 @@
+foam.CLASS({
+  package: 'foam.u2',
+  name: 'FragmentedTextField',
+  extends: 'foam.u2.View',
+
+  requires: [
+    'foam.core.ArraySlot',
+  ],
+
+  css: `
+    ^ {
+      display: flex;
+      position: relative;
+    }
+    ^symbol {
+      display: flex;
+      align-items: center;
+      background: %GREY5%;
+      border: 1px solid %GREY3%;
+      margin-left: -1px;
+      margin-right: -1px;
+      line-height: 100%;
+      z-index: -1;
+
+      /* TODO: get from theme when available */
+      padding-left: 8px;
+      padding-right: 8px;
+    }
+    ^ > *:not(:first-child):not(:last-child) {
+      border-radius: 0 !important;
+    }
+    ^ > *:first-child {
+      border-top-right-radius: 0 !important;
+      border-bottom-right-radius: 0 !important;
+    }
+    ^ > *:last-child {
+      border-top-left-radius: 0 !important;
+      border-bottom-left-radius: 0 !important;
+    }
+  `,
+
+  properties: [
+    {
+      name: 'delegates',
+      class: 'Array'
+    },
+  ],
+
+  methods: [
+    function initE() {
+      return this
+        .addClass(this.myClass())
+        .createInnerFields()
+    },
+    function createInnerFields() {
+      var slots = [];
+      for ( let i = 0 ; i < this.delegates.length ; i++ ) {
+        let e = this.delegates[i];
+        if ( typeof e === 'string' ) {
+          this.start().addClass(this.myClass('symbol'))
+            .add(e).end();
+          continue;
+        }
+        var u2Elem = this.start(e)
+        slots.push(u2Elem.data$)
+      }
+
+      this.data$ = this.ArraySlot.create({ slots }).map(arr => {
+        return '' + arr.join('');
+      });
+
+      return this;
+    }
+  ]
+});

--- a/src/foam/u2/FragmentedTextField.js
+++ b/src/foam/u2/FragmentedTextField.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 foam.CLASS({
   package: 'foam.u2',
   name: 'FragmentedTextField',


### PR DESCRIPTION
A more user-friendly view that can be used instead of #3639, but less suitable for complex formatting situations.

This view works well when the formatting is statically delimited, such as what the applyFormat function from #3644 supports.

Here's an example:
<img width="564" alt="Screen Shot 2020-06-23 at 3 43 59 PM" src="https://user-images.githubusercontent.com/7225168/85453358-c6386680-b569-11ea-9a62-774a477076ab.png">
```
.tag(this.FragmentedTextField, {
  delegates: [
    {
      class: 'foam.u2.TextField',
      attributes: [ { name: 'maxlength', value: 2 } ]
    },
    '-',
    {
      class: 'foam.u2.TextField',
      attributes: [ { name: 'maxlength', value: 3 } ]
    },
    '-',
    {
      class: 'foam.u2.TextField',
      attributes: [ { name: 'maxlength', value: 3 } ]
    },
  ],
  data$: this.data$,
})
```