### PR TITLE
Revert "RuleEngine.reload - always return cloned object"

### DIFF
--- a/src/foam/nanos/ruler/RuleEngine.java
+++ b/src/foam/nanos/ruler/RuleEngine.java
@@ -306,11 +306,8 @@ public class RuleEngine extends ContextAwareSupport {
     }
 
     // Return the original object as the reloaded object if nu == old or nu == obj.
-    if ( nu.equals(old) ) {
-      return old;
-    }
-    if ( nu.equals(cloned) ) {
-      return cloned;
+    if ( nu.equals(old) || nu.equals(cloned) ) {
+      return obj;
     }
 
     // For greedy mode, return the reloaded object `nu` as is. Otherwise,


### PR DESCRIPTION
Reverts foam-framework/foam2#4234

Breaks test cases - change has some very subtle side effects.