### PR TITLE
[NP-1958] Make sequence-invoked wizard more configurable

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -587,6 +587,7 @@ FOAM_FILES([
   { name: "foam/u2/stack/StackView", flags: ['web'] },
   { name: "foam/u2/crunch/Style", flags: ['web'] },
   { name: "foam/u2/crunch/CrunchController", flags: ['web'] },
+  { name: "foam/u2/crunch/wizardflow/ConfigureFlowAgent", flags: ['web'] },
   { name: "foam/u2/crunch/wizardflow/CapabilityAdaptAgent", flags: ['web'] },
   { name: "foam/u2/crunch/wizardflow/CheckPendingAgent", flags: ['web'] },
   { name: "foam/u2/crunch/wizardflow/LoadCapabilitiesAgent", flags: ['web'] },

--- a/src/foam/u2/crunch/CrunchController.js
+++ b/src/foam/u2/crunch/CrunchController.js
@@ -30,6 +30,7 @@ foam.CLASS({
     'foam.log.LogLevel',
     'foam.nanos.crunch.AgentCapabilityJunction',
     'foam.nanos.crunch.UserCapabilityJunction',
+    'foam.u2.crunch.wizardflow.ConfigureFlowAgent',
     'foam.u2.crunch.wizardflow.CapabilityAdaptAgent',
     'foam.u2.crunch.wizardflow.CheckPendingAgent',
     'foam.u2.crunch.wizardflow.LoadCapabilitiesAgent',
@@ -67,6 +68,7 @@ foam.CLASS({
       return this.Sequence.create(null, this.__subContext__.createSubContext({
         rootCapability: capabilityOrId
       }))
+        .add(this.ConfigureFlowAgent)
         .add(this.CapabilityAdaptAgent)
         .add(this.LoadCapabilitiesAgent)
         .add(this.CheckPendingAgent)

--- a/src/foam/u2/crunch/wizardflow/ConfigureFlowAgent.js
+++ b/src/foam/u2/crunch/wizardflow/ConfigureFlowAgent.js
@@ -1,0 +1,73 @@
+foam.CLASS({
+  package: 'foam.u2.crunch.wizardflow',
+  name: 'ConfigureFlowAgent',
+  implements: [ 'foam.core.ContextAgent' ],
+
+  imports: [
+    'stack'
+  ],
+
+  exports: [
+    'pushView',
+    'popView'
+  ],
+
+  requires: [
+    'foam.u2.dialog.Popup'
+  ],
+
+  properties: [
+    {
+      name: 'popupMode',
+      class: 'Boolean',
+      value: true
+    },
+    {
+      name: 'ensureHash',
+      documentation: `
+        Sets the url hash on subsequent stack pushes.
+      `,
+      class: 'String'
+    },
+    {
+      name: 'pushView',
+      class: 'Function',
+      expression: function () {
+        var self = this;
+        return this.popupMode 
+          ? function (viewSpec) {
+            ctrl.add(
+              self.Popup.create({ closable: false })
+                .tag(viewSpec)
+            )
+          }
+          : function (viewSpec) {
+            self.stack.push(viewSpec);
+            if ( self.ensureHash ) {
+              location.hash = self.ensureHash;
+            }
+          }
+          ;
+      }
+    },
+    {
+      name: 'popView',
+      class: 'Function',
+      expression: function () {
+        var self = this;
+        return this.popupMode 
+          ? function (x) {
+            x.closeDialog();
+          }
+          : function (x) {
+            self.stack.back();
+          }
+          ;
+      }
+    }
+  ],
+
+  methods: [
+    async function execute () {}
+  ]
+});

--- a/src/foam/u2/crunch/wizardflow/ConfigureFlowAgent.js
+++ b/src/foam/u2/crunch/wizardflow/ConfigureFlowAgent.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 foam.CLASS({
   package: 'foam.u2.crunch.wizardflow',
   name: 'ConfigureFlowAgent',


### PR DESCRIPTION
Allows the following configurations in the wizard sequence:
- It is possible to choose between popup and view stack wizards (or, provide any alternative implementation)
- StepWizardAgent now accepts a config for the wizard controller, and a ViewSpec for the wizard view
- You can specify a value for `location.hash` to be set to after the wizard is displayed. It is also possible to display multiple views in a sequence with different location hashes by preceding each one with an appropriate configuration of `ConfigureFlowAgent`.