### PR TITLE
[DO_NOT_MERGE] Added configure to AuthWebAgent to set the proper SPID

### DIFF
--- a/src/foam/box/SessionServerBox.java
+++ b/src/foam/box/SessionServerBox.java
@@ -100,6 +100,7 @@ public class SessionServerBox
 
       // Make context available to thread-local XLocator
       XLocator.set(effectiveContext);
+      session.setContext(effectiveContext);
 
       session.touch();
 

--- a/src/foam/nanos/http/AuthWebAgent.java
+++ b/src/foam/nanos/http/AuthWebAgent.java
@@ -69,6 +69,8 @@ public class AuthWebAgent
       .put(HttpServletResponse.class, x.get(HttpServletResponse.class))
       .put(PrintWriter.class,         x.get(PrintWriter.class));
 
+    requestX = requestX.put("appConfig", ((AppConfig) requestX.get("appConfig")).configure(requestX, null));
+
     try {
       XLocator.set(requestX);
       super.execute(requestX);

--- a/src/foam/nanos/http/AuthWebAgent.java
+++ b/src/foam/nanos/http/AuthWebAgent.java
@@ -68,9 +68,7 @@ public class AuthWebAgent
       .put(HttpServletRequest.class,  x.get(HttpServletRequest.class))
       .put(HttpServletResponse.class, x.get(HttpServletResponse.class))
       .put(PrintWriter.class,         x.get(PrintWriter.class));
-
-    requestX = requestX.put("appConfig", ((AppConfig) requestX.get("appConfig")).configure(requestX, null));
-
+    
     try {
       XLocator.set(requestX);
       super.execute(requestX);


### PR DESCRIPTION
AppConfig configure doesn't occur on DIG calls, this leads to the URL not being set properly (ie. somehost:8080 shows up as localhost:8080).

Adding configure to AuthWebAgent seems to fix the problems, although I'm not sure if it's the best place to put it.