### PR TITLE
remove explicit check for checkbox

### DIFF
--- a/src/foam/u2/detail/SectionedDetailPropertyView.js
+++ b/src/foam/u2/detail/SectionedDetailPropertyView.js
@@ -86,10 +86,6 @@ foam.CLASS({
       cursor: pointer;
     }
 
-    ^flex {
-      display: flex;
-    }
-
     ^error .foam-u2-tag-TextArea,
     ^error .foam-u2-tag-Select,
     ^error .foam-u2-TextField,
@@ -235,21 +231,13 @@ foam.CLASS({
         .addClass(`sectioned-detail-property-${this.prop.name}`)
         .add(this.slot(function(mode, prop, prop$label) {
 
-          var isCheckBox = false;
-          if ( foam.Function.isInstance(prop.view) ) {
-            isCheckBox = prop.view.class === 'foam.u2.CheckBox' || ( prop.view.cls_ && prop.view.cls_.id === 'foam.u2.CheckBox' );
-          }
-          else {
-            isCheckBox = prop.view.class === 'foam.u2.CheckBox';
-          }
-
           var errorSlot = prop.validateObj && prop.validationTextVisible ?
             this.data.slot(prop.validateObj) :
             foam.core.ConstantSlot.create({ value: null });
 
           return self.E()
             .start(self.Rows)
-              .callIf(prop$label && ! isCheckBox, function() {
+              .callIf(prop$label && ! prop.view.class != 'foam.u2.CheckBox', function() {
                 this.start('m3')
                   .add(prop$label)
                   .style({ 'line-height': '2' })
@@ -259,7 +247,6 @@ foam.CLASS({
                 .style({ 'position': 'relative', 'display': 'inline-flex', 'width': '100%' })
                 .start()
                   .style({ 'flex-grow': 1, 'max-width': '100%' })
-                  .enableClass(self.myClass('flex'), isCheckBox)
                   .tag(prop, { mode$: self.mode$ })
                   .callIf(prop.validationStyleEnabled, function() {
                     this.enableClass(self.myClass('error'), errorSlot);


### PR DESCRIPTION
The checkbox text and its validation text were overlapping was because of the css set -- position:absolute.
Since the "position:absolute" had been removed, the text overlapping issue had been fixed. The explicit check for checkbox is not necessary for solving the issue.

<img width="1440" alt="Screen Shot 2020-11-02 at 11 23 10 AM" src="https://user-images.githubusercontent.com/38148986/97892471-0967ca80-1cfe-11eb-8ff4-22265269c6b1.png">
<img width="1440" alt="Screen Shot 2020-11-02 at 11 20 02 AM" src="https://user-images.githubusercontent.com/38148986/97892474-0b318e00-1cfe-11eb-899e-6aca1742e8af.png">
<img width="1440" alt="Screen Shot 2020-11-02 at 11 21 15 AM" src="https://user-images.githubusercontent.com/38148986/97892479-0c62bb00-1cfe-11eb-926a-f22227aeb917.png">
