### PR TITLE
Fix bug in event system

### DIFF
--- a/src/foam/core/FObject.js
+++ b/src/foam/core/FObject.js
@@ -573,10 +573,6 @@ foam.CLASS({
         var l = listeners.l;
         var s = listeners.sub;
 
-        // Update 'listeners' before notifying because the listener
-        // may set next to null.
-        listeners = listeners.next;
-
         // Like l.apply(l, [s].concat(Array.from(a))), but faster.
         // FUTURE: add benchmark to justify
         // ???: optional exception trapping, benchmark
@@ -597,6 +593,8 @@ foam.CLASS({
         } catch (x) {
           if ( foam._IS_DEBUG_ ) console.warn("Listener threw exception", x);
         }
+
+        listeners = listeners.next;
         count++;
       }
       return count;
@@ -721,11 +719,12 @@ foam.CLASS({
         l:    l
       };
       node.sub.detach = function() {
-        if ( node.next ) node.next.prev = node.prev;
-        if ( node.prev ) node.prev.next = node.next;
+        if ( node.prev ) {
+          node.prev.next = node.next;
+          if ( node.next ) node.next.prev = node.prev;
+        }
 
-        // Disconnect so that calling detach more than once is harmless
-        node.next = node.prev = null;
+        node.prev = null;
       };
 
       if ( listeners.next ) listeners.next.prev = node;


### PR DESCRIPTION
It's possible for not all listeners to fire if a listener is detached from a particular topic while that topic is firing.  Test case:

```javascript
function test() {
  var obj = foam.core.FObject.create();

  var s1 = obj.sub('a', 'b', function() {
    console.log('l1');
  });

  var s2 = obj.sub('a', 'b', function() {
    console.log('l2');
  });

  var s3 = obj.sub('a', 'b', function() {
    console.log('l3');
  });

  var s4 = obj.sub('a', 'b', function() {
    console.log('l4');
    s2.detach();
    s3.detach();
  });

  obj.pub('a', 'b');
  obj.pub('a', 'b');
}
test();
```

Output should be 

l4
l1