### PR TITLE
Added top padding to the content portion of the wizardlet view.

### DIFF
--- a/src/foam/u2/wizard/StepWizardletView.js
+++ b/src/foam/u2/wizard/StepWizardletView.js
@@ -89,6 +89,7 @@ foam.CLASS({
       -webkit-mask-image: -webkit-gradient(linear, left 15, left top, from(rgba(0,0,0,1)), to(rgba(0,0,0,0)));
       overflow-y: auto;
       padding: 0 50px;
+      padding-top: 24px;
     }
     ^rightside ^top-buttons {
       text-align: right;


### PR DESCRIPTION
This basically addresses the lack of uniformity when it comes to the top padding of the wizardlet content. That said, this is making an assumption that the titles being generated on the wizardlets are h1 tags.