### PR TITLE
[NP-1833] Add CRUNCH usage docs and FLOW improvements

### DIFF
--- a/src/documentation/crunch-doc.flow
+++ b/src/documentation/crunch-doc.flow
@@ -1,0 +1,92 @@
+<title>CRUNCH Documentation</title>
+
+<h1>Continuous Reactive User Nano-Capability Hierarchy</h1>
+
+<foam class="foam.flow.widgets.DocumentationIncomplete" status="wip" />
+
+<p>
+CRUNCH is a CORE subsystem that enables flexible definitions of incremental steps users can take to gain access to features of an application. A key principle of CRUNCH is the user will only enter new information at the time it's required to perform an action. (although it is possible to have users add information ahead of time also)
+</p>
+
+<h2>CRUNCH Concepts</h2>
+
+<h3>Capability</h3>
+
+<p>
+A `Capability` is an action that can be performed on the system. Most capabilities will simply be instances of `foam.nanos.crunch.Capability` in the journal, although subclasses of Capability can be used when special behaviours are desired.
+</p>
+
+<p>
+Basic configuration of a capability includes specifying what permissions it grants, what information is required from the user, and and when the capability appears.
+</p>
+
+<p>
+A capability may also depend on other capabilities by its `prerequisites` relationship. In this way, CRUNCH facilitates controlled and incremental aquisition of capabilities.
+</p>
+
+<h4>Specify Permissions</h4>
+<p>
+To specify permissions, use the following property.
+
+<foam class="foam.flow.widgets.PropertyShortSummary" of="foam.nanos.crunch.Capability" whitelist="['permissionsGranted']" />
+</p>
+
+<p>
+Specifying permissions is optional. A capability which grants no permissions can be useful for grouping other capabilities.
+</p>
+
+<h4>Specify Required Information</h4>
+<p>
+A capability may require some input from the user. For example, a capability allowing a user to create new content may require their acceptance of a privacy policy.
+</p>
+
+<p>
+The following properties help to specify required information and how it will be processed:
+<foam class="foam.flow.widgets.PropertyShortSummary" of="foam.nanos.crunch.Capability" whitelist="['of','daoKey','contextDAOFindKey']" />
+</p>
+
+<p>
+The class specified by `of` will be displayed to the user before the capability is granted. An instance of this class will be stored in a junction between User and Capability. (the UserCapabilityJunction)
+</p>
+
+<p>
+The `daoKey` property can be used to specify another DAO where the data will be stored. If this is specified, property names of the class specified by the Capability's `of` should match property names of the class specified by the DAO's of.
+</p>
+
+<p>
+The `contextDAOFindKey` property allows an object in the context to be used as a starting point for the object that is stored in the DAO specified by `daoKey`. For example, a capability which sets a property of `User` can specify `subject.user` as the `contextDAOFindKey`.
+</p>
+
+<h4>Specify When the Capability Appears</h4>
+<foam class="foam.flow.widgets.DocumentationIncomplete" status="todo" isSection="true" />
+
+<h3>Capability Prerequisites</h3>
+<foam class="foam.flow.widgets.DocumentationIncomplete" status="todo" isSection="true" />
+
+<h3>CRUNCH Intercepts</h3>
+<foam class="foam.flow.widgets.DocumentationIncomplete" status="todo" isSection="true" />
+
+<h3>Capability Categories</h3>
+<foam class="foam.flow.widgets.DocumentationIncomplete" status="todo" isSection="true" />
+
+<h3>Capability User Associations</h3>
+<p>
+Some applications may support an "acting as" behaviour for users; for example: a user may act on behalf of a company or organization, which is another type of user. When using CORE's application logic, the object `subject` in context has two properties to determine each user.
+
+<foam class="foam.flow.widgets.PropertyShortSummary" of="foam.nanos.auth.Subject" whitelist="['realUser', 'user']" />
+</p>
+
+<p>
+A capability can specify how the user is associated to the capability using the `associatedEntity` property.
+
+<foam class="foam.flow.widgets.PropertyShortSummary" of="foam.nanos.crunch.Capability" whitelist="['associatedEntity']" />
+</p>
+
+<p>
+Setting `associatedEntity` to one of these values will affect which user CRUNCH grants the capability to. The default value is USER, so capabilities will be granted to the effective user if this is not set.
+
+<foam class="foam.flow.widgets.EnumSummary" of="foam.nanos.crunch.AssociatedEntity" />
+</p>
+
+<h2>Subclasses of Capability</h2>
+<foam class="foam.flow.widgets.DocumentationIncomplete" status="todo" isSection="true" />

