### PR TITLE
Return all invalid props on object validate

### DIFF
--- a/src/foam/core/FObject.java
+++ b/src/foam/core/FObject.java
@@ -433,9 +433,9 @@ public interface FObject
       } catch (IllegalStateException e) {
         exceptions.add(prop.getName() + ": " + e.getMessage());
       }
-      if ( exceptions.size() > 0 ) {
-        throw new IllegalStateException(exceptions.toString());
-      }
+    }
+    if ( exceptions.size() > 0 ) {
+      throw new IllegalStateException(exceptions.toString());
     }
   }
 

--- a/src/foam/core/FObject.java
+++ b/src/foam/core/FObject.java
@@ -12,6 +12,7 @@ import foam.lib.json.Outputter;
 import foam.util.SecurityUtil;
 import java.security.*;
 import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -424,12 +425,18 @@ public interface FObject
   }
 
   default void validate(foam.core.X x) {
-
     List<PropertyInfo> props = getClassInfo().getAxiomsByClass(PropertyInfo.class);
+    List<String> exceptions = new ArrayList<String>();
     for ( PropertyInfo prop : props ) {
-      prop.validateObj(x, this);
+      try {
+        prop.validateObj(x, this);
+      } catch (IllegalStateException e) {
+        exceptions.add(prop.getName() + ": " + e.getMessage());
+      }
+      if ( exceptions.size() > 0 ) {
+        throw new IllegalStateException(exceptions.toString());
+      }
     }
-
   }
 
   default boolean verify(byte[] signature, java.security.Signature verifier) throws java.security.SignatureException {


### PR DESCRIPTION
Calling the validate java method on an object will now throw an IllegalStateException containing all invalid properties including the error message associated to the props validity.

Currently an illegal state exception is thrown for the first invalid property of an object when its validate method is called. This can create a continuous back and forth between the server and the requestor until an object is fully validated. We can improve this by catching all prop validateObj exceptions and throwing them together. 