### PR TITLE
UCJ conditional data copy skip

### DIFF
--- a/src/foam/nanos/crunch/UserCapabilityJunctionRefine.js
+++ b/src/foam/nanos/crunch/UserCapabilityJunctionRefine.js
@@ -158,7 +158,12 @@ foam.CLASS({
             objectToSave = (FObject) getData();
           }
         }
-        objectToSave = objectToSave.fclone().copyFrom(getData());           // finally copy user inputed data into objectToSave <- typed to the safest possibility from above cases
+        if ( dao.getOf().getObjClass().isAssignableFrom(getData().getClass()) ) { // skip copy if data is the same class as dao.of or is a super class of dao.of
+          objectToSave = (FObject) getData();
+        }
+        else {
+          objectToSave = objectToSave.fclone().copyFrom(getData());           // finally copy user inputed data into objectToSave <- typed to the safest possibility from above cases
+        }
 
         try {                                                                   // save data to dao
           if ( putObject ) dao.put(objectToSave);


### PR DESCRIPTION
This gives UCJ support to put inherited classes (ie. BRBankAccount) to their respective parent's dao (ie. Account, accountDAO).