### PR TITLE
[NP-1875] Move reference to Capability from Theme

### DIFF
--- a/src/foam/nanos/crunch/Capability.js
+++ b/src/foam/nanos/crunch/Capability.js
@@ -344,6 +344,23 @@ foam.CLASS({
   sections: [{ name: 'capabilities' }]
 });
 
+foam.CLASS({
+  package: 'foam.nanos.crunch',
+  name: 'CRUNCHThemeRefinement',
+  refines: 'foam.nanos.theme.Theme',
+
+  properties: [
+    {
+      name: 'admissionCapability',
+      class: 'String',
+      // TODO: Why doesn't a Reference property work here?
+      // class: 'Reference',
+      of: 'foam.nanos.crunch.Capability',
+      documentation: 'Specifies the top-level capability that must be granted before we admit a user to the system.'
+    },
+  ],
+});
+
 foam.RELATIONSHIP({
   sourceModel: 'foam.nanos.crunch.Capability',
   targetModel: 'foam.nanos.crunch.Capability',

--- a/src/foam/nanos/theme/Theme.js
+++ b/src/foam/nanos/theme/Theme.js
@@ -120,12 +120,6 @@ foam.CLASS({
       },
     },
     {
-      name: 'admissionCapability',
-      class: 'Reference',
-      of: 'foam.nanos.crunch.Capability',
-      documentation: 'Specifies the top-level capability that must be granted before we admit a user to the system.'
-    },
-    {
       name: 'domains',
       class: 'Array',
       of: 'String',


### PR DESCRIPTION
This fixes an error message that's appearing in DocBrowser. Two changes were made:

1. Moved admissionCapability from Theme to a refinement in CRUNCH

    This may not be the root cause, but this change should be made anyway as referring to CRUNCH from Theme (which is loaded earlier) is incorrect.

2. Changed `Reference` property to `String`

    In spite of resolving the dependancy issue, an error still persists if `admissionCapability` is a Reference of foam.nanos.crunch.Capability when using `src/foam/doc/index.html`.