### PR TITLE
set gracedaysleft on granted instead of using javafactory

### DIFF
--- a/src/foam/nanos/crunch/UserCapabilityJunctionDAO.js
+++ b/src/foam/nanos/crunch/UserCapabilityJunctionDAO.js
@@ -268,6 +268,11 @@ foam.CLASS({
           }
         }
         obj.setExpiry(junctionExpiry);
+
+        if ( capability.getGracePeriod() > 0 ) {
+          obj.setGraceDaysLeft(capability.getGracePeriod());
+        }
+
         return obj;
       `
     },

--- a/src/foam/nanos/crunch/UserCapabilityJunctionRefine.js
+++ b/src/foam/nanos/crunch/UserCapabilityJunctionRefine.js
@@ -44,9 +44,7 @@ foam.CLASS({
       class: 'Int',
       documentation: `
       Number of days left that a user can use the Capability in this ucj after it goes into GRACE_PERIOD status.
-      `,
-      javaFactory: `
-        return ((Capability) findTargetId(getX())).getGracePeriod();
+      Set when the ucj is first granted.
       `
     }
   ]


### PR DESCRIPTION
fix failing liquid tests because of UserCapabilityJunction.graceDaysLeft javaFactory throws error. 
Instead of setting the prop using javaFactory, set it when the junction is granted.