--- a/src/files.js
+++ b/src/files.js
@@ -718,9 +718,12 @@ FOAM_FILES([
   { name: "foam/core/FObjectTest" },
 
   { name: "foam/flow/Document" },
+  { name: "foam/flow/DocumentMenu" },
   { name: "foam/flow/MarkupEditor" },
   { name: "foam/flow/DocumentationFolderDAO" },
   { name: "foam/flow/widgets/PropertyShortSummary" },
+  { name: "foam/flow/widgets/EnumSummary" },
+  { name: "foam/flow/widgets/DocumentationIncomplete" },
 
   { name: "org/chartjs/Lib" },
   { name: "org/chartjs/ChartCView" },

--- a/src/foam/flow/DocumentMenu.js
+++ b/src/foam/flow/DocumentMenu.js
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.flow',
+  name: 'DocumentMenu',
+  extends: 'foam.nanos.menu.Menu',
+
+  documentation: 'Psedo-menu to display all documents as sub-menus.',
+
+  implements: [ 'foam.mlang.Expressions' ],
+
+  requires: [
+    'foam.nanos.menu.DocumentFileMenu',
+    'foam.dao.ArrayDAO',
+    'foam.dao.PromisedDAO',
+    'foam.nanos.menu.Menu'
+  ],
+
+  imports: [ 'documentDAO' ],
+
+  properties: [
+    {
+      name: 'children_',
+      factory: function() {
+        var aDAO = this.ArrayDAO.create();
+        var pDAO = this.PromisedDAO.create();
+
+        this.documentDAO
+          .select((doc) => {
+            var menu = this.Menu.create({
+              id:     'document.' + doc.id,
+              // label:  doc.title,
+              label:  foam.String.labelize(doc.id),
+              parent: this.id,
+              handler: this.DocumentFileMenu.create({
+                docKey: doc.id,
+              })
+            });
+            aDAO.put(menu);
+        }).then(() => pDAO.promise.resolve(aDAO));
+
+        return pDAO;
+      }
+    },
+    {
+      name: 'children',
+      // Use getter instead of factory to have higher precedence
+      // than than 'children' factory from relationship
+      getter: function() { return this.children_; }
+    }
+  ]
+});
+

--- a/src/foam/flow/DocumentationFolderDAO.js
+++ b/src/foam/flow/DocumentationFolderDAO.js
@@ -33,8 +33,8 @@ foam.CLASS({
       javaType: 'foam.nanos.fs.Storage',
       javaFactory: `
 return new foam.nanos.fs.FallbackStorage(
-  new foam.nanos.fs.ResourceStorage("documents"),
-  new foam.nanos.fs.FileSystemStorage(System.getProperty("DOCUMENT_HOME"))
+  new foam.nanos.fs.FileSystemStorage(System.getProperty("DOCUMENT_HOME")),
+  new foam.nanos.fs.ResourceStorage("documents")
 );`
     }
   ],

--- a/src/foam/flow/widgets/DocumentationIncomplete.js
+++ b/src/foam/flow/widgets/DocumentationIncomplete.js
@@ -1,0 +1,62 @@
+foam.CLASS({
+  package: 'foam.flow.widgets',
+  name: 'DocumentationIncomplete',
+  extends: 'foam.u2.Element',
+
+  css: `
+    ^ {
+      padding: 10pt;
+    }
+    ^ > .cautionTape {
+      background-color: #e6e600;
+      padding: 8pt;
+      /*
+        transform: rotateZ(-4deg);
+
+        it was a fun idea, but not practical as it will overlap
+        other text at certain widths.
+      */
+      font-size: 14pt;
+      text-align: center;
+      pointer-events: none;
+      opacity: 0.9;
+    }
+  `,
+
+  properties: [
+    {
+      name: 'status',
+      class: 'String'
+    },
+    {
+      name: 'isSection',
+      class: 'Boolean'
+    },
+    {
+      name: 'message',
+      class: 'String',
+      expression: function (status, isSection) {
+        return 'This '
+          + (isSection ? 'section' : 'documentation') + ' '
+          + (status == 'todo'
+            ? 'has not been written yet'
+            : 'is incomplete'
+          )
+          + '.'
+          ;
+      }
+    }
+  ],
+
+  methods: [
+    function initE() {
+      this
+        .addClass(this.myClass())
+        .start()
+          .addClass('cautionTape')
+          .add(this.message$)
+        .end()
+        ;
+    }
+  ],
+});

