### PR TITLE
Add ChooseNView

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -485,6 +485,8 @@ FOAM_FILES([
   { name: "foam/u2/view/DraftDetailView", flags: ['web'] },
   { name: "foam/u2/view/FObjectArrayView", flags: ['web'] },
   { name: "foam/u2/view/ChoiceView", flags: ['web'] },
+  { name: "foam/u2/view/UnstyledChooseNView", flags: ['web'] },
+  { name: "foam/u2/view/ChooseNView", flags: ['web'] },
   { name: "foam/u2/view/ChoiceWithOtherView", flags: ['web'] },
   { name: "foam/u2/view/RichChoiceView", flags: ['web'] },
   { name: "foam/u2/view/OverlayActionListView", flags: ['web'] },

--- a/src/foam/u2/view/ChooseNView.js
+++ b/src/foam/u2/view/ChooseNView.js
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.u2.view',
+  name: 'ChooseNView',
+  extends: 'foam.u2.view.UnstyledChooseNView',
+
+  css: `
+    ^ .foam-u2-CheckBox {
+      display: block;
+    }
+  `
+});

--- a/src/foam/u2/view/UnstyledChooseNView.js
+++ b/src/foam/u2/view/UnstyledChooseNView.js
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.u2.view',
+  name: 'UnstyledChooseNView',
+  extends: 'foam.u2.View',
+
+  requires: [
+    'foam.core.SimpleSlot'
+  ],
+
+  properties: [
+    foam.u2.view.ChoiceView.DYNAMIC_SIZE,
+    foam.u2.view.ChoiceView.MAX_SIZE,
+    foam.u2.view.ChoiceView.CHOICES,
+    {
+      name: 'n',
+      class: 'Int'
+    },
+    {
+      name: 'booleanView',
+      class: 'foam.u2.ViewSpec',
+      value: {
+        class: 'foam.u2.CheckBox'
+      }
+    },
+    {
+      name: 'data',
+      class: 'Map',
+      value: {},
+      factory: function () {
+        return {};
+      },
+      adapt: function (_, n) {
+        var set = n;
+        if ( Array.isArray(n) ) {
+          set = {};
+          n.forEach(v => { set[n] = true; })
+        }
+        return set;
+      },
+    }
+  ],
+
+  methods: [
+    function initE() {
+      var self = this;
+      this
+        .addClass(this.myClass())
+        .add(this.slot(function (choices) {
+          return this.E()
+            .forEach(choices, function (choice) {
+              var valueSlot = self.SimpleSlot.create({
+                value: false
+              });
+              this.tag(self.booleanView, {
+                label: choice[1],
+                data$: valueSlot
+              });
+              this.onDetach(valueSlot.sub(() => {
+                isOn = valueSlot.get();
+                console.log('choice', choice[0], isOn);
+                if ( isOn ) {
+                  if ( Object.keys(self.data).length >= self.n ) {
+                    valueSlot.set(false);
+                    return;
+                  }
+                  self.data$set(choice[0], true);
+                } else {
+                  self.data$remove(choice[0]);
+                  delete self.data[choice[0]];
+                }
+              }))
+            })
+        }))
+        ;
+    }
+  ]
+});

--- a/src/foam/u2/view/UnstyledChooseNView.js
+++ b/src/foam/u2/view/UnstyledChooseNView.js
@@ -18,8 +18,9 @@ foam.CLASS({
     foam.u2.view.ChoiceView.MAX_SIZE,
     foam.u2.view.ChoiceView.CHOICES,
     {
-      name: 'n',
-      class: 'Int'
+      name: 'maxSelections',
+      class: 'Int',
+      value: Number.MAX_SAFE_INTEGER
     },
     {
       name: 'booleanView',
@@ -66,7 +67,7 @@ foam.CLASS({
                 isOn = valueSlot.get();
                 console.log('choice', choice[0], isOn);
                 if ( isOn ) {
-                  if ( Object.keys(self.data).length >= self.n ) {
+                  if ( Object.keys(self.data).length >= self.maxSelections ) {
                     valueSlot.set(false);
                     return;
                   }

--- a/src/foam/u2/view/UnstyledChooseNView.js
+++ b/src/foam/u2/view/UnstyledChooseNView.js
@@ -35,11 +35,12 @@ foam.CLASS({
       factory: function () {
         return {};
       },
-      adapt: function (_, n) {
-        var set = n;
-        if ( Array.isArray(n) ) {
+      adapt: function (_, nu) {
+        var set = nu;
+        // Convert array input to a set (represented as an object of `true`)
+        if ( Array.isArray(nu) ) {
           set = {};
-          n.forEach(v => { set[n] = true; })
+          nu.forEach(k => { set[k] = true; })
         }
         return set;
       },


### PR DESCRIPTION
ChooseNView allows selecting up to `n` of the specified choices. Each choice is rendered using `CheckBox` by default, but this can be overridden using the `booleanView` property.

This change is related to rendering an "AtLeastCapability" (tentative name, referred to as `OrCapability` in tickets) capabilities in the step wizard. This view helps to guarantee the maximum number of selections isn't surpassed while a validation elsewhere can prevent continuation until the minimum number of selections is met.