### PR TITLE
Added java validationPredicate errorMessage support

### DIFF
--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -237,7 +237,7 @@ foam.CLASS({
       expression: function(validationPredicates) {
         return validationPredicates
           .map((vp) => {
-            exception = vp.errorMessage ?
+            var exception = vp.errorMessage ?
               `throw new IllegalStateException(((${this.forClass_}) obj).${vp.errorMessage});` :
               `throw new IllegalStateException(${foam.java.asJavaValue(vp.errorString)});`
             return `if ( ! ${foam.java.asJavaValue(vp.predicate)}.f(obj) ) {

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -3,7 +3,6 @@
  * Copyright 2017,2018 The FOAM Authors. All Rights Reserved.
  * http://www.apache.org/licenses/LICENSE-2.0
  */
-
 foam.INTERFACE({
   package: 'foam.lib.csv',
   name: 'FromCSVSetter',
@@ -238,11 +237,12 @@ foam.CLASS({
       expression: function(validationPredicates) {
         return validationPredicates
           .map((vp) => {
-            return `
-              if ( ! ${foam.java.asJavaValue(vp.predicate)}.f(obj) ) {
-                throw new IllegalStateException(${foam.java.asJavaValue(vp.errorString)});
-              }
-            `;
+            exception = vp.errorMessage ?
+              `throw new IllegalStateException(((${this.forClass_}) obj).${vp.errorMessage});` :
+              `throw new IllegalStateException(${foam.java.asJavaValue(vp.errorString)});`
+            return `if ( ! ${foam.java.asJavaValue(vp.predicate)}.f(obj) ) {
+              ${exception}
+            }`;
           })
           .join('');
       }

--- a/src/foam/nanos/crunch/RenewableData.js
+++ b/src/foam/nanos/crunch/RenewableData.js
@@ -47,7 +47,7 @@ foam.CLASS({
               )
             )
           },
-          errorMessage: 'DATA_ERROR'
+          errorMessage: 'REVIEW_ERROR'
         }
       ]
     }


### PR DESCRIPTION
Added java ValidationPredicate errorMessages.

errorMessages defined on validationPredicates were not being thrown when validating objects on server scripts. Encountered this issue when validating objects in beanshell and checking server log errors. Null messages were being returned.

Fix required checking for validationPredicate errorMessage and constructing the java exception.