### PR TITLE
remove browser default session on logout

### DIFF
--- a/src/foam/nanos/auth/ResendVerificationEmail.js
+++ b/src/foam/nanos/auth/ResendVerificationEmail.js
@@ -107,6 +107,7 @@ foam.CLASS({
         this.auth.logout().then(function() {
           this.window.location.hash = '';
           this.window.location.reload();
+          localStorage.removeItem('defaultSession');
         });
       }
     }

--- a/src/foam/nanos/auth/SignOutView.js
+++ b/src/foam/nanos/auth/SignOutView.js
@@ -34,6 +34,7 @@ foam.CLASS({
       this.auth.logout().then(function() {
         self.window.location.hash = '';
         self.window.location.reload();
+        localStorage.removeItem('defaultSession');
       });
     }
   ]

--- a/src/foam/u2/layout/MDSideNavigation.js
+++ b/src/foam/u2/layout/MDSideNavigation.js
@@ -121,7 +121,8 @@ foam.CLASS({
         this.auth.logout().then(function() {
           this.window.location.hash = '';
           this.window.location.reload();
-        })
+          localStorage.removeItem('defaultSession');
+        });
       }
     }
   ],


### PR DESCRIPTION
On logout delete browser default session.
Not completely necessary, but facilitates medusa load-balancer testing.  Without it, all logins from the same client are routed by the load balancer to the same mediator, because of sticky sessions. 