### PR TITLE
fix email notification not being sent when an alarm is created

### DIFF
--- a/src/foam/nanos/alarming/Alarming.js
+++ b/src/foam/nanos/alarming/Alarming.js
@@ -42,6 +42,7 @@ foam.CLASS({
             try {
               Notification notification = new Notification();
               notification.setBody("An alarm has been triggered for " + config.getName());
+              notification.setNotificationType("Alarming");
 
               // Notify a user
               User user = (User) ((DAO) x.get("localUserDAO")).find(config.getAlertUser());

--- a/src/foam/nanos/alarming/rules.jrl
+++ b/src/foam/nanos/alarming/rules.jrl
@@ -27,7 +27,8 @@ p({
   "after":false,
   "action":{"class":"foam.nanos.alarming.Alarming"},
   "enabled":true,
-  "saveHistory":false
+  "saveHistory":false,
+  "lifecycleState":1
 })
 p({
   "class":"foam.nanos.ruler.Rule",


### PR DESCRIPTION
1. Fixed the alarming email rule not running.
2. Set the notificationType so the emails specify it as an alarming notification email, instead of a general notification email.