### PR TITLE
NP2465-And-NP2462 / UI fixes for Signup and User registration 

### DIFF
--- a/src/foam/core/Validation.js
+++ b/src/foam/core/Validation.js
@@ -152,7 +152,7 @@ foam.CLASS({
             predicateFactory: function(e) {
               return e.GTE(foam.mlang.StringLength.create({ arg1: self }), self.minLength);
             },
-            errorString: `Please enter ${this.label.toLowerCase()} with at least ${this.minLength} character${this.minLength>1?'s':''}`
+            errorString: `${this.label} should be at least ${this.minLength} character${this.minLength>1?'s':''}`
           });
         }
 
@@ -162,7 +162,7 @@ foam.CLASS({
             predicateFactory: function(e) {
               return e.LTE(foam.mlang.StringLength.create({ arg1: self }), self.maxLength);
             },
-            errorString: `Please enter ${this.label.toLowerCase()} with at most ${this.maxLength} character${this.maxLength>1?'s':''}`
+            errorString: `${this.label} should be at most ${this.maxLength} character${this.maxLength>1?'s':''}`
           });
         }
 
@@ -172,7 +172,7 @@ foam.CLASS({
             predicateFactory: function(e) {
               return e.GTE(foam.mlang.StringLength.create({ arg1: self }), 1);
             },
-            errorString: `Please enter ${this.label.toLowerCase()}`
+            errorString: `${this.label} required`
           });
         }
         return a;
