### PR TITLE
Prereq chained status

### DIFF
--- a/src/foam/nanos/crunch/Capability.js
+++ b/src/foam/nanos/crunch/Capability.js
@@ -377,29 +377,69 @@ foam.CLASS({
         }
 
         var prereqs = crunchService.getPrereqs(getId());
+        CapabilityJunctionStatus prereqChainedStatus = null;
         if ( prereqs != null ) {
           for ( var capId : prereqs ) {
             var cap = (Capability) capabilityDAO.find(capId);
             if ( cap == null || ! cap.getEnabled() ) continue;
             
             X subjectContext = x.put("subject", subject);
-            UserCapabilityJunction ucJunction = crunchService.getJunctionForSubject(subjectContext, capId, subject);
+            UserCapabilityJunction prereqUcj = crunchService.getJunctionForSubject(subjectContext, capId, subject);
 
-            if ( ucJunction.getStatus() == CapabilityJunctionStatus.GRANTED ) {
-              continue;
-            }
-
-            if ( ucJunction.getStatus() == CapabilityJunctionStatus.PENDING
-              || ucJunction.getStatus() == CapabilityJunctionStatus.APPROVED
-            ) {
-              allGranted = false;
-            } else {
-              return CapabilityJunctionStatus.ACTION_REQUIRED;
-            }
+            prereqChainedStatus = getPrereqChainedStatus(x, ucj, prereqUcj);
+            if ( prereqChainedStatus == CapabilityJunctionStatus.ACTION_REQUIRED ) return CapabilityJunctionStatus.ACTION_REQUIRED;
+            if ( prereqChainedStatus != CapabilityJunctionStatus.GRANTED ) allGranted = false;
           }
         }
         return allGranted ? CapabilityJunctionStatus.GRANTED : CapabilityJunctionStatus.PENDING;
       `,
+    },
+    {
+      name: 'getPrereqChainedStatus',
+      args: [
+        { name: 'x', javaType: 'foam.core.X' },
+        { name: 'ucj', javaType: 'foam.nanos.crunch.UserCapabilityJunction' },
+        { name: 'prereq', javaType: 'foam.nanos.crunch.UserCapabilityJunction' }
+      ],
+      static: true,
+      javaType: 'foam.nanos.crunch.CapabilityJunctionStatus',
+      javaCode: `
+        CapabilityJunctionStatus status = ucj.getStatus();
+
+        Capability capability = (Capability) ucj.findTargetId(x);
+        boolean reviewRequired = capability.getReviewRequired();
+        CapabilityJunctionStatus prereqStatus = prereq.getStatus();
+
+        switch ( (CapabilityJunctionStatus) prereqStatus ) {
+          case AVAILABLE : 
+            status = CapabilityJunctionStatus.ACTION_REQUIRED;
+            break;
+          case ACTION_REQUIRED : 
+            status = CapabilityJunctionStatus.ACTION_REQUIRED;
+            break;
+          case PENDING : 
+            status = reviewRequired && 
+              ( status == CapabilityJunctionStatus.APPROVED || 
+                status == CapabilityJunctionStatus.GRANTED
+              ) ? 
+                CapabilityJunctionStatus.APPROVED : CapabilityJunctionStatus.PENDING;
+            break;
+          case APPROVED : 
+            status = reviewRequired && 
+              ( status == CapabilityJunctionStatus.APPROVED || 
+                status == CapabilityJunctionStatus.GRANTED
+              ) ? 
+                CapabilityJunctionStatus.APPROVED : CapabilityJunctionStatus.PENDING;
+              break;
+          case EXPIRED :
+            status = CapabilityJunctionStatus.ACTION_REQUIRED;
+            break;
+          default : 
+            status = CapabilityJunctionStatus.GRANTED;
+        }
+        return status;
+
+      `
     }
   ]
 });

--- a/src/foam/nanos/crunch/Capability.js
+++ b/src/foam/nanos/crunch/Capability.js
@@ -406,8 +406,7 @@ foam.CLASS({
       javaCode: `
         CapabilityJunctionStatus status = ucj.getStatus();
 
-        Capability capability = (Capability) ucj.findTargetId(x);
-        boolean reviewRequired = capability.getReviewRequired();
+        boolean reviewRequired = getReviewRequired();
         CapabilityJunctionStatus prereqStatus = prereq.getStatus();
 
         switch ( (CapabilityJunctionStatus) prereqStatus ) {

--- a/src/foam/nanos/crunch/ReputDependentUCJs.js
+++ b/src/foam/nanos/crunch/ReputDependentUCJs.js
@@ -81,8 +81,14 @@ foam.CLASS({
               }
             }
 
+            Capability dependent = null;
             for ( UserCapabilityJunction ucjToReput : ucjsToReput ) {
-              if ( isInvalidate ) ucjToReput.setStatus(cascadeInvalidateStatus(x, ucjToReput, ucj));
+              dependent = (Capability) ucjToReput.findTargetId(x);
+              if ( isInvalidate ) ucjToReput.setStatus(dependent.getPrereqChainedStatus(x, ucjToReput, ucj));
+              if ( ucjToReput.getStatus() == CapabilityJunctionStatus.GRANTED ) {
+                if ( ucj.getIsInGracePeriod() ) ucjToReput.setIsInGracePeriod(true);
+                if ( ucj.getIsRenewable() ) ucjToReput.setIsRenewable(true);
+              }
               if ( effectiveUserId != null && effectiveX != null &&
                    ucjToReput.getSourceId() == effectiveUserId )
                 userCapabilityJunctionDAO.inX(effectiveX).put(ucjToReput);
@@ -91,53 +97,6 @@ foam.CLASS({
             }
           }
         }, "Reput the UCJs of dependent capabilities");
-      `
-    },
-    {
-      name: 'cascadeInvalidateStatus',
-      args: [
-        { name: 'x', javaType: 'foam.core.X' },
-        { name: 'ucj', javaType: 'foam.nanos.crunch.UserCapabilityJunction' },
-        { name: 'prereq', javaType: 'foam.nanos.crunch.UserCapabilityJunction' }
-      ],
-      javaType: 'foam.nanos.crunch.CapabilityJunctionStatus',
-      javaCode: `
-        CapabilityJunctionStatus newStatus = ucj.getStatus();
-
-        Capability capability = (Capability) ucj.findTargetId(x);
-        boolean reviewRequired = capability.getReviewRequired();
-        CapabilityJunctionStatus prereqStatus = prereq.getStatus();
-
-        switch ( (CapabilityJunctionStatus) prereqStatus ) {
-          case AVAILABLE : 
-            newStatus = CapabilityJunctionStatus.ACTION_REQUIRED;
-            break;
-          case ACTION_REQUIRED : 
-            newStatus = CapabilityJunctionStatus.ACTION_REQUIRED;
-            break;
-          case PENDING : 
-            newStatus = reviewRequired && 
-              ( newStatus == CapabilityJunctionStatus.APPROVED || 
-                newStatus == CapabilityJunctionStatus.GRANTED
-              ) ? 
-                CapabilityJunctionStatus.APPROVED : CapabilityJunctionStatus.PENDING;
-            break;
-          case APPROVED : 
-            newStatus = reviewRequired && 
-            ( newStatus == CapabilityJunctionStatus.APPROVED || 
-              newStatus == CapabilityJunctionStatus.GRANTED
-            ) ? 
-              CapabilityJunctionStatus.APPROVED : CapabilityJunctionStatus.PENDING;
-            break;
-          case EXPIRED :
-            newStatus = CapabilityJunctionStatus.ACTION_REQUIRED;
-            break;
-          default : // GRANTED
-            if ( prereq.getIsInGracePeriod() ) ucj.setIsInGracePeriod(true);
-            if ( prereq.getIsRenewable() ) ucj.setIsRenewable(true);
-        }
-        return newStatus;
-
       `
     }
   ]


### PR DESCRIPTION
integrate cascadeinvalidatestatus logic in the reput ucj rule with getPrereqChainedStatus so it may be overriden by minmaxcapabilities