### PR TITLE
set tableWidth for bussinessName and countryId 

### DIFF
--- a/src/foam/nanos/auth/Address.js
+++ b/src/foam/nanos/auth/Address.js
@@ -88,6 +88,7 @@ foam.CLASS({
       documentation: `A foreign key into the CountryDAO which represents the country.`,
       required: true,
       gridColumns: 6,
+      tableWidth: 135,
       validateObj: function(countryId) {
         if ( typeof countryId !== 'string' || countryId.length === 0 ) {
           return this.COUNTRY_REQUIRED;

--- a/src/foam/nanos/auth/User.js
+++ b/src/foam/nanos/auth/User.js
@@ -449,7 +449,8 @@ foam.CLASS({
       documentation: 'The name of the business associated with the User.',
       width: 50,
       section: 'business',
-      visibility: 'HIDDEN'
+      visibility: 'HIDDEN',
+      tableWidth: 170
     },
     {
       class: 'StringArray',


### PR DESCRIPTION
set tableWidth for bussinessName and countryId to make sure the column titles are always fully displayed

Before:
<img width="590" alt="Screen Shot 2020-11-06 at 2 30 07 PM" src="https://user-images.githubusercontent.com/38148986/98603934-e9fa1000-22b0-11eb-8018-d6c236a74eda.png">

After:
<img width="882" alt="Screen Shot 2020-11-09 at 4 40 04 PM" src="https://user-images.githubusercontent.com/38148986/98603961-f2eae180-22b0-11eb-856f-0b6fc01082d0.png">
<img width="963" alt="Screen Shot 2020-11-09 at 5 31 33 PM" src="https://user-images.githubusercontent.com/38148986/98604336-7a385500-22b1-11eb-9622-df05018b047a.png">
