### PR TITLE
Add http request to rule engine's system context

### DIFF
--- a/src/foam/nanos/ruler/RuleEngine.java
+++ b/src/foam/nanos/ruler/RuleEngine.java
@@ -13,6 +13,7 @@ import foam.nanos.logger.Logger;
 import foam.nanos.pm.PM;
 import foam.util.SafetyUtil;
 
+import javax.servlet.http.HttpServletRequest;
 import java.lang.Exception;
 import java.time.Duration;
 import java.time.Instant;
@@ -29,7 +30,7 @@ public class RuleEngine extends ContextAwareSupport {
   private X userX_;
 
   public RuleEngine(X x, X systemX, DAO delegate) {
-    setX(systemX);
+    setX(systemX.put(HttpServletRequest.class, x.get(HttpServletRequest.class)));
     setDelegate(delegate);
     ruleHistoryDAO_ = (DAO) x.get("ruleHistoryDAO");
     userX_ = x;


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-2368

## Changes
Add http request to rule engine's system context for use by email utility to find the theme and parameters for emails.

There are rules that need to update some restricted properties on object eg. User.COMPLIANCE then it will also send a notification to the user but system context doesn't have the http request which is used when finding the corresponding theme and parameters for the notification email.