### PR TITLE
fix menu disply hwhen there is only one

### DIFF
--- a/src/foam/nanos/menu/MenuToolBar.js
+++ b/src/foam/nanos/menu/MenuToolBar.js
@@ -36,7 +36,7 @@ foam.CLASS({
     ^options {
       display: flex;
       flex-direction: row;
-      justify-content: space-between;
+      justify-content: center;
       align-items: center;
       padding: 0 36px 32px 36px;
     }


### PR DESCRIPTION
address: https://nanopay.atlassian.net/browse/NP-2144
notes: previous one is merge too fast, haven't push the addition changes which specific for there is only one menu. also double checked others, UI will not break or shift
previous:
<img width="870" alt="Screen Shot 2020-09-25 at 2 41 18 PM" src="https://user-images.githubusercontent.com/41084370/94309733-8907ba00-ff46-11ea-9fa3-1365ee7d0ee6.png">
fix:
<img width="854" alt="Screen Shot 2020-09-25 at 3 36 26 PM" src="https://user-images.githubusercontent.com/41084370/94309748-8efd9b00-ff46-11ea-89d5-61d5217784dc.png">
