### PR TITLE
Fix service provider permissionGranted containing duplicate "serviceprovider.read.<SPID>" permission

### DIFF
--- a/src/foam/nanos/auth/ServiceProvider.js
+++ b/src/foam/nanos/auth/ServiceProvider.js
@@ -51,18 +51,9 @@ foam.CLASS({
       `
     },
     {
-      name: 'permissionsGranted',
-      networkTransient: true,
-      javaGetter: `
-        int c = permissionsGranted_ != null ? permissionsGranted_.length : 0;
-        String[] perms = new String[c + 1];
-        for ( int i = 0 ; i < c ; i++ ) {
-          perms[i] = permissionsGranted_[i];
-        }
-        perms[c] = "serviceprovider.read." + getId();
-        return perms;
-      `,
-      hidden: true
+      name: 'inherentPermissions',
+      javaGetter: 'return new String[] { "serviceprovider.read." + getId() };',
+      documentation: 'Service provider must have "serviceprovider.read.<SPID>" inherent permission.',
     }
   ],
 

--- a/src/foam/nanos/auth/ServiceProvider.js
+++ b/src/foam/nanos/auth/ServiceProvider.js
@@ -53,6 +53,9 @@ foam.CLASS({
     {
       name: 'inherentPermissions',
       javaGetter: 'return new String[] { "serviceprovider.read." + getId() };',
+      factory: function() {
+        return [ 'serviceprovider.read.' + this.id ];
+      },
       documentation: 'Service provider must have "serviceprovider.read.<SPID>" inherent permission.',
     }
   ],

--- a/src/foam/nanos/crunch/Capability.js
+++ b/src/foam/nanos/crunch/Capability.js
@@ -154,6 +154,13 @@ foam.CLASS({
       documentation: `Model used to store information required by this credential`
     },
     {
+      name: 'inherentPermissions',
+      class: 'StringArray',
+      documentation: `List of inherent permissions provided by this capability`,
+      storageTransient: true,
+      visibility: 'HIDDEN'
+    },
+    {
       name: 'permissionsGranted',
       class: 'StringArray',
       documentation: `List of permissions granted by this capability`,
@@ -264,6 +271,11 @@ foam.CLASS({
 
         // check if permission is a capability string implied by this permission
         if ( this.stringImplies(this.getName(), permission) ) return true;
+
+        String[] inherentPermissions = this.getInherentPermissions();
+        for ( String permissionName : inherentPermissions ) {
+          if ( this.stringImplies(permissionName, permission) ) return true;
+        }
 
         String[] permissionsGranted = this.getPermissionsGranted();
         for ( String permissionName : permissionsGranted ) {


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-2639

## Issues
- Service provider permissionGranted containing duplicate "serviceprovider.read.<SPID>" permission

## Changes
- Add inherent permissions property to capability
- Set inherent permissions for service provider to "serviceprovider.read.<SPID>"