### PR TITLE
Add DAOWizardlet

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -792,6 +792,7 @@ FOAM_FILES([
   { name: "foam/u2/wizard/StepWizardletStepsView" },
   { name: "foam/u2/wizard/StepWizardletView" },
   { name: "foam/u2/wizard/ScrollWizardletView" },
+  { name: "foam/u2/wizard/DAOWizardlet" },
   { name: "foam/nanos/crunch/ui/CapabilityWizardlet" },
 
   { name: "foam/graphics/ZoomMapView" },

--- a/src/foam/u2/wizard/DAOWizardlet.js
+++ b/src/foam/u2/wizard/DAOWizardlet.js
@@ -1,0 +1,43 @@
+foam.CLASS({
+  package: 'foam.u2.wizard',
+  name: 'DAOWizardlet',
+  extends: 'foam.u2.wizard.BaseWizardlet',
+
+  properties: [
+    {
+      name: 'of',
+      class: 'Class'
+    },
+    {
+      name: 'data',
+      class: 'FObjectProperty',
+      of: 'foam.core.FObject',
+      factory: function () {
+        return this.of.create({}, this.__context__);
+      }
+    },
+    {
+      name: 'daoKey',
+      class: 'String',
+      expression: function (of) {
+        return foam.String.daoize(of.name);
+      }
+    },
+    {
+      name: 'dao',
+      class: 'foam.dao.DAOProperty',
+      expression: function (daoKey) {
+        return this.__context__[daoKey];
+      }
+    }
+  ],
+
+  methods: [
+    {
+      name: 'save',
+      code: function () {
+        return this.dao.put(this.data);
+      }
+    }
+  ]
+});

--- a/src/foam/u2/wizard/DAOWizardlet.js
+++ b/src/foam/u2/wizard/DAOWizardlet.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 foam.CLASS({
   package: 'foam.u2.wizard',
   name: 'DAOWizardlet',


### PR DESCRIPTION
This PR adds a wizardlet which puts its data into the corresponding DAO (or one specified by a `daoKey`).

The following example, which can be run in the Javascript console, creates a wizard for adding Cron jobs:

```
ctrl.add(foam.u2.dialog.Popup.create({ closeable: false }, ctrl.__subContext__).tag({
  class: 'foam.u2.wizard.StepWizardletView',
  data: foam.u2.wizard.StepWizardletController.create({
    wizardlets: [ foam.u2.wizard.DAOWizardlet.create({
      title: 'Cron Wizard',
      of: 'foam.nanos.cron.Cron',
    }, ctrl.__subContext__) ]
  }),
  onClose: (x) => {
    x.closeDialog();
  }
}));
```

(note that `ctrl.__subContext__` arguments are only needed if you run this from the javascript console; in a regular view it should work as expected without those)