### PR TITLE
Fix group implies throwing exception

### DIFF
--- a/src/foam/nanos/auth/Group.js
+++ b/src/foam/nanos/auth/Group.js
@@ -161,9 +161,16 @@ foam.CLASS({
         }
       ],
       javaCode: `
-        List<GroupPermissionJunction> junctions = ((ArraySink) getPermissions(x).getJunctionDAO().where(EQ(GroupPermissionJunction.SOURCE_ID, getId())).select(new ArraySink())).getArray();
+        List<GroupPermissionJunction> junctions = ((ArraySink) getPermissions(x)
+          .getJunctionDAO()
+            .where(EQ(GroupPermissionJunction.SOURCE_ID, getId()))
+            .select(new ArraySink())).getArray();
 
         for ( GroupPermissionJunction j : junctions ) {
+          if ( j.getTargetId().isBlank() ) {
+            continue;
+          }
+
           if ( j.getTargetId().startsWith("@") ) {
             DAO   dao   = (DAO) x.get("groupDAO");
             Group group = (Group) dao.find(j.getTargetId().substring(1));


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-1593

## Issues
- Blank permission id on groupPermissionJunction would cause AuthPermission.implies to throw IllegalArgumentException in `Group.implies` call.

## Changes
- Check and skip group permission junction entry where permission id is blank

## Stacktrace
```
ERROR,[Service],groupDAO,AAC Admin (8026),check,("javax.security.auth.AuthPermission" "service.groupDAO"),java.lang.IllegalArgumentException: name can't be empty
	at java.base/java.security.BasicPermission.init(BasicPermission.java:93)
	at java.base/java.security.BasicPermission.<init>(BasicPermission.java:130)
	at java.base/javax.security.auth.AuthPermission.<init>(AuthPermission.java:146)
	at foam.nanos.auth.Group.implies(Group.java:1306)
	at foam.nanos.auth.UserAndGroupAuthService.check(UserAndGroupAuthService.java:414)
	at foam.nanos.auth.CapabilityAuthService.check(CapabilityAuthService.java:330)
	at net.nanopay.meter.compliance.ComplianceAuthService.check(ComplianceAuthService.java:129)
	at foam.nanos.auth.CachingAuthService.check(CachingAuthService.java:153)
	at foam.nanos.auth.ProxyAuthService.check(ProxyAuthService.java:376)
	at foam.nanos.auth.EnabledCheckAuthService.check(EnabledCheckAuthService.java:66)
	at foam.nanos.auth.ProxyAuthService.check(ProxyAuthService.java:376)
	at foam.nanos.auth.ProxyAuthService.check(ProxyAuthService.java:376)
	at foam.nanos.auth.ProxyAuthService.check(ProxyAuthService.java:376)
	at foam.nanos.auth.twofactor.TwoFactorAuthService.check(TwoFactorAuthService.java:75)
	at foam.nanos.auth.SystemAuthService.check(SystemAuthService.java:39)
	at foam.nanos.boot.NSpec.checkAuthorization(NSpec.java:1495)
	at foam.box.SessionServerBox.send(SessionServerBox.java:107)
	at foam.nanos.http.ServiceWebAgent.execute(ServiceWebAgent.java:129)
	at foam.nanos.http.NanoRouter.service(NanoRouter.java:111)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:763)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1631)
	at org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter.doFilter(WebSocketUpgradeFilter.java:226)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1618)
	at net.nanopay.security.csp.CSPFilter.doFilter(CSPFilter.java:24)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1618)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:549)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1369)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:489)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1284)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
	at org.eclipse.jetty.server.Server.handle(Server.java:501)
	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:383)
	at org.eclipse.jetty.server.HttpChannel$$Lambda$100/0000000000000000.dispatch(Unknown Source)
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:556)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:375)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:272)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103)
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:336)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:313)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:171)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:129)
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:375)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:806)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:938)
	at java.base/java.lang.Thread.run(Thread.java:834)
```