### PR TITLE
Fix ucj object is frozen

### DIFF
--- a/src/foam/nanos/crunch/ReputDependentUCJs.js
+++ b/src/foam/nanos/crunch/ReputDependentUCJs.js
@@ -66,7 +66,7 @@ foam.CLASS({
             for ( CapabilityCapabilityJunction ccj : ccjs ) {
               UserCapabilityJunction ucjToReput = (UserCapabilityJunction) filteredUserCapabilityJunctionDAO
                 .find(EQ(UserCapabilityJunction.TARGET_ID, ccj.getSourceId()));
-              if ( ucjToReput != null ) ucjsToReput.add(ucjToReput);
+              if ( ucjToReput != null ) ucjsToReput.add((UserCapabilityJunction) ucjToReput.fclone());
             }
 
             X effectiveX = x;


### PR DESCRIPTION
## Ref
- https://github.com/foam-framework/foam2/pull/3322

## Stack trace
```
2020-11-20T10:46:23.120-0500,qtp1621957279-2165,ERROR,Object is frozen.,java.lang.UnsupportedOperationException: Object is frozen.
	at foam.core.FObject.assertNotFrozen(FObject.java:550)
	at foam.nanos.crunch.UserCapabilityJunction.setStatus(UserCapabilityJunction.java:730)
	at foam.nanos.crunch.ruler.ValidateUCJDataOnPut$2.execute(ValidateUCJDataOnPut.java:66)
	at foam.core.ContextAgentRunnable.run(ContextAgentRunnable.java:30)
	at foam.core.CompoundContextAgency.execute(CompoundContextAgency.java:199)
	at foam.nanos.ruler.RuleEngine.execute(RuleEngine.java:82)
	at foam.nanos.ruler.RulerDAO.applyRules(RulerDAO.java:982)
	at foam.nanos.ruler.RulerDAO.put_(RulerDAO.java:953)
	at foam.dao.ProxyDAO.put_(ProxyDAO.java:323)
	at foam.dao.ProxyDAO.put_(ProxyDAO.java:323)
	at foam.dao.ProxyDAO.put_(ProxyDAO.java:323)
	at foam.nanos.crunch.UserCapabilityJunctionDAO.put_(UserCapabilityJunctionDAO.java:202)
	at foam.dao.ProxyDAO.put_(ProxyDAO.java:323)
	at foam.dao.AbstractDAO.put(AbstractDAO.java:560)
	at foam.nanos.crunch.ReputDependentUCJs$3.execute(ReputDependentUCJs.java:123)
	at foam.core.ContextAgentRunnable.run(ContextAgentRunnable.java:30)
	at foam.core.CompoundContextAgency.execute(CompoundContextAgency.java:199)
	at foam.nanos.ruler.RuleEngine.execute(RuleEngine.java:82)
	at foam.nanos.ruler.RulerDAO.applyRules(RulerDAO.java:982)
	at foam.nanos.ruler.RulerDAO.put_(RulerDAO.java:959)
	at foam.dao.ProxyDAO.put_(ProxyDAO.java:323)
	at foam.dao.ProxyDAO.put_(ProxyDAO.java:323)
	at foam.dao.ProxyDAO.put_(ProxyDAO.java:323)
	at foam.nanos.crunch.UserCapabilityJunctionDAO.put_(UserCapabilityJunctionDAO.java:202)
	at foam.dao.ProxyDAO.put_(ProxyDAO.java:323)
	at foam.dao.AbstractDAO.put(AbstractDAO.java:560)
	at foam.nanos.crunch.ServerCrunchService.updateJunction(ServerCrunchService.java:261)
	at foam.nanos.crunch.CrunchServiceSkeleton.send(CrunchServiceSkeleton.java:104)
	at foam.box.SessionServerBox.send(SessionServerBox.java:185)
	at foam.nanos.http.ServiceWebAgent.execute(ServiceWebAgent.java:129)
	at foam.nanos.http.NanoRouter.service(NanoRouter.java:121)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:763)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1631)
	at org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter.doFilter(WebSocketUpgradeFilter.java:226)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1618)
	at net.nanopay.security.csp.CSPFilter.doFilter(CSPFilter.java:24)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1618)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:549)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1369)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:489)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1284)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
	at org.eclipse.jetty.server.Server.handle(Server.java:501)
	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:383)
	at org.eclipse.jetty.server.HttpChannel$$Lambda$100/0000000000000000.dispatch(Unknown Source)
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:556)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:375)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:272)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103)
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:336)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:313)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:171)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:129)
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:375)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:806)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:938)
	at java.base/java.lang.Thread.run(Thread.java:834)
```