### PR TITLE
[Np 2065] Support for wizardlets with no data models (allows removal of `of` from MinMax capabilities)

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -847,6 +847,7 @@ FOAM_FILES([
   { name: "foam/u2/tag/CircleIndicator" },
   { name: "foam/u2/wizard/WizardPosition" },
   { name: "foam/u2/wizard/Wizardlet" },
+  { name: "foam/u2/wizard/WizardletSection" },
   { name: "foam/u2/wizard/BaseWizardlet" },
   { name: "foam/u2/wizard/WizardletView" },
   { name: "foam/u2/wizard/StepWizardConfig" },

--- a/src/foam/core/stdlib.js
+++ b/src/foam/core/stdlib.js
@@ -1028,6 +1028,7 @@ foam.LIB({
         if ( ! opt_defaultMethod ) {
           foam.assert(type, 'Unknown type: ', arg1,
             'and no default method provided');
+          if ( ! type[uid] ) debugger;
           foam.assert(
             type[uid],
             'Missing ' + name + ' multi-method for type ', arg1, ' map: ', map,

--- a/src/foam/core/stdlib.js
+++ b/src/foam/core/stdlib.js
@@ -1028,7 +1028,6 @@ foam.LIB({
         if ( ! opt_defaultMethod ) {
           foam.assert(type, 'Unknown type: ', arg1,
             'and no default method provided');
-          if ( ! type[uid] ) debugger;
           foam.assert(
             type[uid],
             'Missing ' + name + ' multi-method for type ', arg1, ' map: ', map,

--- a/src/foam/nanos/crunch/ui/CapableMinMaxCapabilityWizardlet.js
+++ b/src/foam/nanos/crunch/ui/CapableMinMaxCapabilityWizardlet.js
@@ -68,6 +68,11 @@ foam.CLASS({
       value: false
     },
     {
+      class: 'Boolean',
+      name: 'isVisible',
+      value: true // always true for a MinMax
+    },
+    {
       name: 'sections',
       flags: ['web'],
       transient: true,

--- a/src/foam/nanos/crunch/ui/CapableMinMaxCapabilityWizardlet.js
+++ b/src/foam/nanos/crunch/ui/CapableMinMaxCapabilityWizardlet.js
@@ -66,6 +66,30 @@ foam.CLASS({
       class: 'Boolean',
       name: 'isValid',
       value: false
+    },
+    {
+      name: 'sections',
+      flags: ['web'],
+      transient: true,
+      class: 'FObjectArray',
+      of: 'foam.u2.wizard.WizardletSection',
+      factory: function () {
+        return [
+          this.WizardletSection.create({
+            isAvailable: true,
+            title: this.targetPayload.capability.name,
+            customView: {
+              class: 'foam.u2.view.MultiChoiceView',
+              choices$: this.choices$,
+              booleanView: this.CardSelectView,
+              isValidNumberOfChoices$: this.isValid$,
+              minSelected$: this.min$,
+              maxSelected$: this.max$,
+              onSelect: this.adjustCapablePayloads.bind(this)
+            }
+          })
+        ];
+      }
     }
   ],
 

--- a/src/foam/u2/detail/AbstractSectionedDetailView.js
+++ b/src/foam/u2/detail/AbstractSectionedDetailView.js
@@ -8,6 +8,7 @@ foam.CLASS({
   package: 'foam.u2.detail',
   name: 'AbstractSectionedDetailView',
   extends: 'foam.u2.View',
+  flags: ['web'],
 
   documentation: `
     The abstract for property-sheet style Views with sections for editing an FObject.

--- a/src/foam/u2/view/MultiChoiceView.js
+++ b/src/foam/u2/view/MultiChoiceView.js
@@ -181,6 +181,7 @@ foam.CLASS({
     },
     {
       name: 'objToChoice',
+      class: 'Function',
       value: function(obj) {
         return [ obj.id, obj.toSummary() ];
       }

--- a/src/foam/u2/wizard/BaseWizardlet.js
+++ b/src/foam/u2/wizard/BaseWizardlet.js
@@ -12,6 +12,11 @@ foam.CLASS({
     'foam.u2.wizard.Wizardlet'
   ],
 
+  requires: [
+    'foam.u2.detail.AbstractSectionedDetailView',
+    'foam.u2.wizard.WizardletSection',
+  ],
+
   properties: [
     {
       name: 'of',
@@ -31,14 +36,21 @@ foam.CLASS({
       class: 'Boolean',
       expression: function (of, data, currentSection, data$errors_) {
         let sectionErrors = [];
-        if ( currentSection && data$errors_ ) {
+        if ( currentSection && currentSection.section && data$errors_ ) {
           sectionErrors = data$errors_.filter(error =>
-            currentSection.properties.includes(error[0])
+            currentSection.section.properties.includes(error[0])
           );
         }
 
         if ( ! this.of ) return true;
-        if ( ( ! data ) || currentSection ? sectionErrors.length > 0 : data$errors_) return false;
+        if (
+          ( ! data ) ||
+          ( currentSection && currentSection.section )
+            ? sectionErrors.length > 0
+            : data$errors_
+        ) {
+          return false;
+        }
         return true;
       }
     },
@@ -57,6 +69,24 @@ foam.CLASS({
       class: 'Boolean',
       expression: function (of, isAvailable) {
         return isAvailable && of;
+      }
+    },
+    {
+      name: 'sections',
+      flags: ['web'],
+      transient: true,
+      class: 'FObjectArray',
+      of: 'foam.u2.wizard.WizardletSection',
+      factory: function () {
+        return foam.u2.detail.AbstractSectionedDetailView.create({
+          of: this.of,
+        }, this).sections.map(section => this.WizardletSection.create({
+          section: section,
+          data$: this.data$,
+          isAvailable$: section.createIsAvailableFor(
+            this.data$,
+          )
+        }));
       }
     }
   ],

--- a/src/foam/u2/wizard/StepWizardletController.js
+++ b/src/foam/u2/wizard/StepWizardletController.js
@@ -58,12 +58,7 @@ foam.CLASS({
         to foam.layout.Section object.
       `,
       expression: function(wizardlets) {
-        return wizardlets.map(wizardlet => {
-          // TODO: If no of and if createView DNE null, then we need to spoof a section
-          return this.AbstractSectionedDetailView.create({
-            of: wizardlet.of,
-          }).sections;
-        });
+        return wizardlets.map(w => w.sections);
       }
     },
     {
@@ -97,11 +92,9 @@ foam.CLASS({
         Array format is similar to sections.
       `,
       expression: function(sections) {
-        var availableSlots = [...sections.keys()].map(w => sections[w].map(
-          section => section.createIsAvailableFor(
-            this.wizardlets[w].data$
-          )
-        ));
+        var availableSlots = [...sections.keys()]
+          .map(w => sections[w].map(section => section.isAvailable$));
+
         availableSlots.forEach((sections, wizardletIndex) => {
           sections.forEach((availableSlot, sectionIndex) => {
             availableSlot.sub(() => {

--- a/src/foam/u2/wizard/StepWizardletStepsView.js
+++ b/src/foam/u2/wizard/StepWizardletStepsView.js
@@ -135,9 +135,7 @@ foam.CLASS({
               let isBeforeCurrentSection = w < wi || isCurrent && s < si;
 
               let allowedToSkip = self.data.canSkipTo(pos);
-              let slot = section.createIsAvailableFor(
-                wizardlet.data$
-              ).map(function (isAvailable) {
+              let slot = section.isAvailable$.map(function (isAvailable) {
                 return isAvailable ? self.renderSectionLabel(
                   self.E().addClass(self.myClass('sub-item')),
                   section, s+1,

--- a/src/foam/u2/wizard/StepWizardletView.js
+++ b/src/foam/u2/wizard/StepWizardletView.js
@@ -203,12 +203,8 @@ foam.CLASS({
                       .add(this.loadingSpinner)
                       .end();
                   }
-                  var createView = data$currentWizardlet.createView(data);
-        
-                  if ( createView !== null && foam.u2.View.isInstance(createView) ) {
-                    return createView;
-                  }
 
+                  return data$currentSection.createView();
                   var ctx = this.__subContext__.createSubContext();
                   ctx.register(
                     this.VerticalDetailView,

--- a/src/foam/u2/wizard/WizardletSection.js
+++ b/src/foam/u2/wizard/WizardletSection.js
@@ -1,0 +1,61 @@
+foam.CLASS({
+  package: 'foam.u2.wizard',
+  name: 'WizardletSection',
+  flags: ['web'],
+  documentation: `
+    Describes a sub-section of a wizardlet.
+  `,
+
+  requires: [
+    'foam.u2.detail.SectionView',
+    'foam.u2.detail.VerticalDetailView',
+    'foam.u2.ViewSpec',
+  ],
+
+  properties: [
+    {
+      name: 'section',
+      class: 'FObjectProperty',
+      of: 'foam.layout.Section',
+    },
+    {
+      name: 'title',
+      class: 'String',
+      expression: function(section) {
+        return section.title;
+      }
+    },
+    {
+      name: 'data',
+      documentation: `
+        This property will be set by the aggregating wizardlet.
+      `
+    },
+    {
+      name: 'isAvailable',
+      class: 'Boolean'
+    },
+    {
+      name: 'customView',
+      class: 'foam.u2.ViewSpec'
+    }
+  ],
+
+  methods: [
+    function createView() {
+      if ( this.customView ) {
+        return this.ViewSpec.createView(
+          this.customView, null, this, this.__subContext__);
+      }
+      var ctx = this.__subContext__.createSubContext();
+      ctx.register(
+        this.VerticalDetailView,
+        'foam.u2.detail.SectionedDetailView'
+      );
+      return this.SectionView.create({
+        section: this.section,
+        data$: this.data$,
+      }, ctx)
+    }
+  ],
+});

--- a/src/foam/u2/wizard/WizardletSection.js
+++ b/src/foam/u2/wizard/WizardletSection.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 foam.CLASS({
   package: 'foam.u2.wizard',
   name: 'WizardletSection',


### PR DESCRIPTION
Some background context: The step wizard view has a sidebar rendering each Wizardlet as a numerated step, and each `foam.layout.Section` of the Wizardlet's `of` as a sub-step. This means wizardlets like MinMaxCapabilityWizardlet, which controls the visibility of other wizardlets, need an arbitrary `of` so that it can be rendered.

This PR adds `WizardletSection` and a default factory for the BaseWizardlet's sections to be converted into WizardletSection instances. With this new model a wizardlet can generate pseudo-sections rather than requiring an arbitrary data model, and these can have titles generated by other means.