### PR TITLE
wrap words for table headers

### DIFF
--- a/src/foam/nanos/column/ColumnConfigPropertyValue.js
+++ b/src/foam/nanos/column/ColumnConfigPropertyValue.js
@@ -86,7 +86,7 @@ foam.CLASS({
             }
           }
         }
-        return columnHeader.join('/');
+        return columnHeader.join(' / ');
       }
     },
     {

--- a/src/foam/u2/view/UnstyledTableView.js
+++ b/src/foam/u2/view/UnstyledTableView.js
@@ -345,7 +345,7 @@ foam.CLASS({
                 this.start().
                   addClass(view.myClass('th')).
                   addClass(view.myClass('th-' + prop.name))
-                  .style({ flex: tableWidth ? `0 0 ${tableWidth}px` : '1 0 0' })
+                  .style({ flex: tableWidth ? `0 0 ${tableWidth}px` : '1 0 0', 'word-wrap' : 'break-word', 'white-space' : 'normal'})
                   .add(view.columnConfigToPropertyConverter.returnColumnHeader(view.of, col)).
                   callIf(isFirstLevelProperty && prop.sortable, function() {
                     this.on('click', function(e) {


### PR DESCRIPTION
wrap words for table headers so that the headers could be fully displayed
<img width="1440" alt="Screen Shot 2020-11-05 at 3 46 19 PM" src="https://user-images.githubusercontent.com/38148986/98294827-97ea7f00-1f7e-11eb-8e5a-6b62fdcc1bd1.png">
<img width="1440" alt="Screen Shot 2020-11-05 at 3 47 12 PM" src="https://user-images.githubusercontent.com/38148986/98294836-9a4cd900-1f7e-11eb-93f6-34768a730a60.png">