--- a/src/foam/flow/widgets/DocumentationIncomplete.js
+++ b/src/foam/flow/widgets/DocumentationIncomplete.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 foam.CLASS({
   package: 'foam.flow.widgets',
   name: 'DocumentationIncomplete',

--- a/src/foam/flow/widgets/EnumSummary.js
+++ b/src/foam/flow/widgets/EnumSummary.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 foam.CLASS({
   package: 'foam.flow.widgets',
   name: 'EnumSummary',

--- a/src/foam/flow/widgets/EnumSummary.js
+++ b/src/foam/flow/widgets/EnumSummary.js
@@ -1,0 +1,45 @@
+foam.CLASS({
+  package: 'foam.flow.widgets',
+  name: 'EnumSummary',
+  extends: 'foam.u2.Element',
+  documentation: `
+    Brief summary of properties for overview documentation.
+  `,
+
+  properties: [
+    {
+      name: 'of',
+      class: 'Class'
+    },
+    {
+      name: 'whitelist',
+      class: 'StringArray'
+    }
+  ],
+
+  methods: [
+    function initE() {
+      var vals = this.of.VALUES;
+      if ( this.whitelist.length > 0 ) {
+        vals = vals.filter(ax => this.whitelist.includes(ax.name));
+      }
+
+      var self = this;
+      this
+        .start('table')
+          .start('tr')
+            .start('th').add('Name').end()
+            .start('th').add('Documentation').end()
+          .end()
+          .forEach(vals, function (ax) {
+            this
+              .start('tr')
+                .start('td').add(ax.name).end()
+                .start('td').add(ax.documentation).end()
+              .end()
+          })
+        .end()
+        ;
+    }
+  ],
+});

--- a/src/foam/flow/widgets/PropertyShortSummary.js
+++ b/src/foam/flow/widgets/PropertyShortSummary.js
@@ -24,21 +24,44 @@ foam.CLASS({
         props = props.filter(p => this.whitelist.includes(p.name));
       }
 
+      var self = this;
       this
         .start('table')
-          .start('th')
-            .start('td').add('Property').end()
-            .start('td').add('Property').end()
+          .start('tr')
+            .start('th').add('Property').end()
+            .start('th').add('Type').end()
+            .start('th').add('Documentation').end()
           .end()
           .forEach(props, function (p) {
             this
               .start('tr')
                 .start('td').add(p.name).end()
+                .start('td').add(self.toFriendlyType(p)).end()
                 .start('td').add(p.documentation).end()
               .end()
           })
         .end()
         ;
+    },
+    function toFriendlyType(p) {
+      var propCls = p.cls_.id;
+      const prefix = 'foam.core.';
+      if ( propCls.startsWith(prefix) ) {
+        propCls = propCls.slice(prefix.length);
+      }
+      if ( propCls == 'FObjectProperty' ) {
+        return 'FObject of ' + p.of.id;
+      }
+      if ( propCls == 'FObjectArray' ) {
+        return 'FObject[] of ' + p.of.id;
+      }
+      if ( propCls == 'Enum' ) {
+        return 'Enum of ' + p.of.id;
+      }
+      if ( propCls == 'foam.dao.DaoSpec' ) {
+        return 'DAO of ' + p.of.id;
+      }
+      return propCls;
     }
   ],
 });

--- a/src/foam/nanos/crunch/AssociatedEntity.js
+++ b/src/foam/nanos/crunch/AssociatedEntity.js
@@ -9,11 +9,17 @@ foam.ENUM({
     values: [
       {
         name: 'USER',
-        label: 'user'
+        label: 'user',
+        documentation: `
+          Associate capability junction with effective user
+        `
       },
       {
         name: 'REAL_USER',
-        label: 'realUser'
+        label: 'realUser',
+        documentation: `
+          Associate capability junction with logged-in user
+        `
       },
       {
         name: 'ACTING_USER',

--- a/src/foam/nanos/doc/DocumentationView.js
+++ b/src/foam/nanos/doc/DocumentationView.js
@@ -9,6 +9,27 @@ foam.CLASS({
   name: 'DocumentationView',
   extends: 'foam.u2.View',
 
+  css: `
+    ^ table { width: 100%; }
+    ^ td , ^ th {
+      text-align: left;
+      padding: 8pt;
+    }
+    ^ th {
+      font-weight: bold;
+      background-color: #E0E0E0;
+    }
+    ^ tr:nth-child(even) td:nth-child(odd) {
+      background-color: #F5F5F5;
+    }
+    ^ tr:nth-child(even) td:nth-child(even) {
+      background-color: #F0F0F0;
+    }
+    ^ tr:nth-child(odd) td:nth-child(even) {
+      background-color: #F7F7F7;
+    }
+  `,
+
   properties: [
     {
       class: 'String',
@@ -33,6 +54,7 @@ foam.CLASS({
   methods: [
     function initE() {
       var dao = this.__context__[this.daoKey];
+      this.addClass(this.myClass());
       if ( ! dao ) {
         this.add('No DAO found for key: ', this.daoKey);
       } else this.add(this.slot(function(data, error) {

--- a/src/foam/nanos/fs/FallbackStorage.java
+++ b/src/foam/nanos/fs/FallbackStorage.java
@@ -48,7 +48,11 @@ public class FallbackStorage implements Storage {
   public Set<String> getAvailableFiles(String name, String glob) {
     Set<String> paths = storage_.getAvailableFiles(name, glob);
     if ( paths == null ) return fallback_.getAvailableFiles(name, glob);
-    paths.addAll(fallback_.getAvailableFiles(name, glob));
+    try {
+      paths.addAll(fallback_.getAvailableFiles(name, glob));
+    } catch ( RuntimeException e ) {
+      // Fallback is allowed to fail in this case
+    }
     return paths;
   }
 }

--- a/src/menus
+++ b/src/menus
@@ -210,6 +210,7 @@ p({
   "parent":"integration"
 })
 p({"class":"foam.nanos.menu.Menu","id":"integration.model-doc","label":"UML API Models","handler":{"class":"foam.nanos.menu.ViewMenu","view":{"class":"foam.doc.ModelBrowser","allowedModels":{"net.nanopay.fx.afex.AFEXLog":true}}},"parent":"integration"})
+p({"class":"foam.flow.DocumentMenu","id":"admin.flowdoc","label":"FLOW Documents","handler":{"class":"foam.nanos.menu.ViewMenu","view":{"class":"foam.nanos.boot.DAOConfigSummaryView"}},"parent":"admin"})
 
 // settings
 p({"class":"foam.nanos.menu.Menu","id":"set-password","label":"Change Password","handler":{"class":"foam.nanos.menu.ViewMenu","view":{"class":"foam.nanos.auth.ChangePasswordView"}},"order":100,"parent":"settings"})

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -524,6 +524,7 @@ var classes = [
   'foam.nanos.dig.exception.AuthorizationException',
   'foam.flow.Document',
   'foam.flow.DocumentationFolderDAO',
+  'foam.flow.DocumentMenu',
 
   'foam.nanos.ruler.RuleGroup',
   'foam.nanos.ruler.Rule',


### PR DESCRIPTION
This PR adds the following changes:
- Add CRUNCH documentation
- Add a dynamic menu item for FLOW docs similar to the Data Management menu @kgrgreer added
- Fix accidental re-ordering of `storage` in DocumentationFolderDAO
- Add some u2 elements to render existing documentation from models
- Fix a bug that was preventing documents from loading outside of JAR builds

This PR can help with NP-509, NP-1781, and possibly other documentation-related tickets.