### PR TITLE
crunch controller refactor

### DIFF
--- a/src/foam/u2/crunch/CrunchController.js
+++ b/src/foam/u2/crunch/CrunchController.js
@@ -110,7 +110,7 @@ foam.CLASS({
           ]).then((capAndSections) => {
             return {
               caps: capAndSections[0],
-              wizSec: capAndSections[1]
+              wizCaps: capAndSections[1]
                 .filter(wizardSection =>
                   wizardSection.ucj === null ||
                   (
@@ -138,7 +138,7 @@ foam.CLASS({
           return ctrl.add(this.Popup.create({ closeable: false }).tag({
             class: 'foam.u2.wizard.StepWizardletView',
             data: foam.u2.wizard.StepWizardletController.create({
-              wizardlets: capabilitiesSections.wizSec
+              wizardlets: capabilitiesSections.wizCaps
             }),
             onClose: (x) => {
               this.finalOnClose(x, capabilitiesSections.caps);

--- a/src/foam/u2/crunch/CrunchController.js
+++ b/src/foam/u2/crunch/CrunchController.js
@@ -31,9 +31,10 @@ foam.CLASS({
     'foam.nanos.crunch.ui.CapabilityWizardlet',
     'foam.u2.borders.MarginBorder',
     'foam.u2.crunch.CapabilityInterceptView',
+    'foam.u2.detail.AbstractSectionedDetailView',
     'foam.u2.dialog.Popup'
   ],
-  
+
   messages: [
     { name: 'CANNOT_OPEN_GRANTED', message: 'This capability has already been granted to you.' },
     { name: 'CANNOT_OPEN_PENDING', message: 'This capability is awaiting approval, updates are not permitted at this time.' }
@@ -61,8 +62,7 @@ foam.CLASS({
   methods: [
     function getTC(capabilityId) {
       var tcList = [];
-      var tcRecurse = () => {}; // and we'll do it with this
-
+      var tcRecurse = () => {};
       // Pre-Order Traversial of Capability Dependancies.
       // Using Pre-Order here will cause the wizard to display
       // dependancies in a logical order.
@@ -88,89 +88,110 @@ foam.CLASS({
 
       return tcRecurse(capabilityId, []).then(() => [...new Set(tcList)]);
     },
-    function getCapabilities(capabilityId) {
-      return this.getTC(capabilityId).then(
-        tcList => Promise.all(tcList.map(
-          capId => this.capabilityDAO.find(capId))));
-    },
-    async function launchWizard(capabilityId) {
-      var self = this;
 
+    function getCapabilities(capabilityId) {
+      return Promise.resolve(
+        this.getTC(capabilityId).then(
+          tcList => Promise.all(tcList.map(
+            capId => this.capabilityDAO.find(capId))
+          )
+        ));
+    },
+
+    function getCapsAndWizardlets(capabilityId) {
+      return this.getCapabilities(capabilityId).then( (capabilities) => {
+        return Promise.all([
+          Promise.resolve(capabilities),
+          Promise.all(capabilities
+            .filter(cap => !! cap.of )
+            .map(cap =>
+              this.CapabilityWizardlet.create({ capability: cap }).updateUCJ())
+            )
+          ]).then((capAndSections) => {
+            return {
+              caps: capAndSections[0],
+              wizSec: capAndSections[1]
+                .filter(wizardSection =>
+                  wizardSection.ucj === null ||
+                  (
+                    ! foam.util.equals(wizardSection.ucj.status,
+                      this.CapabilityJunctionStatus.GRANTED ) &&
+                    ! foam.util.equals(wizardSection.ucj.status,
+                      this.CapabilityJunctionStatus.PENDING )
+                  )
+                )
+            };
+          });
+      });
+    },
+
+    function generateSections(generatedWizardlets) {
+      // return Promise.resolve(
+      return Promise.all([
+          generatedWizardlets.map((wizardlet) => {
+            this.AbstractSectionedDetailView.create({
+              of: wizardlet.of,
+            }).sections;
+          })
+        ]);
+      // );
+    },
+
+    function callWizard(capabilityId) {
+      return this.getCapsAndWizardlets(capabilityId)
+        .then((capabilitiesSections) => {
+          return ctrl.add(this.Popup.create({ closeable: false }).tag({
+            class: 'foam.u2.wizard.StepWizardletView',
+            data: foam.u2.wizard.StepWizardletController.create({
+              wizardlets: capabilitiesSections.wizSec
+            }),
+            onClose: (x) => {
+              this.finalOnClose(x, capabilitiesSections.caps);
+            }
+          }));
+        });
+    },
+
+    function finalOnClose(x, capabilities) {
+      return new Promise((wizardResolve) => {
+        x.closeDialog();
+        // Save no-data capabilities (i.e. not displayed in wizard)
+        Promise.all(capabilities.filter(cap => ! cap.of).map(
+          cap => this.userCapabilityJunctionDAO.put(this.UserCapabilityJunction.create({
+            sourceId: this.subject.user.id,
+            targetId: cap.id
+          })).then(() => {
+            console.log('SAVED (no-data cap)', cap.id);
+          })
+        )).then(() => {
+          wizardResolve();
+        });
+      });
+    },
+
+    async function launchWizard(capabilityId) {
       var ucj = await this.userCapabilityJunctionDAO.find(
         this.AND(
           this.EQ(this.UserCapabilityJunction.SOURCE_ID, this.subject.user.id),
           this.EQ(this.UserCapabilityJunction.TARGET_ID, capabilityId)
         ));
-
       if ( ucj ) {
-        var statusGranted = foam.util.equals(ucj.status, self.CapabilityJunctionStatus.GRANTED);
-        var statusPending = foam.util.equals(ucj.status, self.CapabilityJunctionStatus.PENDING);
+        var statusGranted = foam.util.equals(ucj.status, this.CapabilityJunctionStatus.GRANTED);
+        var statusPending = foam.util.equals(ucj.status, this.CapabilityJunctionStatus.PENDING);
         if ( statusGranted || statusPending ) {
           var message = statusGranted ? this.CANNOT_OPEN_GRANTED : this.CANNOT_OPEN_PENDING;
-          self.ctrl.notify(message);
+          this.ctrl.notify(message);
           return;
-        } 
+        }
       }
-      return this.getCapabilities(capabilityId).then(capabilities => {
-        // Map capabilities to CapabilityWizardSection objects
-        return Promise.all([
-
-          // Continue passing capabilities to next callback
-          Promise.resolve(capabilities),
-
-          // Create capability sections
-          Promise.all(capabilities.filter(
-            cap => !! cap.of
-          ).map(
-            cap => this.CapabilityWizardlet.create({
-              capability: cap
-            }).updateUCJ()
-          ))
-
-        ]);
-      }).then(capabilitiesSectionsTuple => {
-        // Two values from Promise.all call above
-        let capabilities = capabilitiesSectionsTuple[0];
-        let sections = capabilitiesSectionsTuple[1];
-
-        return new Promise((wizardResolve) => {
-          sections = sections.filter(wizardSection =>
-            wizardSection.ucj === null || 
-            ( 
-              ! foam.util.equals(wizardSection.ucj.status, self.CapabilityJunctionStatus.GRANTED ) &&
-              ! foam.util.equals(wizardSection.ucj.status, self.CapabilityJunctionStatus.PENDING ) 
-            )
-          );
-          ctrl.add(this.Popup.create({ closeable: false }).tag({
-            class: 'foam.u2.wizard.StepWizardletView',
-            data: foam.u2.wizard.StepWizardletController.create({
-              wizardlets: sections
-            }),
-            onClose: x => {
-              x.closeDialog();
-              // Save no-data capabilities (i.e. not displayed in wizard)
-              Promise.all(capabilities.filter(cap => ! cap.of).map(
-                cap => self.userCapabilityJunctionDAO.put(self.UserCapabilityJunction.create({
-                  sourceId: self.subject.user.id,
-                  targetId: cap.id
-                })).then(() => {
-                  console.log('SAVED (no-data cap)', cap.id);
-                })
-              )).then(() => {
-                wizardResolve();
-              });
-            }
-          }));
-        });
-      }).catch(e => { console.log(e); });
-
+      return this.callWizard(capabilityId);
     },
+
     function maybeLaunchInterceptView(intercept) {
       // Clear stale intercepts (ones which have been closed already)
-      this.activeIntercepts = this.activeIntercepts.filter(ic => {
+      this.activeIntercepts = this.activeIntercepts.filter((ic) => {
         return ( ! ic.aquired ) && ( ! ic.cancelled );
       });
-
       // Try to find a matching intercept view that's already opened.
       // NP-1426 explains this is greater detail.
       for ( let i = 0 ; i < this.activeIntercepts.length ; i++ ) {
@@ -179,19 +200,17 @@ foam.CLASS({
 
         // All options in the active intercept need to satisfy the
         // incoming intercept for this to be a match.
-        activeIntercept.capabilityOptions.forEach(capOpt => {
+        activeIntercept.capabilityOptions.forEach((capOpt) => {
           if ( ! intercept.capabilityOptions.includes(capOpt) ) {
             hasAllOptions = false;
           }
-        })
+        });
         if ( hasAllOptions ) {
           return activeIntercept.promise;
         }
       }
-
       // Register intercept for later occurances of the check above
       this.activeIntercepts.push(intercept);
-
       // Pop up the popup
       var self = this;
       self.ctrl.add(self.Popup.create({ closeable: false })
@@ -201,7 +220,6 @@ foam.CLASS({
           })
         .end()
       );
-
       return intercept.promise;
     }
   ]

--- a/src/foam/u2/crunch/CrunchController.js
+++ b/src/foam/u2/crunch/CrunchController.js
@@ -126,15 +126,10 @@ foam.CLASS({
     },
 
     function generateSections(generatedWizardlets) {
-      // return Promise.resolve(
-      return Promise.all([
-          generatedWizardlets.map((wizardlet) => {
-            this.AbstractSectionedDetailView.create({
-              of: wizardlet.of,
-            }).sections;
-          })
-        ]);
-      // );
+      return generatedWizardlets.map(wizardlet =>
+        this.AbstractSectionedDetailView.create({
+          of: wizardlet.of,
+        }).sections);
     },
 
     function callWizard(capabilityId) {

--- a/src/foam/u2/crunch/CrunchController.js
+++ b/src/foam/u2/crunch/CrunchController.js
@@ -169,7 +169,7 @@ foam.CLASS({
           this.EQ(this.UserCapabilityJunction.TARGET_ID, capabilityId)
         ));
       if ( ucj ) {
-        var statusGranted = foam.util.equals(ucj.status, this.CapabilityJunctionStatus.GRANTED);
+        var statusGranted = ucj.status === this.CapabilityJunctionStatus.GRANTED;
         var statusPending = foam.util.equals(ucj.status, this.CapabilityJunctionStatus.PENDING);
         if ( statusGranted || statusPending ) {
           var message = statusGranted ? this.CANNOT_OPEN_GRANTED : this.CANNOT_OPEN_PENDING;

--- a/src/foam/u2/crunch/CrunchController.js
+++ b/src/foam/u2/crunch/CrunchController.js
@@ -111,13 +111,11 @@ foam.CLASS({
             return {
               caps: capAndSections[0],
               wizCaps: capAndSections[1]
-                .filter(wizardSection =>
+                .filter((wizardSection) =>
                   wizardSection.ucj === null ||
                   (
-                    ! foam.util.equals(wizardSection.ucj.status,
-                      this.CapabilityJunctionStatus.GRANTED ) &&
-                    ! foam.util.equals(wizardSection.ucj.status,
-                      this.CapabilityJunctionStatus.PENDING )
+                    ! wizardSection.ucj.status === this.CapabilityJunctionStatus.GRANTED &&
+                    ! wizardSection.ucj.status === this.CapabilityJunctionStatus.PENDING
                   )
                 )
             };
@@ -128,7 +126,7 @@ foam.CLASS({
     function generateSections(generatedWizardlets) {
       return generatedWizardlets.map(wizardlet =>
         this.AbstractSectionedDetailView.create({
-          of: wizardlet.of,
+          of: wizardlet.of
         }).sections);
     },
 


### PR DESCRIPTION
Now we can use the crunch controller to build the sections, wizardlets and closing logic outside of a wizard.

This will be necessary for: https://nanopay.atlassian.net/browse/NP-1481

### The calls to use will be something like:
var objWithCapsAndWizardlet = this.crunchController.getCapsAndWizardlets(capabilityId);
var usableForViewSections = this.crunchController.generateSections(objWithCapsAndWizardlet.wizCaps);
// to save 
-1 this.crunchController.finalOnClose(x, objWithCapsAndWizardlet.caps)
-2 forEach(objWithCapsAndWizardlet.wizSec, function(wizardlet) { wizardlet.save(); }