### PR TITLE
fix appConfig UI broken

### DIFF
--- a/src/foam/u2/view/FObjectView.js
+++ b/src/foam/u2/view/FObjectView.js
@@ -155,7 +155,7 @@ foam.CLASS({
       if ( ! this.choices.length ) {
         this.onDetach(this.of$.sub(this.updateChoices));
         this.updateChoices();
-        await this.choicesLoaded;
+        this.choicesLoaded;
       }
 
       function dataToClass(d) {


### PR DESCRIPTION
app config service shows nothing due to using await before a prop in FobjectView.
related ticket: 
https://nanopay.atlassian.net/browse/NP-1769
https://nanopay.atlassian.net/browse/NP-1621
<img width="1405" alt="Screen Shot 2020-08-06 at 4 20 57 PM" src="https://user-images.githubusercontent.com/41084370/89578917-ea41c580-d800-11ea-8cd9-199e029487ef.png">
<img width="1249" alt="Screen Shot 2020-08-06 at 4 21 27 PM" src="https://user-images.githubusercontent.com/41084370/89578920-ea41c580-d800-11ea-874a-cd81bfacf2b7.png">

