### PR TITLE
modified height on filter drop down

### DIFF
--- a/src/foam/u2/search/GroupBySearchView.js
+++ b/src/foam/u2/search/GroupBySearchView.js
@@ -32,7 +32,9 @@ foam.CLASS({
   css: `
     ^ select {
       min-width: 220px;
-      min-height: 100px;
+    }
+    ^ .foam-u2-tag-Select {
+      height: auto;
     }
   `,
 
@@ -120,6 +122,7 @@ foam.CLASS({
         })
         .on('mouseover', function(e) {
           try {
+
             var data = self.view.choices[e.target.value][0];
 
             if ( ! self.previewMode ) {

--- a/src/foam/u2/search/GroupBySearchView.js
+++ b/src/foam/u2/search/GroupBySearchView.js
@@ -32,6 +32,7 @@ foam.CLASS({
   css: `
     ^ select {
       min-width: 220px;
+      min-height: 100px;
     }
   `,
 


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/NP-13

increasing the select size function works well but this below applied so it was prevented.
^ .foam-u2-tag-Select { height: /*%INPUTHEIGHT%*/ 40px;}
replaced this height to auto.


<img width="802" alt="Screen Shot 2020-11-10 at 3 55 25 PM" src="https://user-images.githubusercontent.com/33228583/98733614-c85f5e00-236e-11eb-95ef-e231fa697d64.png">
<img width="834" alt="Screen Shot 2020-11-10 at 3 57 46 PM" src="https://user-images.githubusercontent.com/33228583/98733615-c8f7f480-236e-11eb-8c45-d9c89a41d84d.png">
<img width="1217" alt="Screen Shot 2020-11-10 at 4 13 08 PM" src="https://user-images.githubusercontent.com/33228583/98734219-a87c6a00-236f-11eb-8df6-3822937b8d2d.png">
