### PR TITLE
Remove Duplicate admissionCapability Property

### DIFF
--- a/src/foam/nanos/theme/Theme.js
+++ b/src/foam/nanos/theme/Theme.js
@@ -120,12 +120,6 @@ foam.CLASS({
       },
     },
     {
-      name: 'admissionCapability',
-      class: 'Reference',
-      of: 'foam.nanos.crunch.Capability',
-      documentation: 'Specifies the top-level capability that must be granted before we admit a user to the system.'
-    },
-    {
       class: 'Array',
       name: 'domains',
       of: 'String',


### PR DESCRIPTION
Remove duplicated admissionCapability property from Theme model. Original can be found in Capability model.