### PR TITLE
Do not re-put saved UCJs with status AVAILABLE

### DIFF
--- a/src/foam/nanos/crunch/ReputDependentUCJs.js
+++ b/src/foam/nanos/crunch/ReputDependentUCJs.js
@@ -66,7 +66,14 @@ foam.CLASS({
             for ( CapabilityCapabilityJunction ccj : ccjs ) {
               UserCapabilityJunction ucjToReput = (UserCapabilityJunction) filteredUserCapabilityJunctionDAO
                 .find(EQ(UserCapabilityJunction.TARGET_ID, ccj.getSourceId()));
-              if ( ucjToReput != null ) ucjsToReput.add((UserCapabilityJunction) ucjToReput.fclone());
+
+              // Skip null and AVAILABLE UCJs
+              if (
+                ucjToReput == null
+                || ucjToReput.getStatus() == CapabilityJunctionStatus.AVAILABLE
+              ) continue;
+
+              ucjsToReput.add((UserCapabilityJunction) ucjToReput.fclone());
             }
 
             X effectiveX = x;


### PR DESCRIPTION
UCJs can be saved with status AVAILABLE, and ReputDependantUCJ's should behave the same way for these as it does for non-existent UCJ's (i.e. it should never re-put an AVAILABLE UCJ, since missing UCJs are also considered as AVAILABLE)

This doesn't fix granting of an unintended option in a UCJ MinMax but it is required for that to work properly. Right now the other option will go from no-UCJ to granted, which is reproducable in UCJ DAO without the wizard, and I'm not sure where this is happening.