### PR TITLE
refine src/tgt id of cap junction to show cap name

### DIFF
--- a/src/foam/nanos/crunch/CapabilityCapabilityJunctionRefine.js
+++ b/src/foam/nanos/crunch/CapabilityCapabilityJunctionRefine.js
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.nanos.crunch',
+  name: 'CapabilityCapabilityJunctionRefine',
+  refines: 'foam.nanos.crunch.CapabilityCapabilityJunction',
+
+  documentation: `
+    Refine capabilitycapabilityjunction to add tablecellformatters for source and target id
+  `,
+
+  properties: [
+    {
+      class: 'Reference',
+      of: 'foam.nanos.crunch.Capability',
+      name: 'sourceId',
+      tableCellFormatter: function(value, obj, axiom) {
+        this.__subSubContext__.capabilityDAO
+          .find(value)
+          .then((capability) => this.add(capability.name))
+          .catch((error) => {
+            this.add(value);
+          });
+      }
+    },
+    {
+      class: 'Reference',
+      of: 'foam.nanos.crunch.Capability',
+      name: 'targetId',
+      tableCellFormatter: function(value, obj, axiom) {
+        this.__subSubContext__.capabilityDAO
+          .find(value)
+          .then((capability) => this.add(capability.name))
+          .catch((error) => {
+            this.add(value);
+          });
+      }
+    }
+  ]
+});

--- a/src/foam/nanos/crunch/CapabilityCategoryCapabilityJunctionRefine.js
+++ b/src/foam/nanos/crunch/CapabilityCategoryCapabilityJunctionRefine.js
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.nanos.crunch',
+  name: 'CapabilityCategoryCapabilityJunctionRefine',
+  refines: 'foam.nanos.crunch.CapabilityCategoryCapabilityJunction',
+
+  documentation: `
+    Refine capabilitycategorycapabilityjunction to add tablecellformatters for source and target id
+  `,
+
+  properties: [
+    {
+      class: 'Reference',
+      of: 'foam.nanos.crunch.Capability',
+      name: 'targetId',
+      tableCellFormatter: function(value, obj, axiom) {
+        this.__subSubContext__.capabilityDAO
+          .find(value)
+          .then((capability) => this.add(capability.name))
+          .catch((error) => {
+            this.add(value);
+          });
+      }
+    }
+  ]
+});

--- a/src/foam/nanos/crunch/UserCapabilityJunctionRefine.js
+++ b/src/foam/nanos/crunch/UserCapabilityJunctionRefine.js
@@ -16,6 +16,26 @@ foam.CLASS({
 
   properties: [
     {
+      class: 'Reference',
+      of: 'foam.nanos.auth.User',
+      name: 'sourceId',
+      label: 'User'
+    },
+    {
+      class: 'Reference',
+      of: 'foam.nanos.crunch.Capability',
+      name: 'targetId',
+      label: 'Capability',
+      tableCellFormatter: function(value, obj, axiom) {
+        this.__subSubContext__.capabilityDAO
+          .find(value)
+          .then((capability) => this.add(capability.name))
+          .catch((error) => {
+            this.add(value);
+          });
+      }
+    },
+    {
       name: 'created',
       class: 'DateTime',
       factory: function() {

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -322,6 +322,8 @@ FOAM_FILES([
   { name: "foam/nanos/crunch/CapabilityCategory" },
   { name: "foam/nanos/crunch/CapabilityJunctionStatus" },
   { name: "foam/nanos/crunch/UserCapabilityJunctionRefine" },
+  { name: "foam/nanos/crunch/CapabilityCapabilityJunctionRefine" },
+  { name: "foam/nanos/crunch/CapabilityCategoryCapabilityJunctionRefine" },
   { name: "foam/nanos/crunch/AssociatedEntity" },
   //daos
   { name: "foam/nanos/crunch/UserCapabilityJunctionDAO" },


### PR DESCRIPTION
refine src/target ids of capability junctions so that capability name is displayed in tableview instead of id for easier viewing 