### PR TITLE
[NP-1834] Add server implementation for Capable

### DIFF
--- a/src/foam/nanos/crunch/CrunchService.js
+++ b/src/foam/nanos/crunch/CrunchService.js
@@ -33,6 +33,52 @@ foam.INTERFACE({
       ]
     },
     {
+      name: 'getCapabilityPath',
+      documentation: `
+        getGrantPath provides an array of capability objects representing
+        the list of capabilities required to grant the desired capability.
+      `,
+      async: true,
+      type: 'List',
+      args: [
+        {
+          name: 'x',
+          type: 'Context'
+        },
+        {
+          name: 'sourceId',
+          type: 'String'
+        },
+        {
+          name: 'filterGrantedUCJ',
+          type: 'boolean'
+        }
+      ]
+    },
+    {
+      name: 'getMultipleCapabilityPath',
+      documentation: `
+        getGrantPath provides an array of capability objects representing
+        the list of capabilities required to grant the desired capability.
+      `,
+      async: true,
+      type: 'List',
+      args: [
+        {
+          name: 'x',
+          type: 'Context'
+        },
+        {
+          name: 'capabilities',
+          type: 'String[]'
+        },
+        {
+          name: 'filterGrantedUCJ',
+          type: 'boolean'
+        }
+      ]
+    },
+    {
       name: 'getJunction',
       documentation: `
         getJunction provides the correct UserCapabilityJunction based on the

--- a/src/foam/nanos/crunch/CrunchService.js
+++ b/src/foam/nanos/crunch/CrunchService.js
@@ -69,7 +69,7 @@ foam.INTERFACE({
           type: 'Context'
         },
         {
-          name: 'capabilities',
+          name: 'capabilityIds',
           type: 'String[]'
         },
         {

--- a/src/foam/nanos/crunch/ServerCrunchService.java
+++ b/src/foam/nanos/crunch/ServerCrunchService.java
@@ -17,12 +17,18 @@ import foam.nanos.logger.Logger;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.Queue;
 import static foam.mlang.MLang.*;
 
 public class ServerCrunchService implements CrunchService {
   public List getGrantPath(X x, String rootId) {
+    return getCapabilityPath(x, rootId, true);
+  }
+
+  public List getCapabilityPath(X x, String rootId, boolean filterGrantedUCJ) {
     Logger logger = (Logger) x.get("logger");
 
     DAO prerequisiteDAO = (DAO) x.get("prerequisiteCapabilityJunctionDAO");
@@ -48,9 +54,11 @@ public class ServerCrunchService implements CrunchService {
     while ( nextSources.size() > 0 ) {
       String sourceCapabilityId = nextSources.poll();
 
-      UserCapabilityJunction ucj = crunchService.getJunction(x, sourceCapabilityId);
-      if ( ucj != null && ucj.getStatus() == CapabilityJunctionStatus.GRANTED ) {
-        continue;
+      if ( ! filterGrantedUCJ ) {
+        UserCapabilityJunction ucj = crunchService.getJunction(x, sourceCapabilityId);
+        if ( ucj != null && ucj.getStatus() == CapabilityJunctionStatus.GRANTED ) {
+          continue;
+        }
       }
 
       if ( alreadyListed.contains(sourceCapabilityId) ) continue;
@@ -76,6 +84,32 @@ public class ServerCrunchService implements CrunchService {
 
     Collections.reverse(grantPath);
     return grantPath;
+  }
+
+  // Return capability path for multiple prerequisites without duplicates.
+  public List getMultipleCapabilityPath(
+    X x, String[] capabilities, boolean filterGrantedUCJ
+  ) {
+    Set alreadyListed = new HashSet<String>();
+
+    List multiplePath = new ArrayList();
+
+    for ( String capId : capabilities ) {
+      List crunchyPath = getCapabilityPath(x, capId, filterGrantedUCJ);
+      for ( Object obj : crunchyPath ) {
+        Capability cap = null;
+        if ( obj instanceof List ) {
+          List list = (List) obj;
+          cap = (Capability) list.get(list.size() - 1);
+        } else {
+          cap = (Capability) obj;
+        }
+        if ( alreadyListed.contains(cap.getId()) ) continue;
+        multiplePath.add(obj);
+      }
+    }
+
+    return multiplePath;
   }
 
   public UserCapabilityJunction getJunction(X x, String capabilityId) {

--- a/src/foam/nanos/crunch/ServerCrunchService.java
+++ b/src/foam/nanos/crunch/ServerCrunchService.java
@@ -88,13 +88,13 @@ public class ServerCrunchService implements CrunchService {
 
   // Return capability path for multiple prerequisites without duplicates.
   public List getMultipleCapabilityPath(
-    X x, String[] capabilities, boolean filterGrantedUCJ
+    X x, String[] capabilityIds, boolean filterGrantedUCJ
   ) {
     Set alreadyListed = new HashSet<String>();
 
     List multiplePath = new ArrayList();
 
-    for ( String capId : capabilities ) {
+    for ( String capId : capabilityIds ) {
       List crunchyPath = getCapabilityPath(x, capId, filterGrantedUCJ);
       for ( Object obj : crunchyPath ) {
         Capability cap = null;

--- a/src/foam/nanos/crunch/lite/Capable.js
+++ b/src/foam/nanos/crunch/lite/Capable.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 foam.INTERFACE({
   package: 'foam.nanos.crunch.lite',
   name: 'Capable',

--- a/src/foam/nanos/crunch/lite/Capable.js
+++ b/src/foam/nanos/crunch/lite/Capable.js
@@ -1,0 +1,150 @@
+foam.INTERFACE({
+  package: 'foam.nanos.crunch.lite',
+  name: 'Capable',
+  documentation: `
+    Capable is an interface for binding capability payloads to an object rather
+    than associating them with a user.
+  `,
+
+  javaImports: [
+    'foam.core.FObject',
+    'foam.core.Validator',
+    'foam.core.X',
+    'foam.nanos.crunch.Capability',
+    'foam.nanos.crunch.CrunchService',
+    'java.util.ArrayList',
+    'java.util.HashMap',
+    'java.util.HashSet',
+    'java.util.List',
+    'java.util.Map',
+    'java.util.Set',
+  ],
+
+  axioms: [
+    {
+      name: 'javaExtras',
+      buildJavaClass: function(cls) {
+        cls.methods.push(foam.java.Method.create({
+          name: 'setRequirements',
+          type: 'void',
+          visibility: 'default',
+          args: [
+            { name: 'x', type: 'X' },
+            { name: 'capabilities', type: 'String[]' }
+          ],
+          body: `
+            List<CapablePayload> payloads = new ArrayList<>();
+
+            CrunchService crunchService = (CrunchService) x.get("crunchService");
+            List crunchPath = crunchService.getMultipleCapabilityPath(
+              x, capabilities, false);
+
+            for ( Object obj : crunchPath ) {
+              if ( ! (obj instanceof Capability) ) {
+                // Lists correspond to capabilities with their own prerequisite
+                // logic, such as MinMaxCapability. Clients will need to be
+                // made aware of these capabilities separately.
+                if ( obj instanceof List ) {
+                  List list = (List) obj;
+
+                  // Add payload object prerequisites
+                  List prereqs = new ArrayList();
+                  for ( int i = 0 ; i < list.size() - 1 ; i++ ) {
+                    Capability prereqCap = (Capability) list.get(i);
+                    list.add(new CapablePayload.Builder(x)
+                      .setCapabilityId(prereqCap.getId())
+                      .build());
+                  }
+
+                  // Add payload object
+                  /* TODO: Figure out why this is an error when adding
+                           support for MinMaxCapability
+                  Capability cap = (Capability) list.get(list.size() - 1);
+                  payloads.add(new CapablePayload.Builder(x)
+                    .setCapabilityId(cap.getId())
+                    .setPrerequisites(prereqs.toArray(
+                      new CapablePayload[list.size()]))
+                    .build());
+                  */
+                  continue;
+                }
+
+                throw new RuntimeException(
+                  "Expected capability or list");
+              }
+              Capability cap = (Capability) obj;
+              payloads.add(new CapablePayload.Builder(x)
+                .setCapabilityId(cap.getId())
+                .build());
+            }
+            
+            // Re-FObjectArray
+            setCapabilityPayloads(payloads.toArray(
+              new CapablePayload[payloads.size()]
+            ));
+          `
+        }));
+        cls.methods.push(foam.java.Method.create({
+          name: 'verifyRequirements',
+          type: 'boolean',
+          visibility: 'default',
+          type: 'void',
+          javaThrows: [ 'IllegalStateException' ],
+          args: [
+            { name: 'x', type: 'X' },
+            { name: 'capabilities', type: 'String[]' }
+          ],
+          body: `
+            // Marshal payloads into a hashmap
+            Map<String, FObject> payloads = new HashMap<String, FObject>();
+            for ( CapablePayload payload : getCapabilityPayloads() ) {
+              payloads.put(payload.getCapabilityId(), (FObject) payload.getData());
+            }
+
+            CrunchService crunchService = (CrunchService) x.get("crunchService");
+            List crunchPath = crunchService.getMultipleCapabilityPath(
+              x, capabilities, false);
+
+            for ( Object obj : crunchPath ) {
+              if ( ! (obj instanceof Capability) ) {
+                // TODO: Implement logic for sub-lists (MinMaxCapability)
+                throw new RuntimeException("TODO");
+              }
+              Capability cap = (Capability) obj;
+              if ( cap.getOf() == null ) continue;
+
+              if ( ! payloads.containsKey(cap.getId()) ) {
+                throw new IllegalStateException(String.format(
+                  "Missing payload object for capability '%s'",
+                  cap.getId()
+                ));
+              }
+
+              FObject dataObject = payloads.get(cap.getId());
+              if ( dataObject instanceof Validator ) {
+                Validator validator = (Validator) dataObject;
+                validator.validate(x, dataObject);
+              }
+            }
+          `
+        }));
+      }
+    },
+  ],
+
+  methods: [
+    {
+      name: 'getCapabilityPayloads',
+      type: 'CapablePayload[]'
+    },
+    {
+      name: 'setCapabilityPayloads',
+      args: [
+        {
+          name: 'payloads',
+          type: 'CapablePayload[]'
+        }
+      ]
+    }
+  ],
+});

--- a/src/foam/nanos/crunch/lite/Capable.js
+++ b/src/foam/nanos/crunch/lite/Capable.js
@@ -36,18 +36,18 @@ foam.INTERFACE({
           visibility: 'default',
           args: [
             { name: 'x', type: 'X' },
-            { name: 'capabilities', type: 'String[]' }
+            { name: 'capabilityIds', type: 'String[]' }
           ],
           body: `
             List<CapablePayload> payloads = new ArrayList<>();
 
             CrunchService crunchService = (CrunchService) x.get("crunchService");
             List crunchPath = crunchService.getMultipleCapabilityPath(
-              x, capabilities, false);
+              x, capabilityIds, false);
 
             for ( Object obj : crunchPath ) {
               if ( ! (obj instanceof Capability) ) {
-                // Lists correspond to capabilities with their own prerequisite
+                // Lists correspond to capabilityIds with their own prerequisite
                 // logic, such as MinMaxCapability. Clients will need to be
                 // made aware of these capabilities separately.
                 if ( obj instanceof List ) {
@@ -98,7 +98,7 @@ foam.INTERFACE({
           javaThrows: [ 'IllegalStateException' ],
           args: [
             { name: 'x', type: 'X' },
-            { name: 'capabilities', type: 'String[]' }
+            { name: 'capabilityIds', type: 'String[]' }
           ],
           body: `
             // Marshal payloads into a hashmap
@@ -109,7 +109,7 @@ foam.INTERFACE({
 
             CrunchService crunchService = (CrunchService) x.get("crunchService");
             List crunchPath = crunchService.getMultipleCapabilityPath(
-              x, capabilities, false);
+              x, capabilityIds, false);
 
             for ( Object obj : crunchPath ) {
               if ( ! (obj instanceof Capability) ) {

--- a/src/foam/nanos/crunch/lite/CapableObjectData.js
+++ b/src/foam/nanos/crunch/lite/CapableObjectData.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 foam.CLASS({
   package: 'foam.nanos.crunch.lite',
   name: 'CapableObjectData',

--- a/src/foam/nanos/crunch/lite/CapableObjectData.js
+++ b/src/foam/nanos/crunch/lite/CapableObjectData.js
@@ -1,0 +1,13 @@
+foam.CLASS({
+  package: 'foam.nanos.crunch.lite',
+  name: 'CapableObjectData',
+
+  properties: [
+    {
+      name: 'capablePayloads',
+      class: 'FObjectArray',
+      // javaType: 'java.util.List<foam.nanos.crunch.crunchlite.CapablePayload>',
+      of: 'foam.nanos.crunch.lite.CapablePayload'
+    }
+  ],
+});

--- a/src/foam/nanos/crunch/lite/CapablePayload.js
+++ b/src/foam/nanos/crunch/lite/CapablePayload.js
@@ -1,0 +1,56 @@
+foam.CLASS({
+  package: 'foam.nanos.crunch.lite',
+  name: 'CapablePayload',
+  documentation: `
+    Composite object containing a capability ID and an instance of
+    payload data. This is similar to a UserCapabilityJunction, but
+    it is not associated with a user and has less features.
+  `,
+
+  javaImports: [
+    'foam.core.Validator'
+  ],
+
+  implements: [
+    'foam.core.Validator'
+  ],
+
+  properties: [
+    {
+      name: 'capabilityId',
+      class: 'String'
+    },
+    {
+      name: 'data',
+      class: 'FObjectProperty'
+    },
+    {
+      name: 'prerequisites',
+      class: 'FObjectArray',
+      of: 'CapablePayload',
+      documentation: `
+        Specifies prerequisites that were not present in the higher-level
+        capability path, for example options for a MinMaxCapability.
+
+        To save data to one of these payloads, clone it and add it to the
+        parent-most list of CapablePayload objects. The validator will not
+        recurse into this list because these payloads may be conditionally
+        applicable.
+      `,
+      javaFactory: `
+        return null;
+      `
+    }
+  ],
+
+  methods: [
+    {
+      name: 'validate',
+      javaCode: `
+        // TODO: Unsure about this; somebody should verify
+        Validator validator = (Validator) getData();
+        validator.validate(x, getData());
+      `,
+    }
+  ],
+});

--- a/src/foam/nanos/crunch/lite/CapablePayload.js
+++ b/src/foam/nanos/crunch/lite/CapablePayload.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 foam.CLASS({
   package: 'foam.nanos.crunch.lite',
   name: 'CapablePayload',

--- a/src/foam/nanos/crunch/ui/CapableObjectWizardlet.js
+++ b/src/foam/nanos/crunch/ui/CapableObjectWizardlet.js
@@ -27,7 +27,7 @@ foam.CLASS({
     {
       name: 'targetObject',
       class: 'FObjectProperty',
-      of: 'foam.nanos.crunch.Capable'
+      of: 'foam.nanos.crunch.lite.Capable'
     },
 
     // Properties for WizardSection interface
@@ -43,11 +43,7 @@ foam.CLASS({
       factory: function () {
         if ( ! this.of ) return null;
 
-        var ret = this.of.create({}, this);
-        if ( this.ucj === null ) return ret;
-      
-        ret = Object.assign(ret, this.ucj.data);
-        return ret;
+        return this.of.create({}, this);
       }
     },
     {
@@ -61,8 +57,8 @@ foam.CLASS({
   methods: [
     {
       name: 'save',
+      // TODO: implement capable save for client
       code: function() {
-        return this.crunchController.save(this);
       }
     }
   ]

--- a/src/foam/nanos/crunch/ui/CapableObjectWizardlet.js
+++ b/src/foam/nanos/crunch/ui/CapableObjectWizardlet.js
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+foam.CLASS({
+  package: 'foam.nanos.crunch.ui',
+  name: 'CapableObjectWizardlet',
+  extends: 'foam.u2.wizard.BaseWizardlet',
+
+  imports: [
+    'crunchController'
+  ],
+
+  requires: [
+    'foam.core.Action',
+    'foam.core.Property',
+    'foam.layout.Section',
+    'foam.layout.SectionAxiom'
+  ],
+
+  properties: [
+    // Properties specific to CapabilityWizardSection
+    {
+      name: 'capability'
+    },
+    {
+      name: 'targetObject',
+      class: 'FObjectProperty',
+      of: 'foam.nanos.crunch.Capable'
+    },
+
+    // Properties for WizardSection interface
+    {
+      name: 'of',
+      class: 'Class',
+      expression: function (capability) {
+        return capability.of;
+      }
+    },
+    {
+      name: 'data',
+      factory: function () {
+        if ( ! this.of ) return null;
+
+        var ret = this.of.create({}, this);
+        if ( this.ucj === null ) return ret;
+      
+        ret = Object.assign(ret, this.ucj.data);
+        return ret;
+      }
+    },
+    {
+      name: 'title',
+      expression: function(capability) {
+        return capability.name;
+      }
+    }
+  ],
+
+  methods: [
+    {
+      name: 'save',
+      code: function() {
+        return this.crunchController.save(this);
+      }
+    }
+  ]
+});
+

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -327,6 +327,9 @@ FOAM_FILES([
   { name: "foam/nanos/crunch/crunchtest/FakeTestObject" },
   // models
   { name: "foam/nanos/crunch/Capability" },
+  { name: "foam/nanos/crunch/lite/CapablePayload" },
+  { name: "foam/nanos/crunch/lite/CapableObjectData" },
+  { name: "foam/nanos/crunch/lite/Capable" },
   { name: "foam/nanos/crunch/CapabilityCategory" },
   { name: "foam/nanos/crunch/CapabilityJunctionStatus" },
   { name: "foam/nanos/crunch/UserCapabilityJunctionRefine" },

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -624,6 +624,8 @@ var classes = [
   'foam.nanos.crunch.crunchtest.FakeTestObject',
   //models
   'foam.nanos.crunch.Capability',
+  'foam.nanos.crunch.lite.Capable',
+  'foam.nanos.crunch.lite.CapablePayload',
   'foam.nanos.crunch.CapabilityCategory',
   'foam.nanos.crunch.CapabilityCategoryCapabilityJunction',
   'foam.nanos.crunch.CapabilityJunctionStatus',


### PR DESCRIPTION
I haven't included a property for UCJ capability requirements yet as I'm thinking there may be a better place for it. We can add a property to CapabilityRuntimeException for Capable objects and handle them as an ordinary intercept situation, with potentially minor changes to CrunchController to iterate over the Capables and create CapableCapabilityWizardlets