### PR TITLE
add padding-left for help-icon to add spacing before help-icon

### DIFF
--- a/src/foam/u2/detail/SectionedDetailPropertyView.js
+++ b/src/foam/u2/detail/SectionedDetailPropertyView.js
@@ -24,6 +24,7 @@ foam.CLASS({
     }
 
     ^helper-icon {
+      padding-left: 12px;
       width: 20px;
       height: 20px;
     }


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/NP-2168

<img width="1166" alt="Screen Shot 2020-10-01 at 3 27 26 PM" src="https://user-images.githubusercontent.com/38148986/94855264-3d4c8900-03fc-11eb-9862-eb67a67f25d9.png">
