### PR TITLE
[NP-1834] Allow Capable objects' requirements to be set from client

### DIFF
--- a/src/foam/nanos/crunch/CrunchService.js
+++ b/src/foam/nanos/crunch/CrunchService.js
@@ -12,6 +12,10 @@ foam.INTERFACE({
     services.
   `,
 
+  javaImports: [
+    'foam.nanos.crunch.lite.CapablePayload'
+  ],
+
   methods: [
     {
       name: 'getGrantPath',
@@ -151,6 +155,21 @@ foam.INTERFACE({
         },
         {
           name: 'capabilityId',
+          type: 'String[]'
+        },
+      ]
+    },
+    {
+      name: 'getCapableObjectPayloads',
+      async: true,
+      type: 'CapablePayload[]',
+      args: [
+        {
+          name: 'x',
+          type: 'Context'
+        },
+        {
+          name: 'capabilityIds',
           type: 'String[]'
         },
       ]

--- a/src/foam/nanos/crunch/lite/Capable.js
+++ b/src/foam/nanos/crunch/lite/Capable.js
@@ -39,55 +39,13 @@ foam.INTERFACE({
             { name: 'capabilityIds', type: 'String[]' }
           ],
           body: `
-            List<CapablePayload> payloads = new ArrayList<>();
-
             CrunchService crunchService = (CrunchService) x.get("crunchService");
-            List crunchPath = crunchService.getMultipleCapabilityPath(
-              x, capabilityIds, false);
 
-            for ( Object obj : crunchPath ) {
-              if ( ! (obj instanceof Capability) ) {
-                // Lists correspond to capabilityIds with their own prerequisite
-                // logic, such as MinMaxCapability. Clients will need to be
-                // made aware of these capabilities separately.
-                if ( obj instanceof List ) {
-                  List list = (List) obj;
-
-                  // Add payload object prerequisites
-                  List prereqs = new ArrayList();
-                  for ( int i = 0 ; i < list.size() - 1 ; i++ ) {
-                    Capability prereqCap = (Capability) list.get(i);
-                    list.add(new CapablePayload.Builder(x)
-                      .setCapability(prereqCap)
-                      .build());
-                  }
-
-                  // Add payload object
-                  /* TODO: Figure out why this is an error when adding
-                           support for MinMaxCapability
-                  Capability cap = (Capability) list.get(list.size() - 1);
-                  payloads.add(new CapablePayload.Builder(x)
-                    .setCapability(cap)
-                    .setPrerequisites(prereqs.toArray(
-                      new CapablePayload[list.size()]))
-                    .build());
-                  */
-                  continue;
-                }
-
-                throw new RuntimeException(
-                  "Expected capability or list");
-              }
-              Capability cap = (Capability) obj;
-              payloads.add(new CapablePayload.Builder(x)
-                .setCapability(cap)
-                .build());
-            }
-            
-            // Re-FObjectArray
-            setCapablePayloads(payloads.toArray(
-              new CapablePayload[payloads.size()]
-            ));
+            setCapablePayloads(
+              crunchService.getCapableObjectPayloads(
+                x, capabilityIds
+              )
+            );
           `
         }));
         cls.methods.push(foam.java.Method.create({

--- a/src/foam/nanos/crunch/lite/CapableObjectData.js
+++ b/src/foam/nanos/crunch/lite/CapableObjectData.js
@@ -20,4 +20,23 @@ foam.CLASS({
       class: 'StringArray',
     }
   ],
+
+  methods: [
+    {
+      // TODO: investigate why this default implementation doesn't
+      //   work when put in the Capable interface itself; this
+      //   behaviour works with mlang.Expressions so it's odd that
+      //   it doesn't work for this case.
+      name: 'setRequirements',
+      flags: ['web'],
+      code: function(capabilityIds) {
+        var crunchService = this.__subContext__['crunchService'];
+        return crunchService.getCapableObjectPayloads(
+          null, capabilityIds
+        ).then(result => {
+          this.capablePayloads = result;
+        })
+      }
+    }
+  ]
 });


### PR DESCRIPTION
This allows setting Capable requirements on the client for UI generation purposes.

Note that `verifyRequirements` still must be called on the server, and also requires a list of capability IDs to be passed to it. This should be the same list passed to `setRequirements` but should under no circumstances be taken from the capability payloads on the object provided by the client.