### PR TITLE
Allow object with spid="*" to be found

### DIFF
--- a/src/foam/nanos/auth/ServiceProviderAwareSupport.js
+++ b/src/foam/nanos/auth/ServiceProviderAwareSupport.js
@@ -101,7 +101,7 @@ returning true if the spid or context users spid matches the current object.`,
       if ( obj != null &&
            obj instanceof ServiceProviderAware ) {
         ServiceProviderAware sp = (ServiceProviderAware) obj;
-        return sp.getSpid().equals("*") || sp.getSpid().startsWith(spid) ||
+        return sp.getSpid().startsWith(spid) || sp.getSpid().equals("*") ||
                  isUserSpid && auth.check(x, getSpidReadPermission(sp.getSpid()));
       }
 
@@ -123,7 +123,7 @@ returning true if the spid or context users spid matches the current object.`,
             if ( result != null &&
                  result instanceof ServiceProviderAware ) {
               ServiceProviderAware sp = (ServiceProviderAware) result;
-              return sp.getSpid().equals("*") || sp.getSpid().startsWith(spid) ||
+              return sp.getSpid().startsWith(spid) || sp.getSpid().equals("*") ||
                        isUserSpid && auth.check(x, getSpidReadPermission(sp.getSpid()));
             } else {
               break;

--- a/src/foam/nanos/auth/ServiceProviderAwareSupport.js
+++ b/src/foam/nanos/auth/ServiceProviderAwareSupport.js
@@ -101,7 +101,7 @@ returning true if the spid or context users spid matches the current object.`,
       if ( obj != null &&
            obj instanceof ServiceProviderAware ) {
         ServiceProviderAware sp = (ServiceProviderAware) obj;
-        return sp.getSpid().startsWith(spid) ||
+        return sp.getSpid().equals("*") || sp.getSpid().startsWith(spid) ||
                  isUserSpid && auth.check(x, getSpidReadPermission(sp.getSpid()));
       }
 
@@ -123,7 +123,7 @@ returning true if the spid or context users spid matches the current object.`,
             if ( result != null &&
                  result instanceof ServiceProviderAware ) {
               ServiceProviderAware sp = (ServiceProviderAware) result;
-              return sp.getSpid().startsWith(spid) ||
+              return sp.getSpid().equals("*") || sp.getSpid().startsWith(spid) ||
                        isUserSpid && auth.check(x, getSpidReadPermission(sp.getSpid()));
             } else {
               break;


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-2472

## Issues
- Treviso backoffice users need to find theme of "\*" spid defined in the parent group. The themeDAO has GlobalReadAuthorizer but ServiceProviderAwareSupport prevents it from reading the theme with "*" spid and fails the loading of group theme.

## Changes
- Allow object with spid="\*" to be found