### PR TITLE
Enhance assertValue failure message

### DIFF
--- a/src/foam/core/AxiomArray.js
+++ b/src/foam/core/AxiomArray.js
@@ -60,8 +60,8 @@ foam.CLASS({
             prop.of);
         for ( var i = 0 ; i < v.length ; i++ ) {
           foam.assert(of.isInstance(v[i]),
-              'Element', i, 'of', prop.name, 'is not an instance of',
-              prop.of);
+              'Element', i, 'of', prop.name, 'is not an instance of', prop.of,
+              'at', this.package + '.' + this.name, '[', v[i].name, ']');
         }
       }
     },


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-1944

## Issues
- It's quite difficult to figure out the root cause when the build outputs "Assertion failed: Element 6 of methods is not an instance of Method" and nothing else

## Changes
- Include package name, model name and value in assertValue failure message for better diagnoses