### PR TITLE
EasyDAO.logger.javaFactory Breaking Debuggers Temp Fix

### DIFF
--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -121,7 +121,7 @@ foam.CLASS({
     },
     {
       /**
-       * TODO: More investigation needed
+       * TODO: More investigation needed at https://github.com/foam-framework/foam2/pull/4085
        * Even though this property doesn't get called
        * If you uncomment the javaFactory it will break debuggers
        * To reproduce:
@@ -141,7 +141,13 @@ foam.CLASS({
       /*
       javaFactory: `
         Logger logger = (Logger) getX().get("logger");
-        return logger;
+        if ( logger == null ) {
+          logger = new foam.nanos.logger.StdoutLogger();
+        }
+
+        logger = new PrefixLogger(new Object[] {
+          this.getClass().getSimpleName()
+        }, logger);
       `
       */
     },
@@ -726,7 +732,7 @@ model from which to test ServiceProvider ID (spid)`,
       name: 'init_',
       javaCode: `
        if ( of_ == null ) {
-         
+
         // TODO: replace logger instantiation once javaFactory issue above is fixed
         Logger logger = (Logger) getX().get("logger");
         if ( logger == null ) {


### PR DESCRIPTION
Really odd bug, essentially it causes both the server and intellij to freeze up and log numerous out of memory messages. More interestingly enough, it seems to only occur when you are using a debugger inside a Try block within an agency.submit block.

Seems to happen when at **EasyDAO.logger.javaFactory** when we set its value to the logger retrieved in the getX() context. Did not occur when we did the following:
   
 EasyDAO.logger.javaFactory: `
        getX().get("logger");
        return foam.nanos.logger.NullLogger.instance();
      `

Breaks when we do the following:

 EasyDAO.logger.javaFactory: `
        Logger logger = (Logger) getX().get("logger");
        return logger;
      `

**EasyDAO.logger** doesn't even have to be called anywhere on EasyDAO, as just having the property instantiated with that javaFactory, despite **EasyDAO.logger** not being getted or setted anywhere else within EasyDAO code will cause it to break. Therefore based on these reasons, we may assume that setting EasyDAO.logger.javaFactory to `return (Logger) getX().get("logger")` ends up somehow breaking the logger stored in the context.

Need this temp fix because it's blocking us from fixing other bugs since we cannot rely on the debugger anymore.

**To reproduce:**

1. Uncomment the javaFactory as left commented in the code

2. Using intellij, set a breakpoint in a try block within an agency.submit (I used CapabilityValidateRule line:56 in .js)

3. Trigger the breakpoint (for my example I just submitted an invoice)

4. Step over the line

5. Server should be hanging no threads available to stop the server using Ctrl+C and Java core dumps should appear as well (didn't appear when @nick-prat  tested yesterday):
<img width="1680" alt="Screen Shot 2020-10-15 at 4 57 23 PM" src="https://user-images.githubusercontent.com/26717171/96185701-4bc09780-0f08-11eb-8c8a-0cb2feab51f1.png">

6. Intellij should be stuck on "Waiting until last debugger command completes"
<img width="1680" alt="Screen Shot 2020-10-15 at 4 56 16 PM" src="https://user-images.githubusercontent.com/26717171/96185816-7874af00-0f08-11eb-94f0-809477ad55a0.png">

7. Need to resort to using kill -9 on both the server & debugger
****