### PR TITLE
CapabilityPayloadDAO fix

### DIFF
--- a/src/foam/nanos/approval/SendGroupRequestApprovalDAO.js
+++ b/src/foam/nanos/approval/SendGroupRequestApprovalDAO.js
@@ -73,7 +73,7 @@ foam.CLASS({
 
         if ( group == null ) {
           Logger logger = (Logger) x.get("logger");
-          logger.error(GROUP_NOT_SET_ERROR_MSG);
+          logger.error(GROUP_NOT_SET_ERROR_MSG, request.getGroup(), request.getApprover());
           throw new RuntimeException(GROUP_NOT_SET_ERROR_MSG);
         }
 


### PR DESCRIPTION
Keep the capabilities retrieved from the CrunchService.getGrantPath in order so that they are resubmitted in the CapabilityPayloadDAO in order. This is necessary for MinMaxCapabilities to work properly.