### PR TITLE
Fixed to sme notification template on top level cap

### DIFF
--- a/src/foam/nanos/crunch/SendNotificationOnTopLevelCapabilityStatusUpdate.js
+++ b/src/foam/nanos/crunch/SendNotificationOnTopLevelCapabilityStatusUpdate.js
@@ -20,7 +20,8 @@ foam.CLASS({
     'foam.dao.DAO',
     'foam.nanos.auth.User',
     'foam.nanos.notification.Notification',
-    'java.util.Date'
+    'java.util.Date',
+    'java.util.HashMap'
   ],
 
   methods: [
@@ -33,7 +34,7 @@ foam.CLASS({
           UserCapabilityJunction junction = (UserCapabilityJunction) obj;
           Capability cap = (Capability) junction.findTargetId(x);
           User user = (User) junction.findSourceId(x);
-          
+
           if ( cap == null || ! cap.getVisible() ) return;
 
           DAO notificationDAO = (DAO) x.get("notificationDAO");
@@ -43,6 +44,10 @@ foam.CLASS({
           .append("' has been set to ")
           .append(junction.getStatus())
           .append(".");
+
+          HashMap<String, Object> args = new HashMap<>();
+            args.put("capName", cap.getName());
+            args.put("junctionStatus", junction.getStatus());
 
           Notification notification = new Notification();
 
@@ -54,6 +59,8 @@ foam.CLASS({
           notification.setNotificationType("Capability Status Update");
           notification.setCreated(new Date());
           notification.setBody(sb.toString());
+          notification.setEmailName("top-level-capability-status-update");
+          notification.setEmailArgs(args);
           user.doNotify(x, notification);
         }
       }, "Send Notification On Top Level Capability Status Update");


### PR DESCRIPTION
nanopay : https://github.com/nanoPayinc/NANOPAY/pull/10800

https://nanopay.atlassian.net/browse/NP-2303

fixed notification template to sme from nanopay base on top level capability (not like the tickets description but this pr only cares the template, the other Pr will handle it)



<img width="524" alt="Screen Shot 2020-10-15 at 3 34 36 PM" src="https://user-images.githubusercontent.com/33228583/96177473-eff01180-0efb-11eb-8210-5fdee6c5c4fd.png">
