### PR TITLE
[ME#3753] [NP-1777] Capability.getJunction(x)

### DIFF
--- a/src/foam/nanos/crunch/ClientCrunchService.js
+++ b/src/foam/nanos/crunch/ClientCrunchService.js
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.nanos.crunch',
+  name: 'ClientCrunchService',
+
+  implements: [
+    'foam.nanos.crunch.CrunchService'
+  ],
+
+  properties: [
+    {
+      class: 'Stub',
+      of: 'foam.nanos.crunch.CrunchService',
+      name: 'delegate'
+    }
+  ]
+});
+

--- a/src/foam/nanos/crunch/CrunchService.js
+++ b/src/foam/nanos/crunch/CrunchService.js
@@ -1,0 +1,21 @@
+foam.INTERFACE({
+  package: 'foam.nanos.crunch',
+  name: 'CrunchService',
+
+  methods: [
+    {
+      name: 'getGrantPath',
+      type: 'List',
+      args: [
+        {
+          name: 'x',
+          type: 'Context'
+        },
+        {
+          name: 'sourceId',
+          type: 'String'
+        }
+      ]
+    }
+  ],
+});

--- a/src/foam/nanos/crunch/CrunchService.js
+++ b/src/foam/nanos/crunch/CrunchService.js
@@ -5,6 +5,7 @@ foam.INTERFACE({
   methods: [
     {
       name: 'getGrantPath',
+      async: true,
       type: 'List',
       args: [
         {

--- a/src/foam/nanos/crunch/JavaCrunchService.java
+++ b/src/foam/nanos/crunch/JavaCrunchService.java
@@ -3,6 +3,7 @@ package foam.nanos.crunch;
 import foam.core.X;
 import foam.dao.ArraySink;
 import foam.dao.DAO;
+import foam.nanos.logger.Logger;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -14,6 +15,9 @@ import static foam.mlang.MLang.*;
 
 public class JavaCrunchService implements CrunchService {
   public List getGrantPath(X x, String rootId) {
+    Logger logger = (Logger) x.get("logger");
+    logger.info("Handling CrunchService grantPath request: " + rootId);
+
     DAO prerequisiteDAO = (DAO) x.get("prerequisiteCapabilityJunctionDAO");
     DAO capabilityDAO = (DAO) x.get("capabilityDAO");
     // TODO:
@@ -47,6 +51,7 @@ public class JavaCrunchService implements CrunchService {
           int newIndex = entry.getValue();
           if ( newIndex > previousIndex ) newIndex--;
         }
+        alreadyListed = newAlreadyListed;
       }
 
       // Add capability to grant path, and remember index in case it's replaced

--- a/src/foam/nanos/crunch/JavaCrunchService.java
+++ b/src/foam/nanos/crunch/JavaCrunchService.java
@@ -1,0 +1,62 @@
+package foam.nanos.crunch;
+
+import foam.dao.DAO;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+
+public class JavaCrunchService implements CrunchService {
+  public List getGrantPath(X x, String rootId) {
+    DAO prerequisiteDAO = (DAO) x.get("prerequisiteCapabilityJunctionDAO");
+    DAO capabilityDAO = (DAO) x.get("capabilityDAO");
+
+    // Lookup for indices of previously observed capabilities
+    Map<String,Integer> alreadyListed = new HashMap<String,Integer>();
+    // Return list (list is reversed at the end to put prerequisites first)
+    List grantPath = new List<>();
+
+    Queue<String> nextSources = new ArrayDeque<String>();
+    nextSources.add(rootId)
+
+    for ( int i = 0 ; i < nextSources.size() ; i++ ) {
+      String sourceId = nextSources.poll();
+
+      // Remove previously added prerequisite if one matches
+      if ( alreadyListed.containsKey(sourceId) ) {
+        int previousIndex = alreadyListed.get(sourceId);
+        grantPath.remove(previousIndex);
+
+        // Remove previously stored index of capability
+        alreadyListed.remove(sourceId);
+
+        // Shift remembered indexes, now that grantList has been shifted
+        Map<String,Integer> newAlreadyListed = new HashMap<String,Integer>();
+        for ( Map.Entry<String,Integer> entry : alreadyListed ) {
+          int newIndex = entry.getValue();
+          if ( newIndex > previousIndex ) newIndex--;
+        }
+      }
+
+      // Add capability to grant path, and remember index in case it's replaced
+      Capability cap = (Capability) capabilityDAO.find(sourceId);
+      alreadyListed.set(sourceId, grantPath.size());
+      grantPath.add(cap);
+
+      // Enqueue prerequisites for adding to grant path
+      List prereqs = prerequisiteDAO
+        .where(MLang.EQ(CapabilityCapabilityJunction.SOURCE_ID, sourceId))
+        .select(new ArraySink())
+        .getArray();
+      for ( CapabilityCapabilityJunction prereq : prereqs ) {
+        nextSources.put(prereq);
+      }
+    }
+
+    Collections.reverse(grantPath);
+    return grantPath;
+  }
+}

--- a/src/foam/nanos/crunch/JavaCrunchService.java
+++ b/src/foam/nanos/crunch/JavaCrunchService.java
@@ -1,5 +1,7 @@
 package foam.nanos.crunch;
 
+import foam.core.X;
+import foam.dao.ArraySink;
 import foam.dao.DAO;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -8,22 +10,28 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import static foam.mlang.MLang.*;
 
 public class JavaCrunchService implements CrunchService {
   public List getGrantPath(X x, String rootId) {
     DAO prerequisiteDAO = (DAO) x.get("prerequisiteCapabilityJunctionDAO");
     DAO capabilityDAO = (DAO) x.get("capabilityDAO");
+    // TODO:
+    // DAO junctionDAO
 
     // Lookup for indices of previously observed capabilities
     Map<String,Integer> alreadyListed = new HashMap<String,Integer>();
     // Return list (list is reversed at the end to put prerequisites first)
-    List grantPath = new List<>();
+    List grantPath = new ArrayList<>();
 
     Queue<String> nextSources = new ArrayDeque<String>();
-    nextSources.add(rootId)
+    nextSources.add(rootId);
 
-    for ( int i = 0 ; i < nextSources.size() ; i++ ) {
+    while ( nextSources.size() > 0 ) {
       String sourceId = nextSources.poll();
+
+      // TODO:
+      // UserCapabilityJunction ucj = (UserCapabilityJunction)
 
       // Remove previously added prerequisite if one matches
       if ( alreadyListed.containsKey(sourceId) ) {
@@ -35,7 +43,7 @@ public class JavaCrunchService implements CrunchService {
 
         // Shift remembered indexes, now that grantList has been shifted
         Map<String,Integer> newAlreadyListed = new HashMap<String,Integer>();
-        for ( Map.Entry<String,Integer> entry : alreadyListed ) {
+        for ( Map.Entry<String,Integer> entry : alreadyListed.entrySet() ) {
           int newIndex = entry.getValue();
           if ( newIndex > previousIndex ) newIndex--;
         }
@@ -43,16 +51,17 @@ public class JavaCrunchService implements CrunchService {
 
       // Add capability to grant path, and remember index in case it's replaced
       Capability cap = (Capability) capabilityDAO.find(sourceId);
-      alreadyListed.set(sourceId, grantPath.size());
+      alreadyListed.put(sourceId, grantPath.size());
       grantPath.add(cap);
 
       // Enqueue prerequisites for adding to grant path
-      List prereqs = prerequisiteDAO
-        .where(MLang.EQ(CapabilityCapabilityJunction.SOURCE_ID, sourceId))
-        .select(new ArraySink())
-        .getArray();
-      for ( CapabilityCapabilityJunction prereq : prereqs ) {
-        nextSources.put(prereq);
+      List prereqs = ( (ArraySink) prerequisiteDAO
+        .where(EQ(CapabilityCapabilityJunction.SOURCE_ID, sourceId))
+        .select(new ArraySink()) ).getArray();
+      for ( Object prereqObj : prereqs ) {
+        CapabilityCapabilityJunction prereq =
+          (CapabilityCapabilityJunction) prereqObj;
+        nextSources.add(prereq.getTargetId());
       }
     }
 

--- a/src/foam/nanos/crunch/JavaCrunchService.java
+++ b/src/foam/nanos/crunch/JavaCrunchService.java
@@ -56,6 +56,12 @@ public class JavaCrunchService implements CrunchService {
 
       // Add capability to grant path, and remember index in case it's replaced
       Capability cap = (Capability) capabilityDAO.find(sourceId);
+
+      UserCapabilityJunction ucj = cap.getJunction(x);
+      if ( ucj != null && ucj.getStatus() == CapabilityJunctionStatus.GRANTED ) {
+        continue;
+      }
+
       alreadyListed.put(sourceId, grantPath.size());
       grantPath.add(cap);
 

--- a/src/foam/nanos/crunch/services.jrl
+++ b/src/foam/nanos/crunch/services.jrl
@@ -112,3 +112,25 @@ p({
   """,
   "client":"{\"of\":\"foam.nanos.crunch.CapabilityCapabilityJunction\", \"remoteListenerSupport\": false}"
 })
+
+p({
+  "class": "foam.nanos.boot.NSpec",
+  "name": "crunchService",
+  "serve": true,
+  "authenticate": true,
+  "boxClass": "foam.nanos.crunch.CrunchServiceSkeleton",
+  "serviceClass": "foam.nanos.crunch.JavaCrunchService",
+  "client":
+    """
+      {
+        "class": "foam.nanos.crunch.ClientCrunchService",
+        "delegate": {
+          "class": "foam.box.SessionClientBox",
+          "delegate": {
+            "class": "foam.box.HTTPBox",
+            "url": "service/crunchService"
+          }
+        }
+      }
+    """
+})

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -333,6 +333,8 @@ FOAM_FILES([
   { name: "foam/nanos/crunch/IsUserCapabilityJunctionStatusUpdate" },
   { name: "foam/nanos/crunch/RemoveJunctionsOnUserRemoval" },
   { name: "foam/nanos/crunch/CascadeInvalidate" },
+  { name: "foam/nanos/crunch/CrunchService" },
+  { name: "foam/nanos/crunch/ClientCrunchService" },
 
   // approval
   { name: 'foam/nanos/approval/ApprovalRequest' },

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -628,6 +628,7 @@ var classes = [
   'foam.nanos.crunch.IsUserCapabilityJunctionStatusUpdate',
   'foam.nanos.crunch.RemoveJunctionsOnUserRemoval',
   'foam.nanos.crunch.CascadeInvalidate',
+  'foam.nanos.crunch.CrunchService',
   //authservice
   'foam.nanos.auth.CapabilityAuthService',
   // userQueryService
@@ -688,7 +689,8 @@ var skeletons = [
   'foam.nanos.test.EchoService',
   'foam.strategy.StrategizerService',
   'foam.nanos.auth.UserQueryService',
-  'foam.nanos.export.GoogleSheetsExport'
+  'foam.nanos.export.GoogleSheetsExport',
+  'foam.nanos.crunch.CrunchService'
 ];
 
 var proxies = [


### PR DESCRIPTION
PR depends on #3746
PR is mutually exclusive to #3753 

This is one solution for determining a capabilities status based on context without repeating the logic of determining which user (i.e. `subject.realUser` vs `subject.user`) and which junction type (i.e. if it's an AgentCapabilityJunction)