### PR TITLE
[DO_NOT_MERGE] [NP-1916] Simplify UCJ status checks

### DIFF
--- a/src/foam/nanos/crunch/BasicCapabilityJunctionStatus.js
+++ b/src/foam/nanos/crunch/BasicCapabilityJunctionStatus.js
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+foam.ENUM({
+  package: 'foam.nanos.crunch',
+  name: 'BasicCapabilityJunctionStatus',
+
+  documentation: `
+    Represents a subset of values for CapabilityJunctionStatus which the
+    complete set of values can be reduced to.
+
+    This can simplify status checks when, for example, you want to know
+    if a capability is effectively granted but don't need to know the
+    exact status.
+  `,
+
+  values: [
+    {
+      name: 'PENDING',
+      label: 'pending',
+      documentation: `This is for capabilities that are waiting verification. Capability access may take upto 24hrs.`,
+      background: '#bfae32'
+    },
+    {
+      name: 'GRANTED',
+      label: 'granted',
+      documentation: `This is for capabilities that have passed all checks. Capabilities in this status have their features unlocked.`,
+      background: '#32bf5e'
+    },
+    {
+      name: 'EXPIRED',
+      label: 'expired',
+      documentation: `A capability can expire due to a number of factors. The data that was previously collected will be removed or reset and must be re-added or re-approved to gain access.`,
+      background: '#bf3232'
+    },
+    {
+      name: 'AVAILABLE',
+      label: 'available',
+      documentation: `This status is used when a capability has had no previous actions and is accessible if you so choose.`,
+      background: '#604aff'
+    },
+  ]
+});

--- a/src/foam/nanos/crunch/CapabilityJunctionStatus.js
+++ b/src/foam/nanos/crunch/CapabilityJunctionStatus.js
@@ -6,49 +6,65 @@
 foam.ENUM({
   package: 'foam.nanos.crunch',
   name: 'CapabilityJunctionStatus',
+
+  properties: [
+    {
+      name: 'basicStatus',
+      class: 'Enum',
+      of: 'foam.nanos.crunch.BasicCapabilityJunctionStatus'
+    }
+  ],
+
   values: [
     {
       name: 'PENDING',
       label: 'pending',
       documentation: `This is for capabilities that are waiting verification. Capability access may take upto 24hrs.`,
-      background: '#bfae32'
+      background: '#bfae32',
+      broadStatus: 'PENDING'
     },
     {
       name: 'GRANTED',
       label: 'granted',
       documentation: `This is for capabilities that have passed all checks. Capabilities in this status have their features unlocked.`,
-      background: '#32bf5e'
+      background: '#32bf5e',
+      broadStatus: 'GRANTED'
     },
     {
       name: 'EXPIRED',
       label: 'expired',
       documentation: `A capability can expire due to a number of factors. The data that was previously collected will be removed or reset and must be re-added or re-approved to gain access.`,
-      background: '#bf3232'
+      background: '#bf3232',
+      broadStatus: 'EXPIRED'
     },
     {
       name: 'ACTION_REQUIRED',
       label: 'action required',
       documentation: `A capability started and requires further action to complete.`,
-      background: '#cf6f0a'
+      background: '#cf6f0a',
+      broadStatus: 'AVAILABLE'
     },
     {
       name: 'AVAILABLE',
       label: 'available',
       documentation: `This status is used when a capability has had no previous actions and is accessible if you so choose.`,
-      background: '#604aff'
+      background: '#604aff',
+      broadStatus: 'AVAILABLE'
     },
     {
       name: 'GRACE_PERIOD',
       label: 'grace period',
       documentation: `This status is used when a capability is expired, but for your benefit we allow a certian set of days to continue accessing the features that are unlocked by this capability.`,
-      background: 'grey'
+      background: 'grey',
+      broadStatus: 'GRANTED'
     },
     {
       name: 'APPROVED',
       label: 'approved',
       documentation: `- not seen by users - Denoting a UCJ requiring review has been approved. It would need to go through the rules of the ucjDAO before 
       being set to granted.`,
-      background: '#bfae32'
+      background: '#bfae32',
+      broadStatus: 'PENDING'
     }
   ]
 });

