### PR TITLE
Create NOC Notification on ERROR Alarms.  Also fix AlarmConfig to ini…

### DIFF
--- a/src/foam/nanos/alarming/AddAlarmNameDAO.js
+++ b/src/foam/nanos/alarming/AddAlarmNameDAO.js
@@ -32,6 +32,8 @@ foam.CLASS({
       } else {
         config = new AlarmConfig();
         config.setName(alarm.getName());
+        config.setSeverity(alarm.getSeverity());
+        config.setClusterable(alarm.getClusterable());
         try {
           configDAO.put(config);
         } catch ( Exception e ) {

--- a/src/foam/nanos/alarming/AddAlarmNameDAO.js
+++ b/src/foam/nanos/alarming/AddAlarmNameDAO.js
@@ -33,7 +33,6 @@ foam.CLASS({
         config = new AlarmConfig();
         config.setName(alarm.getName());
         config.setSeverity(alarm.getSeverity());
-        config.setClusterable(alarm.getClusterable());
         try {
           configDAO.put(config);
         } catch ( Exception e ) {

--- a/src/foam/nanos/alarming/AlarmLoggingDAO.js
+++ b/src/foam/nanos/alarming/AlarmLoggingDAO.js
@@ -21,7 +21,7 @@ foam.CLASS({
     {
       name: 'put_',
       javaCode: `
-      Alarm old = (Alarm) getDelegate().find_(x, obj.getProperty("id"));
+      Alarm old = (Alarm) getDelegate().find_(x, ((Alarm)obj).getId());
       Alarm alarm = (Alarm) getDelegate().put_(x, obj);
       if ( old != null &&
            old.getIsActive() == alarm.getIsActive() ) {

--- a/src/foam/nanos/alarming/AlarmLoggingDAO.js
+++ b/src/foam/nanos/alarming/AlarmLoggingDAO.js
@@ -12,14 +12,22 @@ foam.CLASS({
   documentation: `Generate Logger messages for each alarm`,
 
   javaImports: [
+    'foam.dao.DAO',
     'foam.nanos.logger.Logger',
+    'foam.nanos.notification.Notification'
   ],
 
   methods: [
     {
       name: 'put_',
       javaCode: `
+      Alarm old = (Alarm) getDelegate().find_(x, obj.getProperty("id"));
       Alarm alarm = (Alarm) getDelegate().put_(x, obj);
+      if ( old != null &&
+           old.getIsActive() == alarm.getIsActive() ) {
+        return alarm;
+      }
+
       Logger logger = (Logger) x.get("logger");
       switch ( alarm.getSeverity() ) {
         case DEBUG:
@@ -33,6 +41,14 @@ foam.CLASS({
           break;
         case ERROR:
           logger.error("Alarm", alarm.getName(), alarm.getIsActive(), alarm.getNote());
+          if ( alarm.getIsActive() ) {
+            Notification notification = new Notification.Builder(x)
+              .setTemplate("NOC")
+              .setToastMessage(alarm.getName())
+              .setBody(alarm.getNote())
+              .build();
+              ((DAO) x.get("localNotificationDAO")).put(notification);
+          }
           break;
         default:
           logger.info("Alarm", alarm.getName(), alarm.getIsActive(), alarm.getNote());

--- a/src/foam/nanos/auth/UserAndGroupAuthService.js
+++ b/src/foam/nanos/auth/UserAndGroupAuthService.js
@@ -38,6 +38,7 @@ foam.CLASS({
     'foam.nanos.auth.Subject',
     'foam.nanos.auth.User',
     'foam.nanos.logger.Logger',
+    'foam.nanos.notification.Notification',
     'foam.nanos.session.Session',
     'foam.util.Email',
     'foam.util.Password',
@@ -106,6 +107,7 @@ foam.CLASS({
       ],
       javaThrows: ['foam.nanos.auth.AuthenticationException'],
       javaCode: `
+      try {
         if ( user == null ) {
           throw new AuthenticationException("User not found");
         }
@@ -140,10 +142,38 @@ foam.CLASS({
 
         Session session = x.get(Session.class);
         session.setUserId(user.getId());
+
+        if ( Group.ADMIN_GROUP.equalsIgnoreCase(user.getGroup()) ||
+             check(x.put("user", user), "*") ) {
+          session.setClusterable(false); 
+          String msg = "Admin login for " + user.getId() + " succeeded on " + System.getProperty("hostname", "localhost");
+          ((foam.nanos.logger.Logger) x.get("logger")).warning(msg);
+          Notification notification = new Notification.Builder(x)
+            .setTemplate("NOC")
+            .setToastMessage(msg)
+            .setBody(msg)
+            .build();
+          ((DAO) x.get("localNotificationDAO")).put(notification);
+        }
+
         ((DAO) getLocalSessionDAO()).inX(x).put(session);
         session.setContext(session.applyTo(session.getContext()));
-
         return user;
+      } catch ( AuthenticationException e ) {
+        if ( user != null &&
+             ( Group.ADMIN_GROUP.equalsIgnoreCase(user.getGroup()) ||
+               check(x.put("user", user), "*") ) ) {
+          String msg = "Admin login for " + user.getId() + " failed on " + System.getProperty("hostname", "localhost");
+          ((foam.nanos.logger.Logger) x.get("logger")).warning(msg);
+          Notification notification = new Notification.Builder(x)
+            .setTemplate("NOC")
+            .setToastMessage(msg)
+            .setBody(msg)
+            .build();
+          ((DAO) x.get("localNotificationDAO")).put(notification);
+        }
+        throw e;
+      }
       `
     },
     {
@@ -414,6 +444,7 @@ foam.CLASS({
             );
 
             if ( junction == null ) {
+              ((foam.nanos.logger.Logger) x.get("logger")).warning("There was a user and an agent in the context, but a junction between them was not found.", "user", user.getId(), "agent", agent.getId());
               throw new RuntimeException("There was a user and an agent in the context, but a junction between them was not found.");
             }
 

--- a/src/foam/nanos/auth/UserAndGroupAuthService.js
+++ b/src/foam/nanos/auth/UserAndGroupAuthService.js
@@ -144,7 +144,7 @@ foam.CLASS({
         session.setUserId(user.getId());
 
         if ( Group.ADMIN_GROUP.equalsIgnoreCase(user.getGroup()) ||
-             check(x.put("user", user), "*") ) {
+             check(userX, "*") ) {
           session.setClusterable(false); 
           String msg = "Admin login for " + user.getId() + " succeeded on " + System.getProperty("hostname", "localhost");
           ((foam.nanos.logger.Logger) x.get("logger")).warning(msg);
@@ -162,7 +162,7 @@ foam.CLASS({
       } catch ( AuthenticationException e ) {
         if ( user != null &&
              ( Group.ADMIN_GROUP.equalsIgnoreCase(user.getGroup()) ||
-               check(x.put("user", user), "*") ) ) {
+               check(userX, "*") ) ) {
           String msg = "Admin login for " + user.getId() + " failed on " + System.getProperty("hostname", "localhost");
           ((foam.nanos.logger.Logger) x.get("logger")).warning(msg);
           Notification notification = new Notification.Builder(x)
@@ -413,6 +413,7 @@ foam.CLASS({
       javaCode: `
         Session session = x.get(Session.class);
         if ( session != null && session.getUserId() != 0 ) {
+((foam.nanos.logger.Logger) x.get("logger")).info(this.getClass().getSimpleName(), "logout", session.getId());
           ((DAO) getLocalSessionDAO()).remove(session);
         }
       `

--- a/src/foam/nanos/notification/NotificationTemplateDAO.js
+++ b/src/foam/nanos/notification/NotificationTemplateDAO.js
@@ -70,7 +70,7 @@ the notification will be handled. `,
             template.setId(notification.getId());
             template.setBody(notification.getBody());
             template.setRead(notification.getRead());
-            template.clearTemplate();
+            template.setTemplate(notification.getToastMessage());
 
             // Notify a user directly
             DAO userDAO = (DAO) x.get("localUserDAO");


### PR DESCRIPTION
1. Create NOC Notification on ERROR Alarms
2. Create NOC Notification on admin logins
3. Fix AlarmConfig setup. 
4. Use Notification.toastMessage as template created Notification.template value - The Notification.template value was hijacked to support templates. The NotificationTemplateDAO looks up the template via the 'template' value, but then clears it to create the real Notification.  The toastMessage is set as the 'template' value, as the 'template' value becomes the subject of generated emails. 
