### PR TITLE
Fix service provider aware dao update

### DIFF
--- a/src/foam/nanos/auth/ServiceProviderAwareDAO.js
+++ b/src/foam/nanos/auth/ServiceProviderAwareDAO.js
@@ -77,6 +77,9 @@ ServiceProviderAware`,
                 ! (auth.check(x, "serviceprovider.update." + oldSp.getSpid()) &&
                    auth.check(x, "serviceprovider.update." + sp.getSpid())) ) {
       throw new AuthorizationException("You do not have permission to update ServiceProvider (spid) property.");
+    } else if ( sp.getSpid().equals(oldSp.getSpid()) &&
+                ! auth.check(x, "serviceprovider.read." + sp.getSpid()) ) {
+      throw new AuthorizationException("You do not have permission to update data on other ServiceProvider.");
     }
 
     return super.put_(x, obj);


### PR DESCRIPTION
## Ref
- https://github.com/nanoPayinc/NANOPAY/pull/11019

## Issues
- User can update data belong to other spid if they leave the spid property unchanged

## Changes
- Do not allow update data on other service provider