### PR TITLE
Override theme defaultMenu

### DIFF
--- a/src/foam/nanos/theme/Themes.js
+++ b/src/foam/nanos/theme/Themes.js
@@ -30,6 +30,7 @@ foam.CLASS({
     'foam.nanos.auth.Group',
     'foam.nanos.auth.Subject',
     'foam.nanos.auth.User',
+    'foam.util.SafetyUtil',
     'javax.servlet.http.HttpServletRequest',
     'org.eclipse.jetty.server.Request'
   ],
@@ -78,6 +79,9 @@ Later themes:
             var groupTheme = await group.theme$find;
             if ( groupTheme ) {
               theme = theme && theme.copyFrom(groupTheme) || theme;
+              if ( !! group.defaultMenu ) {
+                theme.defaultMenu = group.defaultMenu;
+              }
             }
             group = await group.parent$find;
           }
@@ -122,6 +126,9 @@ Later themes:
           Theme groupTheme = group.findTheme(x);
           if ( groupTheme != null ) {
             theme = (Theme) theme.fclone().copyFrom(groupTheme);
+            if ( ! SafetyUtil.isEmpty(group.getDefaultMenu()) ) {
+              theme.setDefaultMenu(group.getDefaultMenu());
+            }
           }
           group = (Group) groupDAO.find(group.getParent());
         }

--- a/src/services
+++ b/src/services
@@ -830,12 +830,15 @@ p({
   "name":"localGroupPermissionJunctionDAO",
   "description":"The junction DAO for the many-to-many relationship between groups and permissions",
   "serviceScript":"""
-    return new foam.dao.EasyDAO.Builder(x)
+    dao = new foam.dao.EasyDAO.Builder(x)
       .setOf(foam.nanos.auth.GroupPermissionJunction.getOwnClassInfo())
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
       .setJournalName("groupPermissionJunctions")
       .setPm(true)
       .build();
+
+    dao.addPropertyIndex(new foam.core.PropertyInfo[] { foam.nanos.auth.GroupPermissionJunction.SOURCE_ID });
+    return dao;
   """
 })
 p({


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-1593

## Issues
- spid-admin group is configured with defaultMenu: "users" and theme: nanopay-theme but the nanopay-theme has its own defaultMenu set to "accounts" so the user is redirected to "accounts" instead. The nanopay-theme is also used by many other groups such as fraud-ops and payment-ops.

## Changes
- Override theme default menu with that of group's if it's configured so that groups can have their own default menu while using the same theme
- Add index on GroupPermissionJunction.SOURCE_ID