### PR TITLE
Fixed ConnectedCapability bug and had to change from FObjectArray to Array

### DIFF
--- a/src/foam/nanos/crunch/connection/ConnectedCapability.js
+++ b/src/foam/nanos/crunch/connection/ConnectedCapability.js
@@ -38,8 +38,7 @@ foam.CLASS({
     },
     {
       name: 'data',
-      class: 'FObjectArray',
-      of: 'foam.core.FObject',
+      class: 'Array',
       documentation: `
         Data objects corresponding to 'classes' of the FlatCapability.
         A RuntimeException is thrown if the array length doesn't match or

--- a/src/foam/nanos/crunch/connection/ConnectedCapabilityDAO.js
+++ b/src/foam/nanos/crunch/connection/ConnectedCapabilityDAO.js
@@ -53,7 +53,7 @@ foam.CLASS({
 
         // First pass: validate types provided
         int index = 0;
-        for ( var data : flatData ) {
+        for ( Object data : flatData ) {
           // Skip capability where 'of' property is empty
           while ( index < classes.length && SafetyUtil.isEmpty(classes[index]) ) {
             index++;


### PR DESCRIPTION
Tested:
1. Creating a FlatCapability and setting FlatCapability.targetCapabilityId with a valid capability id works, then  after putting into the FlatCapabilityDAO the FlatCapability.classes and FlatCapability.capabilities properties populate as expected and no entries in the UCJ exist at this point
2. Creating a ConnectedCapability, setting the ConnectedCapability.flatCapability property to the flat capability defined above, and setting ConnectedCapability.data to an array of size n - s, where n is the number of capabilities and s is the number  of capabilities with a null of (essentially in order of classes but we exclude null of's), successfully putting into the ConnectedCapabilityDAO updates the ucjDAO as expected with the the capability from FlatCapability.targetCapabilityId, in addition to all of that target capability's prerequisites

@jlhughes @KernelDeimos @nanoscott 

