### PR TITLE
Define Wizardlets per capability

### DIFF
--- a/src/foam/nanos/crunch/Capability.js
+++ b/src/foam/nanos/crunch/Capability.js
@@ -236,6 +236,26 @@ foam.CLASS({
       javaFactory: `
         return foam.nanos.crunch.AssociatedEntity.USER;
       `
+    },
+    {
+      class: 'Object',
+      name: 'wizardlet',
+      documentation: `
+        Defines the wizardlet used when displaying capability on related wizards.
+      `,
+      factory: function() {
+        return foam.nanos.crunch.ui.CapabilityWizardlet.create({}, this);
+      }
+    },
+    {
+      class: 'Object',
+      name: 'wizardletConfig',
+      documentation: `
+        Configuration placed on top level capabilities which define various configuration options supported by client capability wizards.
+      `,
+      factory: function() {
+        return foam.u2.wizard.StepWizardConfig.create({}, this);
+      }
     }
   ],
 

--- a/src/foam/nanos/crunch/Capability.js
+++ b/src/foam/nanos/crunch/Capability.js
@@ -241,7 +241,7 @@ foam.CLASS({
       class: 'Object',
       name: 'wizardlet',
       documentation: `
-        Defines the wizardlet used when displaying capability on related wizards.
+        Defines a wizardlet used when displaying this capability on related client crunch wizards.
       `,
       factory: function() {
         return foam.nanos.crunch.ui.CapabilityWizardlet.create({}, this);
@@ -251,7 +251,7 @@ foam.CLASS({
       class: 'Object',
       name: 'wizardletConfig',
       documentation: `
-        Configuration placed on top level capabilities which define various configuration options supported by client capability wizards.
+        Configuration placed on top level capabilities defining various configuration options supported by client capability wizards.
       `,
       factory: function() {
         return foam.u2.wizard.StepWizardConfig.create({}, this);

--- a/src/foam/nanos/crunch/services.jrl
+++ b/src/foam/nanos/crunch/services.jrl
@@ -45,12 +45,7 @@ p({
       .setOf(foam.nanos.crunch.Capability.getOwnClassInfo())
       .build();
   """,
-  "client":"""
-    {
-      "of":"foam.nanos.crunch.Capability",
-      "cache":false
-    }
-  """
+  "client":"{\"of\":\"foam.nanos.crunch.Capability\"}"
 })
 
 p({

--- a/src/foam/nanos/crunch/services.jrl
+++ b/src/foam/nanos/crunch/services.jrl
@@ -45,7 +45,12 @@ p({
       .setOf(foam.nanos.crunch.Capability.getOwnClassInfo())
       .build();
   """,
-  "client":"{\"of\":\"foam.nanos.crunch.Capability\"}"
+  "client":"""
+    {
+      "of":"foam.nanos.crunch.Capability",
+      "cache":false
+    }
+  """
 })
 
 p({

--- a/src/foam/u2/crunch/CrunchController.js
+++ b/src/foam/u2/crunch/CrunchController.js
@@ -72,7 +72,7 @@ foam.CLASS({
             .filter(cap => !! cap.of )
             .map(cap => {
                 var associatedEntity = cap.associatedEntity === foam.nanos.crunch.AssociatedEntity.USER ? this.subject.user : this.subject.realUser;
-                var wizardlet = this.CapabilityWizardlet.create({ capability: cap });
+                var wizardlet = cap.wizardlet.cls_.create({ capability: cap, ...cap.wizardlet.instance_ }, this);
                 return this.updateUCJ(wizardlet, associatedEntity);
               })
             )
@@ -100,10 +100,13 @@ foam.CLASS({
 
     function generateAndDisplayWizard(capabilitiesSections) {
       // called in CapabilityRequirementView
+      let topCap = capabilitiesSections.caps[capabilitiesSections.caps.length - 1];
+      let config = topCap.wizardletConfig.cls_.create({ ...topCap.wizardletConfig.instance_ }, this);
       return ctrl.add(this.Popup.create({ closeable: false }).tag({
         class: 'foam.u2.wizard.StepWizardletView',
         data: foam.u2.wizard.StepWizardletController.create({
-          wizardlets: capabilitiesSections.wizCaps
+          wizardlets: capabilitiesSections.wizCaps,
+          config: config
         }),
         onClose: (x) => {
           this.finalOnClose(x, capabilitiesSections.caps);

--- a/src/foam/u2/wizard/StepWizardletController.js
+++ b/src/foam/u2/wizard/StepWizardletController.js
@@ -225,9 +225,6 @@ foam.CLASS({
   ],
 
   methods: [
-    function init() {
-      console.log('StepWizardletController', this);
-    },
     function saveProgress() {
       var p = Promise.resolve();
       return this.wizardlets.slice(0, this.highestIndex).reduce(

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -635,6 +635,7 @@ var classes = [
   'foam.nanos.crunch.RemoveJunctionsOnUserRemoval',
   'foam.nanos.crunch.CrunchService',
   'foam.nanos.crunch.ReputDependentUCJs',
+
   //ucjdao rules
   'foam.nanos.crunch.ruler.CheckUCJOwnershipOnPut',
   'foam.nanos.crunch.ruler.ValidateUCJDataOnPut',


### PR DESCRIPTION
Capabilities can define wizardlets and crunch wizard config used by client crunch wizards.

Use case:  Defining whether wizard can skip to other steps or disabling next button if cap props have satisfied validation predicates.