### PR TITLE
add extends to junctions

### DIFF
--- a/src/foam/dao/Relationship.js
+++ b/src/foam/dao/Relationship.js
@@ -173,6 +173,15 @@ foam.CLASS({
           .filter(f => global.FOAM_FLAGS[f]);
         return foam.util.flagFilter(enabledFlags)(this);
       }
+    },
+    {
+      class: 'String',
+      name: 'extends',
+      value: 'FObject',
+      documentation: `
+        Only used for many to many relationships.
+        Name of the class that this junction class should inherit from.
+      `
     }
     /* FUTURE:
     {
@@ -290,6 +299,7 @@ foam.CLASS({
       foam.CLASS({
         package: this.package,
         name: name,
+        extends: this.extends,
         ids: ['sourceId', 'targetId'],
         properties: [
           {


### PR DESCRIPTION
needed for usercapabiiltyjunction : want to extend a renewable class where all the expiry related info is tracked

e.g. 
```
foam.RELATIONSHIP({
  package: 'foam.nanos.crunch',
  extends:'foam.nanos.crunch.Renewable',
  sourceModel: 'foam.nanos.auth.User',
  targetModel: 'foam.nanos.crunch.Capability',
   ...
});