### PR TITLE
[NP-2065] Fix wizard promise rejects

### DIFF
--- a/src/foam/nanos/crunch/box/CrunchClientReplyBox.js
+++ b/src/foam/nanos/crunch/box/CrunchClientReplyBox.js
@@ -54,6 +54,11 @@ foam.CLASS({
               });
               self.delegate.send(newMsg);
             },
+            reject: function (value) {
+              var newMsg = msg.clone();
+              newMsg.object = new Error(value);
+              self.delegate.send(newMsg);
+            },
             resend: function () {
               self.clientBox.send(self.msg);
             }

--- a/src/foam/u2/crunch/CapabilityIntercept.js
+++ b/src/foam/u2/crunch/CapabilityIntercept.js
@@ -42,6 +42,10 @@ foam.CLASS({
       class: 'Function'
     },
     {
+      name: 'reject',
+      class: 'Function'
+    },
+    {
       name: 'resend',
       class: 'Function'
     },

--- a/src/foam/u2/crunch/CrunchController.js
+++ b/src/foam/u2/crunch/CrunchController.js
@@ -135,15 +135,20 @@ foam.CLASS({
       }
 
       p = p.then(isCompleted => {
+        debugger;
         if ( isCapable ) {
           if ( ! isCompleted ) {
-            intercept.resolve(new Error('user cancelled'));
+            intercept.reject('user cancelled');
             return;
           }
           intercept.resolve(intercept.returnCapable)
           return;
         }
         intercept.resend();
+      })
+
+      p.catch(err => {
+        console.error(err, 'from wizard flow');
       })
 
       return p;

--- a/src/foam/u2/crunch/wizardflow/ConfigureFlowAgent.js
+++ b/src/foam/u2/crunch/wizardflow/ConfigureFlowAgent.js
@@ -41,9 +41,12 @@ foam.CLASS({
       expression: function () {
         var self = this;
         return this.popupMode 
-          ? function (viewSpec) {
+          ? function (viewSpec, onClose) {
             ctrl.add(
-              self.Popup.create({ closable: false })
+              self.Popup.create({
+                closable: false,
+                ...(onClose ? { onClose: onClose } : {}),
+              })
                 .tag(viewSpec)
             )
           }

--- a/src/foam/u2/crunch/wizardflow/StepWizardAgent.js
+++ b/src/foam/u2/crunch/wizardflow/StepWizardAgent.js
@@ -50,7 +50,7 @@ foam.CLASS({
 
   methods: [
     function execute() {
-      return new Promise((resolve, _) => {
+      return new Promise((resolve, reject) => {
         this.pushView({
           ...this.view,
           data: this.StepWizardletController.create({
@@ -62,6 +62,8 @@ foam.CLASS({
             this.popView(x)
             resolve();
           }
+        }, () => {
+          resolve();
         });
       });
     }


### PR DESCRIPTION
Fixes Promise handling for cancelled wizards when RPC calls like DAO puts are used to invoke the wizard. Cancelling the wizard rejects the promise, indicating to the caller that the action did not succeed.