### PR TITLE
[NP-2564] help icon odd behaviour fix

### DIFF
--- a/src/foam/u2/detail/SectionedDetailPropertyView.js
+++ b/src/foam/u2/detail/SectionedDetailPropertyView.js
@@ -55,7 +55,6 @@ foam.CLASS({
       border-top-right-radius: 0px;
       direction: ltr;
       padding: 2px;
-      text-align: center;
     }
 
     ^arrow-right {

--- a/src/foam/u2/wizard/StepWizardletView.js
+++ b/src/foam/u2/wizard/StepWizardletView.js
@@ -88,8 +88,7 @@ foam.CLASS({
       flex-grow: 1;
       -webkit-mask-image: -webkit-gradient(linear, left 15, left top, from(rgba(0,0,0,1)), to(rgba(0,0,0,0)));
       overflow-y: auto;
-      padding: 0 50px;
-      padding-top: 24px;
+      padding: 24px 50px 100px 50px;
     }
     ^rightside ^top-buttons {
       text-align: right;
@@ -99,7 +98,7 @@ foam.CLASS({
     }
     ^rightside ^bottom-buttons {
       background-color: %GREY6%;
-      padding: 25px 50px;
+      padding: 0 50px 25px 50px;
       text-align: right;
     }
     ^buttons {


### PR DESCRIPTION
address: https://nanopay.atlassian.net/browse/NP-2564
summary:
- when you hovered over the help icon, there was not enough space for the message to be displayed so the wizard was scrolled up and down.
- added enough padding to the entry bottom so that there is enough space for the message to be displayed
- removed padding to the button top so that the button and the last entry in the wizard are not too distant.
- make the help text left-justified

<img width="1155" alt="Screen Shot 2020-11-09 at 12 42 37 PM" src="https://user-images.githubusercontent.com/58435071/98576859-244fb700-2289-11eb-97fb-4be324ec4858.png">

