### PR TITLE
bug fix: to open action pending capabilities

### DIFF
--- a/src/foam/u2/crunch/CrunchController.js
+++ b/src/foam/u2/crunch/CrunchController.js
@@ -115,10 +115,9 @@ foam.CLASS({
                 .filter((wizardSection) =>
                   wizardSection.ucj === null ||
                   (
-                    ! wizardSection.ucj.status === this.CapabilityJunctionStatus.GRANTED &&
-                    ! wizardSection.ucj.status === this.CapabilityJunctionStatus.PENDING
-                  )
-                )
+                    wizardSection.ucj.status != this.CapabilityJunctionStatus.GRANTED &&
+                    wizardSection.ucj.status != this.CapabilityJunctionStatus.PENDING
+                  ))
             };
           });
       });


### PR DESCRIPTION
capabilities in capability store that had been started get converted to action pending status. The logic was returning an empty array, that would then cause error in stepWizardletController line 137.

Need to still review logic - since stepWizardletController assumes wizard has at least one wizardlet with at least one section. Don't think it should. 

However since plans are to make crunchController a service to access via DIG, logic review will be offset to undertaking of that task.