### PR TITLE
Prevent infinite recursion on StepWizardLetController

### DIFF
--- a/src/foam/u2/wizard/StepWizardletController.js
+++ b/src/foam/u2/wizard/StepWizardletController.js
@@ -186,6 +186,8 @@ foam.CLASS({
             ) {
             return p;
           }
+
+          if ( p.sectionIndex < -1 ) return null;
         }
 
         return null;


### PR DESCRIPTION
The for loop can lead to an invite recursion relating to the wizardposition's sectionindex