### PR TITLE
prevent update to spid prop on user

### DIFF
--- a/src/foam/nanos/auth/User.js
+++ b/src/foam/nanos/auth/User.js
@@ -522,6 +522,13 @@ foam.CLASS({
         return null (probably as a result of moving order of files
         in nanos), which breaks tests
       `,
+      javaSetter: `
+        if ( spidIsSet_ && ! spid_.equals(val) ) {
+          throw new RuntimeException("Service Provider cannot be updated for User");
+        }
+        spid_ = val;
+        spidIsSet_ = true;
+      `,
       javaGetter: `
         if ( ! spidIsSet_ ) {
           return "";


### PR DESCRIPTION
follow up of PreventMultipleSpidDAO that stops creation of User-ServiceProvider junctions if the user already has a ServiceProvider junction, this prevents the spid prop on user from being updated once set, to avoid differences in user's ServiceProvider capability and ServiceProviderAware reference