### PR TITLE
Fix broken callback links in CrunchController

### DIFF
--- a/src/foam/u2/crunch/CapabilityRequirementView.js
+++ b/src/foam/u2/crunch/CapabilityRequirementView.js
@@ -95,6 +95,10 @@ foam.CLASS({
       name: 'arrayRequirement'
     },
     {
+      class: 'Function',
+      name: 'onClose'
+    },
+    {
       class: 'Object',
       name: 'functionData'
     },
@@ -152,8 +156,10 @@ foam.CLASS({
           ))
       .end()
       .start().addClass('actionPosition')
-        .startContext({ data: this }).start(this.GET_STARTED).end().endContext()
-        .start(this.CANCEL, { buttonStyle: 'SECONDARY' }).end()
+        .startContext({ data: this })
+          .start(this.GET_STARTED).end()
+          .start(this.CANCEL, { buttonStyle: 'SECONDARY' }).end()
+        .endContext()
       .end();
     }
   ],
@@ -161,14 +167,15 @@ foam.CLASS({
     {
       name: 'getStarted',
       code: function(x) {
-        x.crunchController.generateAndDisplayWizard(this.functionData);
         x.closeDialog();
+        this.onClose(x, true);
       }
     },
     {
       name: 'cancel',
       code: function(x) {
         x.closeDialog();
+        this.onClose(x, false);
       }
     }
   ]


### PR DESCRIPTION
Broken callback links were introduced in #3650, but we didn't notice before because we previously didn't need to know if the wizard had completed.

This blocks UI logic for Capable objects (NP-1834) which needs to invoke a wizard for user-associated prerequisites (conditionally) before proceeding to the object's own requirements.