### PR TITLE
[NP-2565] new invoice form ui bug fix

### DIFF
--- a/src/foam/nanos/fs/fileDropZone/FileDropZone.js
+++ b/src/foam/nanos/fs/fileDropZone/FileDropZone.js
@@ -32,6 +32,7 @@ foam.CLASS({
   css: `
     ^ {
       box-sizing: border-box;
+      max-width: 365px;
       padding: 16px;
       border: 2px dashed #8e9090;
       border-radius: 3px;
@@ -85,11 +86,11 @@ foam.CLASS({
   `,
 
   messages: [
-    { name: 'LABEL_DEFAULT_TITLE', message: 'DRAG & DROP YOUR FILE HERE' },
+    { name: 'LABEL_DEFAULT_TITLE', message: 'Drag your file here' },
     { name: 'LABEL_OR',            message: 'or' },
-    { name: 'LABEL_BROWSE',        message: 'browse' },
+    { name: 'LABEL_BROWSE',        message: 'select from your device' },
     { name: 'LABEL_SUPPORTED',     message: 'Supported file types:' },
-    { name: 'LABEL_MAX_SIZE',      message: 'Max Size:' },
+    { name: 'LABEL_MAX_SIZE',      message: 'Max size:' },
     { name: 'ERROR_FILE_TYPE',     message: 'Invalid file type' },
     { name: 'ERROR_FILE_SIZE',     message: 'File size exceeds 15MB' }
   ],


### PR DESCRIPTION
address: https://nanopay.atlassian.net/browse/NP-2565
note:
- give max width to file drop zone so that it doesn't become too big when the text is translated, pushes the file preview which should sit next to the drop zone to the bottom and creates unnecessary space between the drop zone and the note section

<img width="1440" alt="Screen Shot 2020-11-16 at 2 55 10 PM" src="https://user-images.githubusercontent.com/58435071/99304159-fdacf580-281f-11eb-8ab1-8982ce54d66f.png">
