### PR TITLE
Remove Approvals Min Max

### DIFF
--- a/src/foam/nanos/crunch/lite/CapableAdapterDAO.js
+++ b/src/foam/nanos/crunch/lite/CapableAdapterDAO.js
@@ -14,6 +14,8 @@ foam.CLASS({
     'foam.dao.DAO',
     'foam.dao.MDAO',
     'java.util.Arrays',
+    'java.util.ArrayList',
+    'java.util.List',
     'foam.dao.ArraySink'
   ],
 
@@ -67,7 +69,26 @@ foam.CLASS({
     {
       name: 'remove_',
       javaCode: `
-        return obj; // TODO
+        CapablePayload payload = (CapablePayload) obj;
+
+        CapablePayload[] payloads = getCapable().getCapablePayloads();
+        
+        List<CapablePayload> newPayloadsList = new ArrayList<>();
+
+        for ( int i = 0; i < payloads.length; i++ ){
+          if ( ! payload.getCapability().equals(payloads[i].getCapability()) ){
+            newPayloadsList.add(payloads[i]);
+          }
+        }
+
+        if ( payloads.length == newPayloadsList.size() ){
+          return null;
+        }
+
+        CapablePayload[] newPayloads = newPayloadsList.toArray(new CapablePayload[0]);
+        getCapable().setCapablePayloads(newPayloads);
+
+        return obj;
       `,
       code: async function (x, obj) {
         return this.ifFoundElseIfNotFound_(

--- a/src/foam/nanos/crunch/lite/ruler/CapableStatusChangeAdjustApprovalsRuleAction.js
+++ b/src/foam/nanos/crunch/lite/ruler/CapableStatusChangeAdjustApprovalsRuleAction.js
@@ -24,6 +24,7 @@ foam.CLASS({
     'foam.nanos.approval.ApprovalRequest',
     'foam.nanos.approval.Approvable',
     'foam.nanos.crunch.Capability',
+    'foam.nanos.crunch.CrunchService',
     'foam.nanos.crunch.lite.Capable',
     'foam.nanos.crunch.lite.CapablePayload',
     'foam.nanos.crunch.CapabilityJunctionStatus',
@@ -31,6 +32,7 @@ foam.CLASS({
     'foam.nanos.ruler.Operations',
     'foam.nanos.auth.Subject',
     'java.util.ArrayList',
+    'java.util.Arrays',
     'java.util.List',
     'java.util.Map',
     'java.util.HashMap'
@@ -84,6 +86,27 @@ foam.CLASS({
 
             if ( capability.getReviewRequired() ){
               updatedApprovalPayloads.add(newCapablePayload);
+            }
+
+            // handle unapproved requests for a granted minmax
+            if ( capability instanceof foam.nanos.crunch.MinMaxCapability ){
+              var crunchService = (CrunchService) x.get("crunchService");
+              var payloadDAO = (DAO) capableNewObj.getCapablePayloadDAO(x);
+
+              List<String> prereqIdsList = crunchService.getPrereqs(newCapablePayload.getCapability());
+
+              if ( prereqIdsList != null && prereqIdsList.size() > 0 ){
+                String[] prereqIds = prereqIdsList.toArray(new String[prereqIdsList.size()]);
+
+                ((ArraySink) payloadDAO.select(new ArraySink())).getArray().stream()
+                .filter(cp -> Arrays.stream(prereqIds).anyMatch(((CapablePayload) cp).getCapability()::equals))
+                .forEach(cp -> {
+                  CapablePayload capableCp = (CapablePayload) cp;
+                  if  ( capableCp.getStatus() == CapabilityJunctionStatus.PENDING ) {
+                    updatedApprovalPayloads.add(capableCp);
+                  }
+                });
+              }    
             }
           }
         }

--- a/src/foam/nanos/crunch/lite/ruler/CapableStatusChangeAdjustApprovalsRuleAction.js
+++ b/src/foam/nanos/crunch/lite/ruler/CapableStatusChangeAdjustApprovalsRuleAction.js
@@ -89,7 +89,7 @@ foam.CLASS({
             }
 
             // handle unapproved requests for a granted minmax
-            if ( capability instanceof foam.nanos.crunch.MinMaxCapability ){
+            if ( capability instanceof foam.nanos.crunch.MinMaxCapability ) {
               var crunchService = (CrunchService) x.get("crunchService");
               var payloadDAO = (DAO) capableNewObj.getCapablePayloadDAO(x);
 

--- a/src/foam/nanos/crunch/lite/ruler/CapableStatusChangeAdjustApprovalsRuleAction.js
+++ b/src/foam/nanos/crunch/lite/ruler/CapableStatusChangeAdjustApprovalsRuleAction.js
@@ -95,7 +95,7 @@ foam.CLASS({
 
               List<String> prereqIdsList = crunchService.getPrereqs(newCapablePayload.getCapability());
 
-              if ( prereqIdsList != null && prereqIdsList.size() > 0 ){
+              if ( prereqIdsList != null && prereqIdsList.size() > 0 ) {
                 String[] prereqIds = prereqIdsList.toArray(new String[prereqIdsList.size()]);
 
                 ((ArraySink) payloadDAO.select(new ArraySink())).getArray().stream()


### PR DESCRIPTION
Upon granting of a Min Max, all approval requests outstanding for  prereqs in pending status will be removed.

Also previously wired up removing not just the preqreq but the CapablePayload as well however it felt hacky and left some loopholes in previously established data checking -> if the length of the old capable payloads plus new capable payloads are the same.

So just left the removal method implemented still.