### PR TITLE
Fix ServiceProvider permissionsGranted getter

### DIFF
--- a/src/foam/nanos/auth/ServiceProvider.js
+++ b/src/foam/nanos/auth/ServiceProvider.js
@@ -52,8 +52,16 @@ foam.CLASS({
     },
     {
       name: 'permissionsGranted',
-      transient: true,
-      javaGetter: 'return new String[] { "serviceprovider.read." + getId() };',
+      networkTransient: true,
+      javaGetter: `
+        int c = permissionsGranted_ != null ? permissionsGranted_.length : 0;
+        String[] perms = new String[c + 1];
+        for ( int i = 0 ; i < c ; i++ ) {
+          perms[i] = permissionsGranted_[i];
+        }
+        perms[c] = "serviceprovider.read." + getId();
+        return perms;
+      `,
       hidden: true
     }
   ],


### PR DESCRIPTION
There were two problems causing NP-2471. A transient property was set in a journal entry, which caused my last fix (without the null check) to break the build. This PR changes the property to `networkTransient` and adds a null check.