### PR TITLE
Add new logoImages model

### DIFF
--- a/src/foam/nanos/auth/ChangePasswordView.js
+++ b/src/foam/nanos/auth/ChangePasswordView.js
@@ -119,7 +119,7 @@ foam.CLASS({
   methods: [
     function initE() {
       const self = this;
-      const logo = this.theme.largeLogo || this.theme.logo;
+      const logo = this.theme.logo;
 
       this.addClass(this.myClass())
         // header

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -128,6 +128,7 @@ FOAM_FILES([
   { name: "foam/nanos/theme/ThemeDomain" },
   { name: "foam/nanos/theme/ThemeDomainsDAO" },
   { name: "foam/nanos/theme/Themes" },
+  { name: "foam/nanos/theme/LogoImages" },
   { name: "foam/nanos/bench/Benchmark" },
   { name: "foam/nanos/boot/DAOConfigSummaryView", flags: ['web'] },
   { name: "foam/nanos/boot/DAONSpecMenu" },

--- a/src/foam/nanos/theme/LogoImages.js
+++ b/src/foam/nanos/theme/LogoImages.js
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.nanos.theme',
+  name: 'LogoImages',
+  documentation: 'An object that specifies different types of logo images.',
+
+  properties: [
+    {
+      class: 'Image',
+      name: 'smallLightOnDark'
+    },
+    {
+      class: 'Image',
+      name: 'smallDarkOnLight'
+    },
+    {
+      class: 'Image',
+      name: 'mediumLightOnDark'
+    },
+    {
+      class: 'Image',
+      name: 'mediumDarkOnLight'
+    },
+    {
+      class: 'Image',
+      name: 'largeLightOnDark'
+    },
+    {
+      class: 'Image',
+      name: 'largeDarkOnLight'
+    }
+  ]
+})

--- a/src/foam/nanos/theme/Theme.js
+++ b/src/foam/nanos/theme/Theme.js
@@ -25,7 +25,8 @@ foam.CLASS({
   ],
 
   requires: [
-    'foam.nanos.theme.ThemeGlyphs'
+    'foam.nanos.theme.ThemeGlyphs',
+    'foam.nanos.theme.LogoImages'
   ],
 
   tableColumns: [
@@ -206,6 +207,13 @@ foam.CLASS({
       class: 'Color',
       name: 'logoBackgroundColour',
       documentation: 'The logo background colour to display in the application.',
+      section: 'images'
+    },
+    {
+      class: 'FObjectProperty',
+      of: 'foam.nanos.theme.LogoImages',
+      name: 'logoImages',
+      documentation: 'contains 6 different logos to be chosen',
       section: 'images'
     },
     {

--- a/src/foam/nanos/u2/navigation/ApplicationLogoView.js
+++ b/src/foam/nanos/u2/navigation/ApplicationLogoView.js
@@ -37,8 +37,8 @@ foam.CLASS({
       this
         .addClass(this.myClass())
         .start(this.Image, {
-          data$: this.slot(function(theme$largeLogoEnabled, theme$logo, theme$largeLogo) {
-            return theme$largeLogoEnabled ? theme$largeLogo : theme$logo;
+          data$: this.slot(function(theme$logo, theme$logoImages) {
+            return theme$logoImages.smallLightOnDark ? theme$logoImages.smallLightOnDark : theme$logo;
           })
         })
           .addClass('logo')

--- a/src/foam/u2/view/LoginView.js
+++ b/src/foam/u2/view/LoginView.js
@@ -227,7 +227,7 @@ foam.CLASS({
       this.onDetach(() => {
         this.document.removeEventListener('keyup', this.onKeyPressed);
       });
-      let logo = this.theme.largeLogo ? this.theme.largeLogo : this.theme.logo;
+      let logo = this.theme.logo;
       // CREATE MODEL VIEW
       var right = this.Element.create({}, this)
       // Header on-top of rendering model


### PR DESCRIPTION
The new logoImages model contains 6 different images to replace the current largeLogo:
- smallLightOnDark
- smallDarkOnLight
- mediumLightOnDark
- mediumDarkOnLight
- largeLightOnDark
- largeDarkOnLight
However, I think we should standardize the 'logo' (maybe with constant length and width) as well as other sizes of logoImages @jlhughes @kgrgreer 
And I keep largeLogo and largeLogoEnabled for now, and will be removed later, and I also keep the 'logo' because sometime companies/we only need the logo without the slogan or brand word

Related Nanopay changes: https://github.com/nanoPayinc/NANOPAY/pull/11175