### PR TITLE
Fix rule authorization

### DIFF
--- a/src/foam/nanos/auth/ServiceProviderAwareDAO.js
+++ b/src/foam/nanos/auth/ServiceProviderAwareDAO.js
@@ -112,7 +112,10 @@ ServiceProviderAware`,
       if ( ServiceProviderAware.class.isAssignableFrom(getOf().getObjClass()) ) {
 
         PropertyInfo spidProperty = ((PropertyInfo) getOf().getAxiomByName("spid"));
-        spidPredicate = MLang.EQ(spidProperty, spid);
+        spidPredicate = MLang.OR(
+          MLang.EQ(spidProperty, spid),
+          new ServiceProviderAwarePredicate(x, null, getPropertyInfos())
+        );
 
         if ( predicate != null ) {
           spidPredicate = MLang.AND(

--- a/src/foam/nanos/ruler/Rule.js
+++ b/src/foam/nanos/ruler/Rule.js
@@ -426,9 +426,7 @@
       name: 'authorizeOnCreate',
       javaCode: `
         var auth = (AuthService) x.get("auth");
-        if ( ! auth.check(x, "rule.create")
-          && ! auth.check(x, "spid.update." + getSpid())
-        ) {
+        if ( ! auth.check(x, "rule.create") ) {
           throw new AuthorizationException("You do not have permission to create the rule.");
         }
       `
@@ -448,9 +446,7 @@
       name: 'authorizeOnUpdate',
       javaCode: `
         var auth = (AuthService) x.get("auth");
-        if ( ! auth.check(x, "rule.update." + getId())
-          && ! auth.check(x, "spid.update." + getSpid())
-        ) {
+        if ( ! auth.check(x, "rule.update." + getId()) ) {
           throw new AuthorizationException("You do not have permission to update the rule.");
         }
       `


### PR DESCRIPTION
## Ref
- https://github.com/foam-framework/foam2/pull/3774#issuecomment-670824666

## Changes
- Let ServiceProviderAwareDAO.put_ handle rule create and update
- Fix ServiceProviderAwareDAO.select_ to return objects when user has "spid.read.{obj.spid}" permission