### PR TITLE
Context Menu Button Fix

### DIFF
--- a/src/foam/u2/view/OverlayActionListView.js
+++ b/src/foam/u2/view/OverlayActionListView.js
@@ -177,8 +177,9 @@ foam.CLASS({
     async function initializeOverlay() {
       var self = this;
 
-      if ( this.obj )
-        this.obj = await this.dao.inX(ctrl.__subContext__).find(this.obj.id);
+      if ( this.obj ) {
+        this.obj = await this.dao.inX(this.__context__).find(this.obj.id);
+      }
 
       this.onDetach(this.disabled_$.follow(this.ExpressionSlot.create({
         args: this.data.map((action) => action.createIsAvailable$(this.__context__, this.obj)),


### PR DESCRIPTION
Context menu was breaking in certain tables due to this.obj being undefined after assignment. Changed assignment of obj variable to use this.dao.inX(this.__context__) instead of this.dao.inX(ctrl.__subContext__)

Tested with tables in Data Management and Notifications and all worked fine.