### PR TITLE
Keeping !Important  Flag from being overridden by CSS  Variable

### DIFF
--- a/src/foam/nanos/controller/ApplicationController.js
+++ b/src/foam/nanos/controller/ApplicationController.js
@@ -498,7 +498,7 @@ foam.CLASS({
       var M = m.toUpperCase();
 
       return css.replace(
-        new RegExp('/\\*%' + M + '%\\*/[^;]*', 'g'),
+        new RegExp('/\\*%' + M + '%\\*/[^;!]*', 'g'),
         '/*%' + M + '%*/ ' + this.theme[m]);
     },
 


### PR DESCRIPTION
Take the example:

```
    ^selected {
      border-color: /*%PRIMARY3%*/ #406dea !important;
    }
```

If  I used a  variable where PRIMARY3 = #405cdz

Then the CSS would generate:

 ```
    class.selected {
      border-color: #405cdz;
    }
```

The !important flag got completely overriden before. The variable should just be used to define the colour, then the  colour gets applied on the varying cases  in the  views, so we  isolate this  by including the !important tag if it was defined in the view. The colour just is the colour.