### PR TITLE
Moving SPID Aware before Authorization in the DAO stack

### DIFF
--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -205,14 +205,6 @@ foam.CLASS({
             delegate = new foam.dao.ValidatingDAO(getX(), delegate, foam.core.ValidatableValidator.instance());
         }
 
-        if ( getServiceProviderAware() ) {
-          foam.nanos.auth.ServiceProviderAwareDAO dao = new foam.nanos.auth.ServiceProviderAwareDAO.Builder(getX()).setDelegate(delegate).build();
-          if ( getServiceProviderAwarePropertyInfos() != null ) {
-            dao.setPropertyInfos(getServiceProviderAwarePropertyInfos());
-          }
-          delegate = dao;
-        }
-
         if ( getLifecycleAware() ) {
           delegate = new foam.nanos.auth.LifecycleAwareDAO.Builder(getX())
             .setDelegate(delegate)
@@ -258,6 +250,14 @@ foam.CLASS({
             .setDelegate(delegate)
             .setAuthorizer(getAuthorizer())
             .build();
+        }
+
+        if ( getServiceProviderAware() ) {
+          foam.nanos.auth.ServiceProviderAwareDAO dao = new foam.nanos.auth.ServiceProviderAwareDAO.Builder(getX()).setDelegate(delegate).build();
+          if ( getServiceProviderAwarePropertyInfos() != null ) {
+            dao.setPropertyInfos(getServiceProviderAwarePropertyInfos());
+          }
+          delegate = dao;
         }
 
         if ( getNSpec() != null && getNSpec().getServe() && ! getAuthorize() && ! getReadOnly() )

--- a/src/services
+++ b/src/services
@@ -771,6 +771,7 @@ p({
   "serviceScript": """
     dao = new foam.dao.EasyDAO.Builder(x)
       .setEnableInterfaceDecorators(false)
+      .setServiceProviderAware(true)
       .setOf(foam.nanos.ruler.Rule.getOwnClassInfo())
       .setInnerDAO(x.get("localRuleDAO"))
       .build();


### PR DESCRIPTION
In order for the SPID to be set properly for authorization, ServiceProviderAwareDAO needs to be before the AuthorizationDAO in the stack, meaning the call to add it in the EasyDAO has to be *after* it. Updating the EasyDAO to have the correct order here.