### PR TITLE
[NP-2436] Add ReviewWizard and script

### DIFF
--- a/src/foam/nanos/crunch/extra/ReviewWizard.js
+++ b/src/foam/nanos/crunch/extra/ReviewWizard.js
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.nanos.crunch.extra',
+  name: 'ReviewWizard',
+  extends: 'foam.nanos.crunch.Capability',
+  documentation: `
+    This capability is recognized by ReviewWizardDAO.
+  `,
+
+  properties: [
+    {
+      name: 'capabilityToReview',
+      class: 'Reference',
+      of: 'foam.nanos.crunch.Capability'
+    }
+  ],
+});

--- a/src/foam/nanos/crunch/scripts.jrl
+++ b/src/foam/nanos/crunch/scripts.jrl
@@ -1,0 +1,58 @@
+p({
+  "class": "foam.nanos.script.Script",
+  "id": "Generate Review Capabilities",
+  "status": 2,
+  "code": """
+    import foam.dao.ArraySink;
+    import foam.dao.DAO;
+    import foam.nanos.crunch.Capability;
+    import foam.nanos.crunch.CapabilityCapabilityJunction;
+    import foam.nanos.crunch.CrunchService;
+    import foam.nanos.crunch.extra.ReviewCapability;
+    import foam.nanos.crunch.extra.ReviewWizard;
+    import foam.mlang.MLang;
+    import java.util.List;
+
+    // Context Requirements
+    var crunchService = (CrunchService) x.get("crunchService");
+    var capabilityDAO = (DAO) x.get("localCapabilityDAO");
+    var pcjDAO = (DAO) x.get("prerequisiteCapabilityJunctionDAO");
+
+    List reviewWizards = capabilityDAO
+      .where(MLang.INSTANCE_OF(ReviewWizard.class))
+      .select(new ArraySink()).getArray();
+    
+    for ( Object o : reviewWizards ) {
+      var reviewWizard = (ReviewWizard) o;
+
+      // CRUNCH path determines prerequisites for review
+      List idsToReview = crunchService.getCapabilityPath(
+        x, reviewWizard.getCapabilityToReview(), false);
+
+      for ( int i = 0 ; i < idsToReview.size() ; i++ ) {
+        // TODO: add support for minmax lists
+        if ( ! ( idsToReview.get(i) instanceof Capability ) ) continue;
+        var cap = (Capability) idsToReview.get(i);
+
+        // Skip capability with no data to review
+        if ( cap.getOf() == null ) continue;
+
+        // Add review capability for this prerequisite
+        var reviewId = reviewWizard.getId() + ":" + cap.getId();
+        var reviewCapability = new ReviewCapability.Builder(x)
+          .setId(reviewId)
+          .setName(cap.getName())
+          .setCapabilityToReview(cap.getId())
+          .build();
+        capabilityDAO.put(reviewCapability);
+
+        // Add prerequisite junction for this review capability
+        var reviewPrereq = new CapabilityCapabilityJunction.Builder(x)
+          .setSourceId(reviewWizard.getId())
+          .setTargetId(reviewId)
+          .build();
+        pcjDAO.put(reviewPrereq);
+      }
+    }
+  """
+})

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -412,6 +412,7 @@ FOAM_FILES([
   //extras
   { name: 'foam/nanos/crunch/extra/ReviewCapability' },
   { name: 'foam/nanos/crunch/extra/ReviewCapabilityData' },
+  { name: 'foam/nanos/crunch/extra/ReviewWizard' },
 
   // approval
   { name: 'foam/nanos/approval/ApprovalRequest' },

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -704,6 +704,7 @@ var classes = [
   //crunch extras
   'foam.nanos.crunch.extra.ReviewCapability',
   'foam.nanos.crunch.extra.ReviewCapabilityData',
+  'foam.nanos.crunch.extra.ReviewWizard',
 
   //authservice
   'foam.nanos.auth.CapabilityAuthService',


### PR DESCRIPTION
A ReviewWizard capability can be used to generate the corresponding ReviewCapability for each prerequisite of some "top-level" capability. After running the script they can be copied to repository journals from runtime journals.