### PR TITLE
approvalrequestutil.getState returning requested for rejected approvals

### DIFF
--- a/src/foam/nanos/approval/ApprovalRequestUtil.java
+++ b/src/foam/nanos/approval/ApprovalRequestUtil.java
@@ -77,6 +77,7 @@ public class ApprovalRequestUtil {
     } catch (Exception e){
       return tester.getState();
     }
-    return tester.getState();
+    ApprovalStatus state = tester.getState();
+    return state == null ? ApprovalStatus.REQUESTED : ApprovalStatus.APPROVED;
   }
 }

--- a/src/foam/nanos/approval/ApprovalRequestUtil.java
+++ b/src/foam/nanos/approval/ApprovalRequestUtil.java
@@ -78,6 +78,6 @@ public class ApprovalRequestUtil {
       return tester.getState();
     }
     ApprovalStatus state = tester.getState();
-    return state == null ? ApprovalStatus.REQUESTED : ApprovalStatus.APPROVED;
+    return state == null ? ApprovalStatus.REQUESTED : state;
   }
 }

--- a/src/foam/nanos/approval/ApprovalTester.java
+++ b/src/foam/nanos/approval/ApprovalTester.java
@@ -59,8 +59,7 @@ public class ApprovalTester {
    * @return approval status of the test
    */
   public ApprovalStatus test(ApprovalRequest request) {
-    if ( request.getStatus() == ApprovalStatus.REQUESTED
-      || incrRejected(request) >= request.getRequiredRejectedPoints()
+    if ( incrRejected(request) >= request.getRequiredRejectedPoints()
     ) {
       state_ = request.getStatus();
     } else {


### PR DESCRIPTION
ApprovalRequestUtil is returning status REQUESTED on the first REQUESTED it sees, and rejecting was not working if the request happens to show up later in the list returned by approvalrequestdao