### PR TITLE
Do not output id if it is storage transient

### DIFF
--- a/src/foam/lib/formatter/JSONFObjectFormatter.java
+++ b/src/foam/lib/formatter/JSONFObjectFormatter.java
@@ -339,11 +339,14 @@ public class JSONFObjectFormatter
     }
     addInnerNewline();
     PropertyInfo id = (PropertyInfo) newInfo.getAxiomByName("id");
-    if ( ! id.getStorageTransient() ) outputProperty(newFObject, id);
+    boolean outputId = ! id.getStorageTransient();
+    if ( outputId ) outputProperty(newFObject, id);
 
     for ( int i = 0 ; i < size ; i++ ) {
-      append(',');
-      addInnerNewline();
+      if ( i > 0 || outputId ) {
+        append(',');
+        addInnerNewline();
+      }
       PropertyInfo prop = (PropertyInfo) delta.get(i);
       outputProperty(newFObject, prop);
     }

--- a/src/foam/lib/formatter/JSONFObjectFormatter.java
+++ b/src/foam/lib/formatter/JSONFObjectFormatter.java
@@ -339,8 +339,7 @@ public class JSONFObjectFormatter
     }
     addInnerNewline();
     PropertyInfo id = (PropertyInfo) newInfo.getAxiomByName("id");
-    outputProperty(newFObject, id);
-
+    if ( ! id.getStorageTransient() ) outputProperty(newFObject, id);
 
     for ( int i = 0 ; i < size ; i++ ) {
       append(',');


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-2618

## Issues
- Multipart id property is generated as storage transient and should not be written to the journal

## Changes
- Check storage transient to output id property