### PR TITLE
[NP-2436] Add ReviewCapability

### DIFF
--- a/src/foam/nanos/crunch/extra/ReviewCapability.js
+++ b/src/foam/nanos/crunch/extra/ReviewCapability.js
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.nanos.crunch.extra',
+  name: 'ReviewCapability',
+  documentation: `
+    This capability displays a portal to another capability with
+    review options.
+  `,
+
+  properties: [
+    {
+      name: 'capabilityToReview',
+      class: 'Reference',
+      of: 'foam.nanos.crunch.Capability',
+      view: 'foam.nanos.crunch.ui.UCJView'
+    },
+    {
+      name: 'reviewed',
+      class: 'Boolean'
+    }
+  ],
+
+  // TODO: validate; reviewed must be true
+});

--- a/src/foam/nanos/crunch/extra/ReviewCapability.js
+++ b/src/foam/nanos/crunch/extra/ReviewCapability.js
@@ -13,6 +13,10 @@ foam.CLASS({
     as its own data. This is useful for implementing a review process.
   `,
 
+  requires: [
+    'foam.nanos.crunch.ui.ReviewCapabilityWizardlet'
+  ],
+
   properties: [
     {
       class: 'Object',
@@ -21,7 +25,7 @@ foam.CLASS({
         Defines a wizardlet used when displaying this capability on related client crunch wizards.
       `,
       factory: function() {
-        return foam.nanos.crunch.ui.ReviewCapabilityWizardlet.create({}, this);
+        return this.ReviewCapabilityWizardlet.create({}, this);
       }
     },
     {

--- a/src/foam/nanos/crunch/extra/ReviewCapability.js
+++ b/src/foam/nanos/crunch/extra/ReviewCapability.js
@@ -25,7 +25,7 @@ foam.CLASS({
         Defines a wizardlet used when displaying this capability on related client crunch wizards.
       `,
       factory: function() {
-        return this.ReviewCapabilityWizardlet.create({}, this);
+        return this.ReviewCapabilityWizardlet.create();
       }
     },
     {

--- a/src/foam/nanos/crunch/extra/ReviewCapability.js
+++ b/src/foam/nanos/crunch/extra/ReviewCapability.js
@@ -7,12 +7,23 @@
 foam.CLASS({
   package: 'foam.nanos.crunch.extra',
   name: 'ReviewCapability',
+  extends: 'foam.nanos.crunch.Capability',
   documentation: `
-    This capability displays a portal to another capability with
-    review options.
+    This capability displays a portal to another capability as well
+    as its own data. This is useful for implementing a review process.
   `,
 
   properties: [
+    {
+      class: 'Object',
+      name: 'wizardlet',
+      documentation: `
+        Defines a wizardlet used when displaying this capability on related client crunch wizards.
+      `,
+      factory: function() {
+        return foam.nanos.crunch.ui.ReviewCapabilityWizardlet.create({}, this);
+      }
+    },
     {
       name: 'capabilityToReview',
       class: 'Reference',
@@ -20,10 +31,12 @@ foam.CLASS({
       view: 'foam.nanos.crunch.ui.UCJView'
     },
     {
-      name: 'reviewed',
-      class: 'Boolean'
+      name: 'of',
+      class: 'Class',
+      factory: function() {
+        return 'foam.nanos.crunch.extra.ReviewCapabilityData';
+      },
+      javaFactory: 'return ReviewCapabilityData.getOwnClassInfo();'
     }
   ],
-
-  // TODO: validate; reviewed must be true
 });

--- a/src/foam/nanos/crunch/extra/ReviewCapabilityData.js
+++ b/src/foam/nanos/crunch/extra/ReviewCapabilityData.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 foam.CLASS({
   package: 'foam.nanos.crunch.extra',
   name: 'ReviewCapabilityData',

--- a/src/foam/nanos/crunch/extra/ReviewCapabilityData.js
+++ b/src/foam/nanos/crunch/extra/ReviewCapabilityData.js
@@ -9,7 +9,7 @@ foam.CLASS({
   name: 'ReviewCapabilityData',
 
   messages: [
-    { name: 'REVIEW_REQUIRED_ERROR', message: 'All data must be reviewed by a signing officer.' }
+    { name: 'REVIEW_REQUIRED_ERROR', message: 'All data must be reviewed by a privileged user.' }
   ],
 
   properties: [

--- a/src/foam/nanos/crunch/extra/ReviewCapabilityData.js
+++ b/src/foam/nanos/crunch/extra/ReviewCapabilityData.js
@@ -1,0 +1,27 @@
+foam.CLASS({
+  package: 'foam.nanos.crunch.extra',
+  name: 'ReviewCapabilityData',
+
+  messages: [
+    { name: 'REVIEW_REQUIRED_ERROR', message: 'All data must be reviewed by a signing officer.' }
+  ],
+
+  properties: [
+    {
+      name: 'reviewed',
+      class: 'Boolean',
+      validationPredicates: [
+        {
+          args: ['reviewed'],
+          predicateFactory: function(e) {
+            return e.EQ(
+              foam.nanos.crunch.extra.ReviewCapabilityData.REVIEWED,
+              true
+            );
+          },
+          errorMessage: 'REVIEW_REQUIRED_ERROR'
+        }
+      ]
+    }
+  ]
+});

--- a/src/foam/nanos/crunch/extra/doc.flow
+++ b/src/foam/nanos/crunch/extra/doc.flow
@@ -1,0 +1,3 @@
+<title>CRUNCH Extras</title>
+
+This package contains utility classes for use with CRUNCH.

--- a/src/foam/nanos/crunch/ui/ReviewCapabilityView.js
+++ b/src/foam/nanos/crunch/ui/ReviewCapabilityView.js
@@ -1,0 +1,30 @@
+foam.CLASS({
+  package: 'foam.nanos.crunch.ui',
+  name: 'ReviewCapabilityView',
+  extends: 'foam.u2.View',
+
+  requires: [
+    'foam.nanos.crunch.ui.UCJView',
+    'foam.u2.detail.SectionedDetailView'
+  ],
+
+  properties: [
+    {
+      name: 'capabilityId',
+      class: 'Reference',
+      of: 'foam.nanos.crunch.Capability'
+    }
+  ],
+
+  methods: [
+    function initE() {
+      this.SUPER();
+      this
+        .tag(this.UCJView, { data$: this.capabilityId$ })
+        .tag(this.SectionedDetailView, {
+          data$: this.data$
+        })
+        ;
+    }
+  ]
+});

--- a/src/foam/nanos/crunch/ui/ReviewCapabilityView.js
+++ b/src/foam/nanos/crunch/ui/ReviewCapabilityView.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 foam.CLASS({
   package: 'foam.nanos.crunch.ui',
   name: 'ReviewCapabilityView',

--- a/src/foam/nanos/crunch/ui/ReviewCapabilityWizardlet.js
+++ b/src/foam/nanos/crunch/ui/ReviewCapabilityWizardlet.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 foam.CLASS({
   package: 'foam.nanos.crunch.ui',
   name: 'ReviewCapabilityWizardlet',

--- a/src/foam/nanos/crunch/ui/ReviewCapabilityWizardlet.js
+++ b/src/foam/nanos/crunch/ui/ReviewCapabilityWizardlet.js
@@ -1,0 +1,39 @@
+foam.CLASS({
+  package: 'foam.nanos.crunch.ui',
+  name: 'ReviewCapabilityWizardlet',
+  extends: 'foam.nanos.crunch.ui.CapabilityWizardlet',
+
+  properties: [
+    {
+      name: 'sections',
+      factory: function () {
+        var reviewSection = this.WizardletSection.create({
+          title: 'Review',
+          data$: this.data$,
+          isAvailable: true,
+          customView: {
+            class: 'foam.nanos.crunch.ui.ReviewCapabilityView',
+            capabilityId: this.capability.capabilityToReview,
+            data$: this.data$
+          }
+        })
+        return [ reviewSection ];
+      }
+    },
+    {
+      name: 'isValid',
+      class: 'Boolean',
+      documentation: `
+        Override of isValid to omit per-section logic; it is not needed
+        for ReviewCapabilityData which contains only the default section.
+      `,
+      expression: function (of, data, currentSection, data$errors_) {
+        if ( ! this.of ) return true;
+        if ( data$errors_ && data$errors_.length > 0 ) {
+          return false;
+        }
+        return true;
+      }
+    },
+  ],
+})

--- a/src/foam/nanos/crunch/ui/UCJView.js
+++ b/src/foam/nanos/crunch/ui/UCJView.js
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.nanos.crunch.ui',
+  name: 'UCJView',
+  extends: 'foam.u2.View',
+  documentation: `
+    Views the capability ID (in data) by fetching the UCJ associated with
+    the subject in context and displaying it in READ mode.
+
+    UCJView also provides an Edit action, which will present a popup
+    allowing the user to make changes to the UCJ.
+
+    This can be thought of as a view of a capability that is personalized
+    to the user.
+  `,
+
+  methods: [
+    function initE() {
+      this.SUPER();
+    }
+  ]
+
+  // TODO: fetch UCJ
+  // TODO: create UCJEditView for popup
+  // TODO: add edit action (creates popup)
+});

--- a/src/foam/nanos/crunch/ui/UCJView.js
+++ b/src/foam/nanos/crunch/ui/UCJView.js
@@ -82,7 +82,6 @@ foam.CLASS({
 
   actions: [
     function edit() {
-      console.log('actionThis', this);
       var crunchContext = this.__subContext__.createSubContext({
         rootCapability: this.data
       });
@@ -100,7 +99,6 @@ foam.CLASS({
           this.update();
         })
         .catch(err => {
-          debugger;
           console.error(err);
         })
         ;

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -373,6 +373,7 @@ FOAM_FILES([
   { name: "foam/nanos/crunch/lite/ruler/SetCapablePayloadStatusOnPut" },
   { name: "foam/nanos/crunch/lite/ruler/ReputDependantPayloads" },
 
+  // crunch capability categories
   { name: "foam/nanos/crunch/CapabilityCategory" },
   { name: "foam/nanos/crunch/UserCapabilityJunctionRefine" },
   { name: "foam/nanos/crunch/CapabilityCapabilityJunctionRefine" },
@@ -402,9 +403,15 @@ FOAM_FILES([
   //views
   { name: "foam/nanos/crunch/ui/CapableView" },
   { name: "foam/nanos/crunch/ui/CapabilityWizardlet" },
+  { name: "foam/nanos/crunch/ui/ReviewCapabilityWizardlet" },
+  { name: "foam/nanos/crunch/ui/ReviewCapabilityView" },
+  { name: 'foam/nanos/crunch/ui/UCJView' },
   //boxes
   { name: "foam/nanos/crunch/box/CrunchClientBox" },
   { name: "foam/nanos/crunch/box/CrunchClientReplyBox" },
+  //extras
+  { name: 'foam/nanos/crunch/extra/ReviewCapability' },
+  { name: 'foam/nanos/crunch/extra/ReviewCapabilityData' },
 
   // approval
   { name: 'foam/nanos/approval/ApprovalRequest' },

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -670,6 +670,7 @@ var classes = [
   'foam.nanos.crunch.CapabilityJunctionStatus',
   'foam.nanos.crunch.UserCapabilityJunction',
   'foam.nanos.crunch.ui.CapabilityWizardlet',
+  'foam.nanos.crunch.ui.ReviewCapabilityWizardlet',
   'foam.nanos.crunch.ui.MinMaxCapabilityWizardlet',
   'foam.nanos.crunch.AgentCapabilityJunction',
   'foam.nanos.crunch.CapabilityCapabilityJunction',
@@ -699,6 +700,11 @@ var classes = [
   'foam.nanos.crunch.ruler.SetUCJStatusOnPut',
   'foam.nanos.crunch.ruler.ConfigureUCJExpiryOnGranted',
   'foam.nanos.crunch.ruler.SaveUCJDataOnGranted',
+
+  //crunch extras
+  'foam.nanos.crunch.extra.ReviewCapability',
+  'foam.nanos.crunch.extra.ReviewCapabilityData',
+
   //authservice
   'foam.nanos.auth.CapabilityAuthService',
   // userQueryService


### PR DESCRIPTION
A ReviewCapability is a Capability which asks a user to review another Capability they previously obtained. It has a corresponding Wizardlet which displays the capability being reviewed, provides an `Edit` button which opens this capability in a new wizard, and prevents continuing until the review checkbox is checked.

TODO: it may be desired to omit this review checkbox and have the Submit button read "Accept" instead. This will require some additional work to allow wizardlets to determine the labels on the wizard. A caveat to this would be that the user might not scroll to the bottom before hitting accept.

<img width="1058" alt="Screen Shot 2020-10-26 at 2 13 50 AM" src="https://user-images.githubusercontent.com/7225168/97139895-e3588e00-1731-11eb-9222-35d78accf7bb.png">
