### PR TITLE
Cached auth service refinement

### DIFF
--- a/src/foam/nanos/auth/CachedAuthServiceProxy.js
+++ b/src/foam/nanos/auth/CachedAuthServiceProxy.js
@@ -14,7 +14,7 @@ foam.CLASS({
   `,
   imports: [
     'capabilityDAO',
-    'subject',
+    'group',
     'userCapabilityJunctionDAO'
   ],
   properties: [
@@ -25,7 +25,7 @@ foam.CLASS({
   ],
   methods: [
     function init() {
-      this.onDetach(this.subject$.dot('user').dot('group').sub(function() {
+      this.onDetach(this.group$.sub(function() {
         this.cache = {};
       }.bind(this)));
       this.onDetach(this.userCapabilityJunctionDAO.on.sub(

--- a/src/foam/nanos/auth/CachedAuthServiceProxy.js
+++ b/src/foam/nanos/auth/CachedAuthServiceProxy.js
@@ -14,7 +14,7 @@ foam.CLASS({
   `,
   imports: [
     'capabilityDAO',
-    'user',
+    'subject',
     'userCapabilityJunctionDAO'
   ],
   properties: [
@@ -25,7 +25,7 @@ foam.CLASS({
   ],
   methods: [
     function init() {
-      this.onDetach(this.user$.dot('group').sub(function() {
+      this.onDetach(this.subject$.dot('user').dot('group').sub(function() {
         this.cache = {};
       }.bind(this)));
       this.onDetach(this.userCapabilityJunctionDAO.on.sub(


### PR DESCRIPTION
Clears auth cache on context group change - Previously referenced unused property on user so cache was not being cleared.