### PR TITLE
Fix Keyword predicate to check nested FObject

### DIFF
--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -2326,7 +2326,7 @@ foam.CLASS({
   properties: [
     {
       class: 'Boolean',
-      name: '_checkingNestedFObject',
+      name: 'checkingNestedFObject_',
       value: false,
       transient: true,
       visibility: 'HIDDEN',
@@ -2422,15 +2422,15 @@ return false;`
         { name: 'obj', type: 'Any' }
       ],
       code: function(obj) {
-        if ( obj === undefined || obj === null || this._checkingNestedFObject ) {
+        if ( obj === undefined || obj === null || this.checkingNestedFObject_ ) {
           return false;
         }
-        this._checkingNestedFObject = true;
+        this.checkingNestedFObject_ = true;
         return this.f(obj);
       },
       javaCode: `
-        if ( obj == null || get_checkingNestedFObject() ) return false;
-        set_checkingNestedFObject(true);
+        if ( obj == null || getCheckingNestedFObject_() ) return false;
+        setCheckingNestedFObject_(true);
         return this.f(obj);
       `
     },

--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -2330,7 +2330,7 @@ foam.CLASS({
         return this.fInner_(obj, true);
       },
       javaCode: `
-if ( ! ( getArg1().f(obj) instanceof String ) ) return false;
+if ( ! ( getArg1().f(obj) instanceof String ) || obj == null ) return false;
 
 String arg1 = ((String) getArg1().f(obj)).toUpperCase();
 List props = ((foam.core.FObject) obj).getClassInfo().getAxiomsByClass(PropertyInfo.class);

--- a/src/foam/mlang/mlang.js
+++ b/src/foam/mlang/mlang.js
@@ -2348,18 +2348,19 @@ foam.CLASS({
           const props = obj.cls_.getAxiomsByClass(foam.core.Property);
           for ( let i = 0; i < props.length; i++ ) {
             const prop = props[i];
-            if ( this.FObjectProperty.isInstance(prop) )
+            if ( this.FObjectProperty.isInstance(prop) ) {
               if ( this.checkNestedFObject(prop.f(obj)) ) return true;
-            else if ( this.Enum.isInstance(prop) )
+            } else if ( this.Enum.isInstance(prop) ) {
               s = prop.f(obj).label.toLowerCase();
-            else if ( this.Long.isInstance(prop) )
+            } else if ( this.Long.isInstance(prop) ) {
               s = prop.f(obj).toString().toLowerCase();
-            else if ( this.Date.isInstance(prop) )
+            } else if ( this.Date.isInstance(prop) ) {
               s = prop.f(obj).toISOString().toLowerCase();
-            else if ( ! this.String.isInstance(prop) )
-              continue
-            else
+            } else if ( ! this.String.isInstance(prop) ) {
+              continue;
+            } else {
               s = prop.f(obj).toLowerCase();
+            }
           }
 
           if ( s.toLowerCase().includes(arg) ) return true;


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-1688

## Changes
- Handle keyword searching only on the the first level of object's nested FObjectProperty