--- a/src/foam/nanos/crunch/CapabilityJunctionStatus.js
+++ b/src/foam/nanos/crunch/CapabilityJunctionStatus.js
@@ -21,42 +21,42 @@ foam.ENUM({
       label: 'pending',
       documentation: `This is for capabilities that are waiting verification. Capability access may take upto 24hrs.`,
       background: '#bfae32',
-      broadStatus: 'PENDING'
+      basicStatus: 'PENDING'
     },
     {
       name: 'GRANTED',
       label: 'granted',
       documentation: `This is for capabilities that have passed all checks. Capabilities in this status have their features unlocked.`,
       background: '#32bf5e',
-      broadStatus: 'GRANTED'
+      basicStatus: 'GRANTED'
     },
     {
       name: 'EXPIRED',
       label: 'expired',
       documentation: `A capability can expire due to a number of factors. The data that was previously collected will be removed or reset and must be re-added or re-approved to gain access.`,
       background: '#bf3232',
-      broadStatus: 'EXPIRED'
+      basicStatus: 'EXPIRED'
     },
     {
       name: 'ACTION_REQUIRED',
       label: 'action required',
       documentation: `A capability started and requires further action to complete.`,
       background: '#cf6f0a',
-      broadStatus: 'AVAILABLE'
+      basicStatus: 'AVAILABLE'
     },
     {
       name: 'AVAILABLE',
       label: 'available',
       documentation: `This status is used when a capability has had no previous actions and is accessible if you so choose.`,
       background: '#604aff',
-      broadStatus: 'AVAILABLE'
+      basicStatus: 'AVAILABLE'
     },
     {
       name: 'GRACE_PERIOD',
       label: 'grace period',
       documentation: `This status is used when a capability is expired, but for your benefit we allow a certian set of days to continue accessing the features that are unlocked by this capability.`,
       background: 'grey',
-      broadStatus: 'GRANTED'
+      basicStatus: 'GRANTED'
     },
     {
       name: 'APPROVED',
@@ -64,7 +64,7 @@ foam.ENUM({
       documentation: `- not seen by users - Denoting a UCJ requiring review has been approved. It would need to go through the rules of the ucjDAO before 
       being set to granted.`,
       background: '#bfae32',
-      broadStatus: 'PENDING'
+      basicStatus: 'PENDING'
     }
   ]
 });

--- a/src/foam/nanos/crunch/ServerCrunchService.java
+++ b/src/foam/nanos/crunch/ServerCrunchService.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.Queue;
 import static foam.mlang.MLang.*;
+import static foam.nanos.crunch.CapabilityJunctionStatus.*;
 
 public class ServerCrunchService implements CrunchService {
   public List getGrantPath(X x, String rootId) {
@@ -56,7 +57,7 @@ public class ServerCrunchService implements CrunchService {
 
       if ( ! filterGrantedUCJ ) {
         UserCapabilityJunction ucj = crunchService.getJunction(x, sourceCapabilityId);
-        if ( ucj != null && ucj.getStatus() == CapabilityJunctionStatus.GRANTED ) {
+        if ( ucj != null && ucj.isBasically(GRANTED) ) {
           continue;
         }
       }

--- a/src/foam/nanos/crunch/UserCapabilityJunctionRefine.js
+++ b/src/foam/nanos/crunch/UserCapabilityJunctionRefine.js
@@ -170,6 +170,32 @@ foam.CLASS({
 
         return objectToSave;
       `
+    },
+    {
+      name: 'isBasically',
+      type: 'boolean',
+      args: [
+        {
+          name: 'status',
+          type: 'CapabilityJunctionStatus'
+        }
+      ],
+      javaCode: `
+        return getStatus().getBasicStatus() == status.getBasicStatus();
+      `,
+    },
+    {
+      name: 'isReally',
+      type: 'boolean',
+      args: [
+        {
+          name: 'status',
+          type: 'CapabilityJunctionStatus'
+        }
+      ],
+      javaCode: `
+        return getStatus() == status;
+      `,
     }
   ]
 });

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -331,6 +331,7 @@ FOAM_FILES([
   { name: "foam/nanos/crunch/lite/CapableObjectData" },
   { name: "foam/nanos/crunch/lite/Capable" },
   { name: "foam/nanos/crunch/CapabilityCategory" },
+  { name: "foam/nanos/crunch/BasicCapabilityJunctionStatus" },
   { name: "foam/nanos/crunch/CapabilityJunctionStatus" },
   { name: "foam/nanos/crunch/UserCapabilityJunctionRefine" },
   { name: "foam/nanos/crunch/CapabilityCapabilityJunctionRefine" },

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -628,6 +628,7 @@ var classes = [
   'foam.nanos.crunch.lite.CapablePayload',
   'foam.nanos.crunch.CapabilityCategory',
   'foam.nanos.crunch.CapabilityCategoryCapabilityJunction',
+  'foam.nanos.crunch.BasicCapabilityJunctionStatus',
   'foam.nanos.crunch.CapabilityJunctionStatus',
   'foam.nanos.crunch.UserCapabilityJunction',
   'foam.nanos.crunch.AgentCapabilityJunction',


### PR DESCRIPTION
This PR adds a BasicCapabilityJunctionStatus. This makes it possible to add statuses for edge cases without updating lots of rules. Additionally, this fixes a bug in CrunchService caused by only checking `GRANTED` status without checking `GRACE_PERIOD` (which is effectively granted); this also serves as an example of using this new status.

Credit to @noodlemoodle for coming up with the idea and @kgrgreer for showing me an easy way to implement it.