### PR TITLE
Evaluate template literals of model message for subtitle and title

### DIFF
--- a/src/foam/u2/detail/SectionView.js
+++ b/src/foam/u2/detail/SectionView.js
@@ -52,6 +52,14 @@ foam.CLASS({
       class: 'Boolean',
       name: 'showTitle',
       value: true
+    },
+    {
+      class: 'Function',
+      name: 'evaluateMessage',
+      documentation: `Evaluates model messages without executing potentially harmful values`,
+      factory: function() {
+        return (msg) => msg.replace(/\${(.*?)}/g, (x,g) => this.data[g]);
+      }
     }
   ],
 
@@ -69,6 +77,7 @@ foam.CLASS({
             .callIf(showTitle && section$title, function() {
               var slot$ = foam.Function.isInstance(self.section.title) ?
                 foam.core.ExpressionSlot.create({
+                  args: [ self.evaluateMessage$, self.data$ ],
                   obj$: self.data$,
                   code: section.title
                 }) : section.title$;
@@ -77,6 +86,7 @@ foam.CLASS({
             .callIf(section$subTitle, function() {
               var slot$ = foam.Function.isInstance(self.section.subTitle) ?
               foam.core.ExpressionSlot.create({
+                args: [ self.evaluateMessage$, self.data$ ],
                 obj$: self.data$,
                 code: section.subTitle
               }) : section.subTitle$;


### PR DESCRIPTION
Provides interpolated message support for section subtitle and title using a helper method passed in as the first argument of their functions.

This resolves current problems related to composed string locale translations. Composed strings based on data and messages can not work since locale translations vary. Example: this.data.name + this.myMessage may work in english but in spanish the two may be swapped. Interpolated messages provides the translator freedom to compose messages with data values in mind.

Example:
```javascript 
  name: 'someModel',
  properties: [ ['someVar', 'string' ] ],
  messages: [
    { name: 'someMessage' , message: 'my interpolated ${someVar}' }
  ],
  sections: [
   {
     name: 'someSection', 
     subTitle: function(evaluate, data) {
       // Here we use the evaluteMessage function to interpolate and apply the template literal.
       return evaluate(data.someMessage);
    }
 ]
```