### PR TITLE
Dataconfiguredexpiry

### DIFF
--- a/src/foam/nanos/crunch/DecrementGraceDaysLeftCron.java
+++ b/src/foam/nanos/crunch/DecrementGraceDaysLeftCron.java
@@ -36,6 +36,7 @@ public class DecrementGraceDaysLeftCron implements ContextAgent {
       .getArray();
 
     for ( UserCapabilityJunction ucj : junctions ) {
+      ucj = (UserCapabilityJunction) ucj.fclone();
       ucj.setGracePeriod(ucj.getGracePeriod() - 1);
       logger.debug("Decrementing grace days left for UserCapabilityJunction : " + ucj.getId());
       userCapabilityJunctionDAO.put(ucj);

--- a/src/foam/nanos/crunch/RenewableData.js
+++ b/src/foam/nanos/crunch/RenewableData.js
@@ -50,6 +50,18 @@ foam.CLASS({
           errorMessage: 'REVIEW_ERROR'
         }
       ]
+    },
+    {
+      name: 'dataConfiguredExpiry',
+      class: 'Boolean',
+      hidden: true,
+      readPermissionRequired: true,
+      writePermissionRequired: true
+    },
+    {
+      name: 'expiry',
+      class: 'Date',
+      hidden: true
     }
   ],
 

--- a/src/foam/nanos/crunch/ruler/ConfigureUCJExpiryOnGranted.js
+++ b/src/foam/nanos/crunch/ruler/ConfigureUCJExpiryOnGranted.js
@@ -59,7 +59,13 @@ foam.CLASS({
               return;
             }
 
-            Date junctionExpiry = capability.getExpiry();
+            // if the data is Renewable and expiry is user-configured, get the expiry from the RenewableData,
+            // otherwise, get the expiry from the capability
+            FObject data = ucj.getData();
+            
+            Date junctionExpiry = data instanceof RenewableData && ((RenewableData) data).getDataConfiguredExpiry() ?
+              ((RenewableData) data).getExpiry() :
+              capability.getExpiry(); 
 
             ucj.resetRenewalStatus();
     
@@ -76,7 +82,6 @@ foam.CLASS({
               }
             }
             ucj.setExpiry(junctionExpiry);
-            FObject data = ucj.getData();
             if ( junctionExpiry != null && ( data instanceof RenewableData ) ) {
               ((RenewableData) data).setRenewable(false);
               ((RenewableData) data).setReviewed(false);

--- a/src/foam/nanos/crunch/ruler/SetUCJStatusOnPut.js
+++ b/src/foam/nanos/crunch/ruler/SetUCJStatusOnPut.js
@@ -80,7 +80,6 @@ foam.CLASS({
         ACTION_REQUIRED: If not any of the above
       `,
       javaCode: `
-        boolean allGranted = true;
         DAO userCapabilityJunctionDAO = (DAO) x.get("userCapabilityJunctionDAO");
         DAO capabilityDAO = (DAO) x.get("capabilityDAO");
         Capability cap = (Capability) capabilityDAO.find(ucj.getTargetId());


### PR DESCRIPTION
- add expiry property to RenewableData so that the expiry of the data could be used in configuring the expiry of the ucj
- added ExpirableDocument ext. Document that uses the expiry property of RenewableData
- in brazil capabilities journals, set UserIdentity capability to use ExpirableDocument instead of regular document.
- configure expiry/duration for br capabilities
   - unlock payments (expires by expiring certify data reviewed) - duration of 18 month, grace period 7 days
   - office consumption - duration of 3 months,grace period 7 days
   - user identity - expires when the identification document expires or in 10 years whichever comes first 

nanopay : 
ExpirableDocument https://github.com/nanoPayinc/NANOPAY/pull/10693
br configuration https://github.com/nanoPayinc/NANOPAY/pull/10692