@@ -410,14 +410,14 @@ foam.CLASS({
                 predicateFactory: function(e) {
                   return e.HAS(self);
                 },
-                errorString: 'Phone number required.'
+                errorString: 'Phone number required'
               },
               {
                 args: [this.name],
                 predicateFactory: function(e) {
                   return e.REG_EXP(self, PHONE_NUMBER_REGEX);
                 },
-                errorString: 'Invalid phone number.'
+                errorString: 'Invalid phone number'
               }
             ]
           : [

--- a/src/foam/layout/Section.js
+++ b/src/foam/layout/Section.js
@@ -55,7 +55,10 @@ foam.CLASS({
       name: 'subTitle'
     },
     {
-      name: 'wizardTitle'
+      name: 'navTitle',
+      expression: function (title) {
+        return title;
+      }
     },
     {
       documentation: 'function and string',

--- a/src/foam/layout/Section.js
+++ b/src/foam/layout/Section.js
@@ -55,6 +55,9 @@ foam.CLASS({
       name: 'subTitle'
     },
     {
+      name: 'wizardTitle'
+    },
+    {
       documentation: 'function and string',
       name: 'help'
     },

--- a/src/foam/layout/SectionAxiom.js
+++ b/src/foam/layout/SectionAxiom.js
@@ -24,6 +24,9 @@ foam.CLASS({
       name: 'subTitle'
     },
     {
+      name: 'wizardTitle'
+    },
+    {
       name: 'help'
     },
     {

--- a/src/foam/layout/SectionAxiom.js
+++ b/src/foam/layout/SectionAxiom.js
@@ -24,7 +24,7 @@ foam.CLASS({
       name: 'subTitle'
     },
     {
-      name: 'wizardTitle'
+      name: 'navTitle'
     },
     {
       name: 'help'

--- a/src/foam/nanos/u2/navigation/SignUp.js
+++ b/src/foam/nanos/u2/navigation/SignUp.js
@@ -184,7 +184,7 @@ foam.CLASS({
   actions: [
     {
       name: 'login',
-      label: 'Get Started',
+      label: 'Get started',
       isEnabled: function(errors_, isLoading_) {
         return ! errors_ && ! isLoading_;
       },

--- a/src/foam/nanos/u2/navigation/SignUp.js
+++ b/src/foam/nanos/u2/navigation/SignUp.js
@@ -36,7 +36,7 @@ foam.CLASS({
     { name: 'ERROR_MSG', message: 'There was a problem creating your account.' },
     { name: 'EMAIL_ERR', message: 'Valid email required' },
     { name: 'EMAIL_AVAILABILITY_ERR', message: 'This email is taken. Please try another.' },
-    { name: 'USERNAME_EMPTY_ERR', message: 'User name required' },
+    { name: 'USERNAME_EMPTY_ERR', message: 'Username required' },
     { name: 'USERNAME_AVAILABILITY_ERR', message: 'This username is taken. Please try another.' }
   ],
 

--- a/src/foam/nanos/u2/navigation/SignUp.js
+++ b/src/foam/nanos/u2/navigation/SignUp.js
@@ -30,14 +30,13 @@ foam.CLASS({
   ],
 
   messages: [
-    { name: 'TITLE', message: 'Create a free account' },
+    { name: 'TITLE', message: 'Create an account' },
     { name: 'FOOTER_TXT', message: 'Already have an account?' },
     { name: 'FOOTER_LINK', message: 'Sign in' },
     { name: 'ERROR_MSG', message: 'There was a problem creating your account.' },
-    { name: 'EMAIL_EMPTY_ERR', message: 'Please enter email' },
-    { name: 'EMAIL_SYNTAX_ERR', message: 'Please enter valid email' },
+    { name: 'EMAIL_ERR', message: 'Valid email required' },
     { name: 'EMAIL_AVAILABILITY_ERR', message: 'This email is taken. Please try another.' },
-    { name: 'USERNAME_EMPTY_ERR', message: 'Please enter username' },
+    { name: 'USERNAME_EMPTY_ERR', message: 'User name required' },
     { name: 'USERNAME_AVAILABILITY_ERR', message: 'This username is taken. Please try another.' }
   ],
 
@@ -95,9 +94,7 @@ foam.CLASS({
       },
       validateObj: function(email, emailAvailable) {
         // Empty Check
-        if ( email.length === 0 ) return this.EMAIL_EMPTY_ERR;
-        // Syntax Check
-        if ( ! /\S+@\S+\.\S+/.test(email) ) return this.EMAIL_SYNTAX_ERR;
+        if ( email.length === 0 || ! /\S+@\S+\.\S+/.test(email) ) return this.EMAIL_ERR;
         // Availability Check
         if ( ! emailAvailable ) return this.EMAIL_AVAILABILITY_ERR;
       },

--- a/src/foam/u2/wizard/StepWizardletStepsView.js
+++ b/src/foam/u2/wizard/StepWizardletStepsView.js
@@ -168,7 +168,7 @@ foam.CLASS({
         }))
     },
     function renderSectionLabel(elem, section, index, isCurrent) {
-      let title = section.wizardTitle;
+      let title = section.navTitle;
       if ( ! title || ! title.trim() ) title = "Part " + index;
       return elem       
         .style({

--- a/src/foam/u2/wizard/StepWizardletStepsView.js
+++ b/src/foam/u2/wizard/StepWizardletStepsView.js
@@ -168,7 +168,7 @@ foam.CLASS({
         }))
     },
     function renderSectionLabel(elem, section, index, isCurrent) {
-      let title = section.title;
+      let title = section.wizardTitle;
       if ( ! title || ! title.trim() ) title = "Part " + index;
       return elem       
         .style({

--- a/src/foam/u2/wizard/WizardletSection.js
+++ b/src/foam/u2/wizard/WizardletSection.js
@@ -44,6 +44,13 @@ foam.CLASS({
     {
       name: 'customView',
       class: 'foam.u2.ViewSpec'
+    },
+    {
+      name: 'wizardTitle',
+      class: 'String',
+      expression: function(section) {
+        return section.wizardTitle || section.title;
+      }
     }
   ],
 

--- a/src/foam/u2/wizard/WizardletSection.js
+++ b/src/foam/u2/wizard/WizardletSection.js
@@ -46,10 +46,10 @@ foam.CLASS({
       class: 'foam.u2.ViewSpec'
     },
     {
-      name: 'wizardTitle',
+      name: 'navTitle',
       class: 'String',
       expression: function(section) {
-        return section.wizardTitle || section.title;
+        return section.navTitle;
       }
     }
   ],


### PR DESCRIPTION
Addresses:
- https://nanopay.atlassian.net/browse/NP-2465
- https://nanopay.atlassian.net/browse/NP-2462

Changes:
- Added a wizardTitle to section and wizardSection, so that we can specify a wizard title -- For stepWizardlet, we use the wizardTitle to specify the subTtitle for each StepWizardletSteps
- Change String's default validation error messages for consistency
- Didn't manually add sentence cased labels, because this should be automatically handled after NP-2477 is finished

<img width="1440" alt="Screen Shot 2020-10-27 at 10 14 21 AM" src="https://user-images.githubusercontent.com/38148986/97317636-61578a80-1841-11eb-9b14-e6c81e3ddf45.png">
<img width="1440" alt="Screen Shot 2020-10-27 at 10 14 29 AM" src="https://user-images.githubusercontent.com/38148986/97317665-69afc580-1841-11eb-87cb-3e2cdf7793de.png">
<img width="1440" alt="Screen Shot 2020-10-27 at 10 24 10 AM" src="https://user-images.githubusercontent.com/38148986/97317678-6c121f80-1841-11eb-985c-571b5a656e6e.png">

