### PR TITLE
[NP-2626] fix capability hover message ui fix

### DIFF
--- a/src/foam/u2/crunch/CapabilityStore.js
+++ b/src/foam/u2/crunch/CapabilityStore.js
@@ -86,7 +86,7 @@ foam.CLASS({
 
     ^perFeature {
       display: flex;
-      padding-bottom: 10px;
+      padding-bottom: 55px;
     }
 
     ^left-arrow {


### PR DESCRIPTION
**address**: https://nanopay.atlassian.net/browse/NP-2626
**notes**: 
- give enough padding to the bottom to each feature so that the help message is not cut off.
- This is a css hack I found to fix the bug, but please let me know if you know a better solution to the problem.

<img width="1440" alt="Screen Shot 2020-11-06 at 9 57 38 AM" src="https://user-images.githubusercontent.com/58435071/98380490-a71d0b80-2016-11eb-8b76-8f3658454122.png">
<img width="1440" alt="Screen Shot 2020-11-06 at 9 56 05 AM" src="https://user-images.githubusercontent.com/58435071/98380510-abe1bf80-2016-11eb-871a-c5cefe8db486.png">
