### PR TITLE
fixed beneficial owners err msg without label

### DIFF
--- a/src/foam/core/Validation.js
+++ b/src/foam/core/Validation.js
@@ -192,7 +192,7 @@ foam.CLASS({
   refines: 'foam.core.FObjectProperty',
 
   messages: [
-    { name: 'PLEASE_ENTER_VALID', value: 'Please enter valid' },
+    { name: 'PLEASE_ENTER_VALID', message: 'Please enter valid' },
   ],
 
   properties: [
@@ -204,10 +204,11 @@ foam.CLASS({
       name: 'validateObj',
       expression: function(name, label, required, validationPredicates, autoValidate) {
         if ( autoValidate ) {
+          var self = this;
           return [
             [`${name}$errors_`],
             function(errs) {
-              return errs ? `${this.PLEASE_ENTER_VALID} ${label.toLowerCase()}` : null;
+              return errs ? `${self.PLEASE_ENTER_VALID} ${(label || name).toLowerCase()}` : null;
             }
           ];
         }


### PR DESCRIPTION
nanopay : https://github.com/nanoPayinc/NANOPAY/pull/10944

https://nanopay.atlassian.net/browse/NP-2379
https://nanopay.atlassian.net/browse/NP-2378
https://nanopay.atlassian.net/browse/NP-2439
https://nanopay.atlassian.net/browse/NP-2520

fixed being able to go "next" even error messgaes thrown on beneficial owner screens by fixing foam validation.js that only returning when property has 'label'.

fixed even though proper percentage input but not able to go "next" due to the no set hidden  property - 'nationality'.

fixed wrong button message on suppliers screen



<img width="756" alt="Screen Shot 2020-10-28 at 1 04 00 PM" src="https://user-images.githubusercontent.com/33228583/97470605-18c1cf00-191e-11eb-8eec-78d07831976c.png">
<img width="763" alt="Screen Shot 2020-10-28 at 1 04 07 PM" src="https://user-images.githubusercontent.com/33228583/97470607-18c1cf00-191e-11eb-9845-eadc97152db3.png">
<img width="755" alt="Screen Shot 2020-10-28 at 1 04 12 PM" src="https://user-images.githubusercontent.com/33228583/97470608-195a6580-191e-11eb-86f2-9d888dd5ca4d.png">
<img width="526" alt="Screen Shot 2020-10-28 at 1 16 50 PM" src="https://user-images.githubusercontent.com/33228583/97472134-de593180-191f-11eb-800f-a4a93b6d732d.png">
