### PR TITLE
[NP-1712] Update step wizardlet controller

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -802,6 +802,7 @@ FOAM_FILES([
   { name: "foam/u2/wizard/Wizardlet" },
   { name: "foam/u2/wizard/BaseWizardlet" },
   { name: "foam/u2/wizard/WizardletView" },
+  { name: "foam/u2/wizard/StepWizardConfig" },
   { name: "foam/u2/wizard/StepWizardletController" },
   { name: "foam/u2/wizard/StepWizardletStepsView" },
   { name: "foam/u2/wizard/StepWizardletView" },

--- a/src/files.js
+++ b/src/files.js
@@ -798,6 +798,7 @@ FOAM_FILES([
   // Multiple model - crunch - wizard files
   { name: "foam/u2/dialog/SimpleActionDialog" },
   { name: "foam/u2/tag/CircleIndicator" },
+  { name: "foam/u2/wizard/WizardPosition" },
   { name: "foam/u2/wizard/Wizardlet" },
   { name: "foam/u2/wizard/BaseWizardlet" },
   { name: "foam/u2/wizard/WizardletView" },

--- a/src/foam/u2/wizard/BaseWizardlet.js
+++ b/src/foam/u2/wizard/BaseWizardlet.js
@@ -23,7 +23,7 @@ foam.CLASS({
       expression: function (mustBeValid, of, data, data$errors_) {
         if ( ! mustBeValid ) return true;
         if ( ! this.of ) return true;
-        if ( ! this.data || this.data.errors_ ) return false;
+        if ( ( ! data ) || data$errors_ ) return false;
         return true;
       }
     }

--- a/src/foam/u2/wizard/BaseWizardlet.js
+++ b/src/foam/u2/wizard/BaseWizardlet.js
@@ -16,19 +16,22 @@ foam.CLASS({
     {
       name: 'mustBeValid',
       class: 'Boolean'
+    },
+    {
+      name: 'isValid',
+      class: 'Boolean',
+      expression: function (mustBeValid, of, data, data$errors_) {
+        if ( ! mustBeValid ) return true;
+        if ( ! this.of ) return true;
+        if ( ! this.data || this.data.errors_ ) return false;
+        return true;
+      }
     }
   ],
 
   methods: [
     function validate() {
-      /* breaks everything; not sure why
-      var valid = this.SUPER();
-      if ( ! valid ) return false;
-      */
-      if ( ! this.mustBeValid ) return true;
-      if ( ! this.of ) return true;
-      if ( ! this.data || this.data.errors_ ) return false;
-      return true;
+      return this.isValid;
     }
   ]
 });

--- a/src/foam/u2/wizard/StepWizardConfig.js
+++ b/src/foam/u2/wizard/StepWizardConfig.js
@@ -1,0 +1,17 @@
+foam.CLASS({
+  package: 'foam.u2.wizard',
+  name: 'StepWizardConfig',
+
+  properties: [
+    {
+      name: 'allowSkipping',
+      class: 'Boolean',
+      value: true
+    },
+    {
+      name: 'allowBacktracking',
+      class: 'Boolean',
+      value: true
+    }
+  ],
+})

--- a/src/foam/u2/wizard/StepWizardConfig.js
+++ b/src/foam/u2/wizard/StepWizardConfig.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 foam.CLASS({
   package: 'foam.u2.wizard',
   name: 'StepWizardConfig',

--- a/src/foam/u2/wizard/StepWizardletController.js
+++ b/src/foam/u2/wizard/StepWizardletController.js
@@ -81,15 +81,34 @@ foam.CLASS({
             this.wizardlets[w].data$
           )
         ));
-        var flatSlots = availableSlots.reduce((lis, v) => [...lis, ...v]);
-        flatSlots.forEach(s => {
-          s.sub(() => {
-            s.get();
-            this.sectionAvailableSlots = this.sectionAvailableSlots;
-            let name = 'sectionAvailableSlots';
-            this.propertyChange.pub(name, this.slot(name));
-          });
-        })
+        availableSlots.forEach((sections, wizardletIndex) => {
+          sections.forEach((availableSlot, sectionIndex) => {
+            availableSlot.sub(() => {
+              var val = availableSlot.get();
+              this.sectionAvailableSlots = this.sectionAvailableSlots;
+              let name = 'sectionAvailableSlots';
+              this.propertyChange.pub(name, this.slot(name));
+
+              if ( val ) {
+                // If this is a previous position, move the wizard back
+                var maybeNewPos = this.WizardPosition.create({
+                  wizardletIndex: wizardletIndex,
+                  sectionIndex: sectionIndex,
+                });
+                if ( maybeNewPos.compareTo(this.wizardPosition) < 0 ) {
+                  this.wizardPosition = maybeNewPos;
+                }
+              }
+
+              // Invoke a wizard position update (even if position didn't change)
+              // to re-render steps
+              this.wizardPosition = this.WizardPosition.create({
+                wizardletIndex: this.wizardPosition.wizardletIndex,
+                sectionIndex: this.wizardPosition.sectionIndex
+              });
+            });
+          })
+        });
         return availableSlots;
       }
     },

--- a/src/foam/u2/wizard/StepWizardletController.js
+++ b/src/foam/u2/wizard/StepWizardletController.js
@@ -9,6 +9,7 @@ foam.CLASS({
   name: 'StepWizardletController',
 
   requires: [
+    'foam.core.ArraySlot',
     'foam.u2.detail.AbstractSectionedDetailView',
     'foam.u2.detail.VerticalDetailView',
     'foam.u2.stack.Stack',
@@ -66,11 +67,21 @@ foam.CLASS({
         Array format is similar to sections.
       `,
       expression: function(sections) {
-        return [...sections.keys()].map(w => sections[w].map(
+        var availableSlots = [...sections.keys()].map(w => sections[w].map(
           section => section.createIsAvailableFor(
             this.wizardlets[w].data$
           )
         ));
+        var flatSlots = availableSlots.reduce((lis, v) => [...lis, ...v]);
+        flatSlots.forEach(s => {
+          s.sub(() => {
+            s.get();
+            this.sectionAvailableSlots = this.sectionAvailableSlots;
+            let name = 'sectionAvailableSlots';
+            this.propertyChange.pub(name, this.slot(name));
+          });
+        })
+        return availableSlots;
       }
     },
     {

--- a/src/foam/u2/wizard/StepWizardletController.js
+++ b/src/foam/u2/wizard/StepWizardletController.js
@@ -218,9 +218,8 @@ foam.CLASS({
     {
       name: 'canGoNext',
       class: 'Boolean',
-      expression: function (currentWizardlet) {
-        // TODO: merge change of validation
-        return true;
+      expression: function (currentWizardlet$isValid) {
+        return currentWizardlet$isValid;
       }
     }
   ],

--- a/src/foam/u2/wizard/StepWizardletController.js
+++ b/src/foam/u2/wizard/StepWizardletController.js
@@ -137,9 +137,7 @@ foam.CLASS({
           });
         }
 
-        let current = wizardPosition;
-
-        for ( let p = decr(wizardPosition) ; p != null ; p = decr(current) ) {
+        for ( let p = decr(wizardPosition) ; p != null ; p = decr(p) ) {
           console.log('prev p', p);
           if ( sectionAvailableSlots[p.wizardletIndex][p.sectionIndex].get() ) {
             return p;
@@ -170,8 +168,6 @@ foam.CLASS({
             sectionIndex: subSi,
           });
         }
-
-        let current = wizardPosition;
 
         for ( let p = incr(wizardPosition) ; p != null ; p = incr(p) ) {
           console.log('next p', p);

--- a/src/foam/u2/wizard/StepWizardletController.js
+++ b/src/foam/u2/wizard/StepWizardletController.js
@@ -204,28 +204,6 @@ foam.CLASS({
   methods: [
     function init() {
       console.log('StepWizardletController', this);
-      // this.stackContext = this.__subContext__.createSubContext();
-      // this.stackContext.register(
-      //   this.VerticalDetailView,
-      //   'foam.u2.detail.SectionedDetailView'
-      // );
-      // this.subStack.push({
-      //   class: 'foam.u2.detail.SectionView',
-      //   // Note: assumes wizard has at least one wizardlet with at least one section.
-      //   section: this.sections[0][0],
-      //   data$: this.wizardlets[0].data$,
-      // });
-
-      // // If the first screen has no available sections, move next and repeat.
-      // var skipEmptyWizardlets;
-      // skipEmptyWizardlets = () => {
-      //   var currentWizardletIndex =
-      //     this.screenIndexToSection(this.subStack.pos)[0];
-      //   if ( this.countAvailableSections(currentWizardletIndex) < 1 ) {
-      //     return this.next().then(skipEmptyWizardlets);
-      //   }
-      // };
-      // skipEmptyWizardlets();
     },
     function saveProgress() {
       var p = Promise.resolve();
@@ -248,68 +226,18 @@ foam.CLASS({
         }
 
         // number of unsaved wizardlets
-        let N = this.wizardPosition.wizardletIndex - nextScreen.wizardletIndex;
+        let N = nextScreen.wizardletIndex - this.wizardPosition.wizardletIndex;
         // starting index of unsaved wizardlets
         let S = this.wizardPosition.wizardletIndex;
 
         // Save wizardlets
         return [...Array(N).keys()].map(v => S + v)
           .reduce(
-            (i, p) => p.then(() => this.wizardlets[i].save()),
+            (p, i) => p.then(() => this.wizardlets[i].save()),
             Promise.resolve()
           ).then(() => {
             this.wizardPosition = nextScreen;
           });
-
-        // if ( this.isLastWizardlet ) {
-        //   return this.currentWizardlet.save().then(() => true);
-        // }
-
-        // HERE
-        let previousScreenIndex = this.subStack.pos;
-        let screenIndex = this.subStack.pos + 1;
-
-        // Get wizardlet and section indices
-        let sectionIndices = this.screenIndexToSection(screenIndex);
-        let wizardletIndex = sectionIndices[0];
-        let sectionIndex = sectionIndices[1];
-
-        let p = Promise.resolve();
-        if ( this.screenIndexToSection(previousScreenIndex)[0] !== wizardletIndex ) {
-          p = this.currentWizardlet.save();
-        }
-        return p.then(() => {
-          // Get overall index of screen (this is related to subStack position)
-          let screenIndex = this.subStack.pos + 1;
-
-          // Get wizardlet and section indices
-          let sectionIndices = this.screenIndexToSection(screenIndex);
-          let wizardletIndex = sectionIndices[0];
-          let sectionIndex = sectionIndices[1];
-
-          // Section and wizardlet can be obtained with above indices
-          let section = this.sections[wizardletIndex][sectionIndex];
-          let wizardlet = this.wizardlets[wizardletIndex];
-
-          // Set the highestIndex, this way if the user hits back and then save
-          // it will still save all the wizardlets they visited.
-          this.highestIndex = wizardletIndex;
-          this.subStack.push({
-            class: 'foam.u2.detail.SectionView',
-            section: section,
-            data$: wizardlet.data$,
-          })
-
-          // Automatically push the next section if this one is
-          // unavailable.
-          let slot = this.sectionAvailableSlots[wizardletIndex][sectionIndex];
-          if ( ! slot.get() ) {
-            return this.next();
-          }
-
-          // Return false for "not finished"
-          return false;
-        });
       },
     },
     function countAvailableSections(wizardletIndex) {
@@ -320,63 +248,18 @@ foam.CLASS({
       );
     },
     function canSkipTo(pos) {
-      // let currentWizardletIndex =
-      //   this.screenIndexToSection(this.subStack.pos)[0];
-      // for ( let w = currentWizardletIndex ; w <= wizardletIndex ; w++ ) {
-      //   if ( ! this.wizardlets[w].validate() ) return false;
-      // }
+      // TODO: add override
       return true;
     },
     function skipTo(pos) {
+      // TODO: add ucj save logic
       this.wizardPosition = pos;
-      // var skipToScreenRecur;
-      // skipToScreenRecur = () => {
-      //   if ( this.subStack.pos !== screenIndex ) {
-      //     return this.next().then(skipToScreenRecur);
-      //   }
-      // };
-      // return skipToScreenRecur(); // call recursive function
     },
     function back() {
       let previousScreen = this.previousScreen;
       if ( previousScreen !== null ) {
         this.wizardPosition = previousScreen;
       }
-
-      // // Call back again if this section is unavailable
-      // let sectionIndices = this.screenIndexToSection(this.subStack.pos);
-      // let wizardletIndex = sectionIndices[0];
-      // let sectionIndex = sectionIndices[1];
-      // let slot = this.sectionAvailableSlots[wizardletIndex][sectionIndex];
-      // if ( ! slot.get() ) {
-      //   return this.back();
-      // }
-    },
-    // Returns a tuple of two indices, 0: index corresponding to the wizardlet;
-    // and 1: index corresponding to the section under that wizardlet.
-    // This is used to locate the next section to display based on the stack
-    // position.
-    function screenIndexToSection(screenIndex) {
-      let i = 0;
-      for ( let w = 0 ; w < this.wizardlets.length ; w++ ) {
-        let nSections = this.sections[w].length;
-        if ( screenIndex >= i && i + nSections > screenIndex ) {
-          return [w, screenIndex - i]
-        }
-        i += nSections;
-      }
-      throw new Error(
-        `Tried to get wizard screen at index ${i} but it doesn't exist`
-      );
-    },
-
-    function sectionToScreenIndex(wizardletIndex, sectionIndex) {
-      let screenIndex = 0;
-      for ( let w = 0 ; w < wizardletIndex ; w++ ) {
-        screenIndex += this.sections[w].length;
-      }
-      screenIndex += sectionIndex;
-      return screenIndex;
     }
   ]
 });

--- a/src/foam/u2/wizard/StepWizardletController.js
+++ b/src/foam/u2/wizard/StepWizardletController.js
@@ -13,13 +13,22 @@ foam.CLASS({
     'foam.u2.detail.AbstractSectionedDetailView',
     'foam.u2.detail.VerticalDetailView',
     'foam.u2.stack.Stack',
-    'foam.u2.wizard.WizardPosition'
+    'foam.u2.wizard.WizardPosition',
+    'foam.u2.wizard.StepWizardConfig'
   ],
 
   properties: [
     {
       class: 'String',
       name: 'title'
+    },
+    {
+      name: 'config',
+      class: 'FObjectProperty',
+      of: 'foam.u2.wizard.StepWizardConfig',
+      factory: function () {
+        return this.StepWizardConfig.create();
+      }
     },
     {
       name: 'wizardlets',
@@ -248,8 +257,14 @@ foam.CLASS({
       );
     },
     function canSkipTo(pos) {
-      // TODO: add override
-      return true;
+      let diff = pos.compareTo(this.wizardPosition);
+      return ( diff == 0
+        ? true
+        : ( diff > 0
+          ? this.canGoNext && this.config.allowSkipping
+          : this.canGoBack && this.config.allowBacktracking
+        )
+      );
     },
     function skipTo(pos) {
       // TODO: add ucj save logic

--- a/src/foam/u2/wizard/StepWizardletStepsView.js
+++ b/src/foam/u2/wizard/StepWizardletStepsView.js
@@ -98,7 +98,7 @@ foam.CLASS({
             // Render section labels
             let sections = this.data.sections[w];
 
-            let afterCurrentSection = false;
+            // let afterCurrentSection = false;
             for ( let s = 0 ; s < sections.length ; s++ ) {
               let pos = this.WizardPosition.create({
                 wizardletIndex: w,
@@ -106,7 +106,6 @@ foam.CLASS({
               })
               let section = sections[s];
               let isCurrentSection = isCurrent && si === s;
-              let onClickSkips = afterCurrent || afterCurrentSection;
               let allowedToSkip = self.data.canSkipTo(pos);
               let slot = section.createIsAvailableFor(
                 wizardlet.data$
@@ -116,9 +115,8 @@ foam.CLASS({
                   e,
                   section, s+1,
                   isCurrentSection,
-                  ! isCurrentSection && ( ! onClickSkips || allowedToSkip )
+                  allowedToSkip
                 ).on('click', () => {
-                  let targetScreenIndex = self.data.sectionToScreenIndex(w, s);
                   if ( isCurrentSection ) return;
                   if ( allowedToSkip ) {
                     self.data.skipTo(pos);
@@ -127,7 +125,7 @@ foam.CLASS({
                 });
                 return e;
               })
-              if ( isCurrentSection ) afterCurrentSection = true;
+              // if ( isCurrentSection ) afterCurrentSection = true;
               elem.add(slot);
             }
 

--- a/src/foam/u2/wizard/StepWizardletStepsView.js
+++ b/src/foam/u2/wizard/StepWizardletStepsView.js
@@ -28,14 +28,15 @@ foam.CLASS({
 
   requires: [
     'foam.u2.detail.AbstractSectionedDetailView',
-    'foam.u2.tag.CircleIndicator'
+    'foam.u2.tag.CircleIndicator',
+    'foam.u2.wizard.WizardPosition'
   ],
 
   methods: [
     function initE() {
       var self = this;
       this
-        .add(this.slot(function (data$wizardlets, data$subStack$pos) {
+        .add(this.slot(function (data$wizardlets, data$wizardPosition) {
           let elem = this.E();
 
           let afterCurrent = false;
@@ -92,17 +93,21 @@ foam.CLASS({
                 .end();
             
             // Get section index to highlight current section
-            let indices = this.data.screenIndexToSection(data$subStack$pos);
+            let si = data$wizardPosition.sectionIndex;
             
             // Render section labels
             let sections = this.data.sections[w];
 
             let afterCurrentSection = false;
             for ( let s = 0 ; s < sections.length ; s++ ) {
+              let pos = this.WizardPosition.create({
+                wizardletIndex: w,
+                sectionIndex: s,
+              })
               let section = sections[s];
-              let isCurrentSection = isCurrent && indices[1] === s;
+              let isCurrentSection = isCurrent && si === s;
               let onClickSkips = afterCurrent || afterCurrentSection;
-              let allowedToSkip = self.data.canSkipTo(w);
+              let allowedToSkip = self.data.canSkipTo(pos);
               let slot = section.createIsAvailableFor(
                 wizardlet.data$
               ).map(function (isAvailable) {
@@ -115,15 +120,10 @@ foam.CLASS({
                 ).on('click', () => {
                   let targetScreenIndex = self.data.sectionToScreenIndex(w, s);
                   if ( isCurrentSection ) return;
-                  if ( onClickSkips ) {
-                    if ( allowedToSkip ) {
-                      self.data.skipTo(targetScreenIndex);
-                    }
-                    return;
+                  if ( allowedToSkip ) {
+                    self.data.skipTo(pos);
                   }
-                  while ( self.data.subStack.pos !== targetScreenIndex ) {
-                    self.data.back();
-                  }
+                  return;
                 });
                 return e;
               })

--- a/src/foam/u2/wizard/StepWizardletView.js
+++ b/src/foam/u2/wizard/StepWizardletView.js
@@ -20,6 +20,7 @@ foam.CLASS({
   requires: [
     'foam.core.Action',
     'foam.log.LogLevel',
+    'foam.u2.detail.SectionView',
     'foam.u2.dialog.Popup',
     'foam.u2.dialog.SimpleActionDialog',
     'foam.u2.stack.Stack',
@@ -143,18 +144,28 @@ foam.CLASS({
             .start()
               .addClass(this.myClass('entry'))
               .start()
-                .add(this.data.SUB_STACK)
+                .add(this.slot(function (data$currentWizardlet, data$currentSection) {
+                  var ctx = this.__subContext__.createSubContext();
+                  ctx.register(
+                    this.VerticalDetailView,
+                    'foam.u2.detail.SectionedDetailView'
+                  );
+                  return self.SectionView.create({
+                    section: data$currentSection,
+                    data$: data$currentWizardlet.data$,
+                  }, ctx)
+                }))
               .end()
             .end()
             .start()
               .addClass(this.myClass('bottom-buttons'))
-              .add(this.slot(function (data$isLastWizardlet) {
+              .add(this.slot(function (data$isLastScreen) {
                 return this.E()
                   .startContext({ data: self })
                   .addClass(self.myClass('buttons'))
                   .tag(this.GO_PREV, btn)
                   .tag(this.GO_NEXT,
-                    data$isLastWizardlet
+                    data$isLastScreen
                       ? { ...btn, label: this.ACTION_LABEL }
                       : btn
                   )
@@ -228,8 +239,8 @@ foam.CLASS({
     {
       name: 'goNext',
       label: 'next',
-      isEnabled: function (data$isLastWizardlet, data$currentWizardlet) {
-        return data$isLastWizardlet || data$currentWizardlet.validate();
+      isEnabled: function (data$canGoNext) {
+        return data$canGoNext;
       },
       code: function(x) {
         this.data.next().then((isFinished) => {

--- a/src/foam/u2/wizard/WizardPosition.js
+++ b/src/foam/u2/wizard/WizardPosition.js
@@ -11,21 +11,11 @@ foam.CLASS({
   properties: [
     {
       name: 'wizardletIndex',
-      class: 'Int',
-      postSet: function() {
-        console.warn(
-          `WizardPosition should not be mutated; ` +
-          `create a new WizardPosition to guarentee slot updates`);
-      }
+      class: 'Int'
     },
     {
       name: 'sectionIndex',
-      class: 'Int',
-      postSet: function() {
-        console.warn(
-          `WizardPosition should not be mutated; ` +
-          `create a new WizardPosition to guarentee slot updates`);
-      }
+      class: 'Int'
     },
   ],
 });

--- a/src/foam/u2/wizard/WizardPosition.js
+++ b/src/foam/u2/wizard/WizardPosition.js
@@ -1,0 +1,31 @@
+foam.CLASS({
+  package: 'foam.u2.wizard',
+  name: 'WizardPosition',
+
+  documentation: `
+    Identifies a specific screen in a StepWizardlet view by specifying:
+    - the index in an array of wizardlets, and
+    - the index of a section in the data model
+  `,
+
+  properties: [
+    {
+      name: 'wizardletIndex',
+      class: 'Int',
+      postSet: function() {
+        console.warn(
+          `WizardPosition should not be mutated; ` +
+          `create a new WizardPosition to guarentee slot updates`);
+      }
+    },
+    {
+      name: 'sectionIndex',
+      class: 'Int',
+      postSet: function() {
+        console.warn(
+          `WizardPosition should not be mutated; ` +
+          `create a new WizardPosition to guarentee slot updates`);
+      }
+    },
+  ],
+});

--- a/src/foam/u2/wizard/WizardPosition.js
+++ b/src/foam/u2/wizard/WizardPosition.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 foam.CLASS({
   package: 'foam.u2.wizard',
   name: 'WizardPosition',

--- a/src/foam/u2/wizard/WizardPosition.js
+++ b/src/foam/u2/wizard/WizardPosition.js
@@ -16,6 +16,6 @@ foam.CLASS({
     {
       name: 'sectionIndex',
       class: 'Int'
-    },
+    }
   ],
 });

--- a/src/foam/u2/wizard/WizardPosition.js
+++ b/src/foam/u2/wizard/WizardPosition.js
@@ -18,4 +18,13 @@ foam.CLASS({
       class: 'Int'
     }
   ],
+
+  methods: [
+    function compareTo(b) {
+      let a = this;
+      let wizardletDiff = a.wizardletIndex - b.wizardletIndex;
+      if ( wizardletDiff != 0 ) return wizardletDiff;
+      return a.sectionIndex - b.sectionIndex;
+    }
+  ]
 });


### PR DESCRIPTION
This PR removes the StackView from StepWizardletView.

The position of a substack was originally being used to keep track of the wizard screen, but this wasn't a good approach because
- the screen is really identified by two indices (wizardlet and section within wizardlet's data model), and
- unavailable sections had to be pushed to the stack as blank screens before reaching the next available one

This also removes logic from `canSkipTo` which needs to be re-evaluated.