### PR TITLE
Revamp JSON output delta

### DIFF
--- a/src/foam/dao/AbstractF3FileJournal.js
+++ b/src/foam/dao/AbstractF3FileJournal.js
@@ -219,7 +219,7 @@ try {
           public void executeJob() {
             try {
               if ( old != null ) {
-                fmt.outputDelta(old, obj, of);
+                fmt.maybeOutputDelta(old, obj, of);
               } else {
                 fmt.output(obj, of);
               }

--- a/src/foam/dao/history/HistoryDAO.js
+++ b/src/foam/dao/history/HistoryDAO.js
@@ -131,7 +131,7 @@ foam.CLASS({
           historyRecord.setTimestamp(new Date());
           if ( current != null ) {
             FObjectFormatter formatter = formatter_.get();
-            if ( ! formatter.outputDelta(current, obj) ) {
+            if ( ! formatter.maybeOutputDelta(current, obj) ) {
               return super.put_(x, obj);
             }
             historyRecord.setUpdates(getUpdatedProperties(current, obj));

--- a/src/foam/dao/history/HistoryDAO.js
+++ b/src/foam/dao/history/HistoryDAO.js
@@ -44,14 +44,14 @@ foam.CLASS({
       buildJavaClass: function(cls) {
         cls.extras.push(
           `
-            private static final PropertyPredicate propertyPredicate_ = new StoragePropertyPredicate();
-            private static final PropertyPredicate optionalPredicate_ = new StorageOptionalPropertyPredicate();
+            private static final PropertyPredicate PROPERTY_PREDICATE = new StoragePropertyPredicate();
+            private static final PropertyPredicate OPTIONAL_PREDICATE = new StorageOptionalPropertyPredicate();
 
-            protected static final ThreadLocal<FObjectFormatter> formatter_ = new ThreadLocal<FObjectFormatter>() {
+            protected static final ThreadLocal<FObjectFormatter> formatter__ = new ThreadLocal<FObjectFormatter>() {
               @Override
               protected JSONFObjectFormatter initialValue() {
                 JSONFObjectFormatter formatter = new JSONFObjectFormatter();
-                formatter.setPropertyPredicate(propertyPredicate_);
+                formatter.setPropertyPredicate(PROPERTY_PREDICATE);
                 return formatter;
               }
               
@@ -110,8 +110,8 @@ foam.CLASS({
         var props = info.getAxiomsByClass(PropertyInfo.class);
 
         for ( var prop : props ) {
-          if ( propertyPredicate_.propertyPredicateCheck(x, of, prop)
-            && ! optionalPredicate_.propertyPredicateCheck(x, of, prop)
+          if ( PROPERTY_PREDICATE.propertyPredicateCheck(x, of, prop)
+            && ! OPTIONAL_PREDICATE.propertyPredicateCheck(x, of, prop)
             && prop.compare(currentValue, newValue) != 0
           ) {
             updates.add(new PropertyUpdate(
@@ -142,7 +142,7 @@ foam.CLASS({
           historyRecord.setAgent(formatUserName(agent));
           historyRecord.setTimestamp(new Date());
           if ( current != null ) {
-            FObjectFormatter formatter = formatter_.get();
+            FObjectFormatter formatter = formatter__.get();
             if ( ! formatter.maybeOutputDelta(current, obj) ) {
               return super.put_(x, obj);
             }

--- a/src/foam/java/PropertyInfo.js
+++ b/src/foam/java/PropertyInfo.js
@@ -453,7 +453,7 @@ foam.CLASS({
           });
         }
 
-        if ( ! this.includeInID ) {
+        if ( this.includeInID ) {
           m.push({
             name:       'includeInID',
             visibility: 'public',

--- a/src/foam/lib/formatter/AbstractFObjectFormatter.java
+++ b/src/foam/lib/formatter/AbstractFObjectFormatter.java
@@ -7,7 +7,6 @@
 package foam.lib.formatter;
 
 import foam.core.ClassInfo;
-import foam.core.FEnum;
 import foam.core.FObject;
 import foam.core.PropertyInfo;
 import foam.core.X;
@@ -59,7 +58,7 @@ public abstract class AbstractFObjectFormatter
 
   public String stringifyDelta(FObject oldFObject, FObject newFObject) {
     reset();
-    outputDelta(oldFObject, newFObject);
+    maybeOutputDelta(oldFObject, newFObject);
     return b_.toString();
   }
 

--- a/src/foam/lib/formatter/AbstractFObjectFormatter.java
+++ b/src/foam/lib/formatter/AbstractFObjectFormatter.java
@@ -24,7 +24,6 @@ public abstract class AbstractFObjectFormatter
   protected PropertyPredicate propertyPredicate_;
   protected PropertyPredicate optionalPredicate_         = new StorageOptionalPropertyPredicate();
   protected Map<String, List<PropertyInfo>> propertyMap_ = new HashMap<>();
-  protected List<PropertyInfo> delta_;
 
   public AbstractFObjectFormatter(X x) {
     setX(x);
@@ -49,7 +48,6 @@ public abstract class AbstractFObjectFormatter
   }
 
   public void reset() {
-    delta_ = null;
     builder().setLength(0);
   }
 
@@ -86,31 +84,6 @@ public abstract class AbstractFObjectFormatter
     }
 
     return propertyMap_.get(of);
-  }
-
-  protected List getDelta(FObject oldFObject, FObject newFObject) {
-    ClassInfo info     = oldFObject.getClassInfo();
-    String    of       = info.getObjClass().getSimpleName().toLowerCase();
-    List      axioms   = getProperties(info);
-    int       size     = axioms.size();
-    int       optional = 0;
-
-    delta_ = new ArrayList<PropertyInfo>();
-
-    for ( int i = 0 ; i < size ; i++ ) {
-      PropertyInfo prop = (PropertyInfo) axioms.get(i);
-
-      if ( prop.compare(oldFObject, newFObject) != 0 ) {
-        delta_.add(prop);
-        if ( optionalPredicate_.propertyPredicateCheck(getX(), of, prop) ) {
-          optional += 1;
-        }
-      }
-    }
-    if ( optional > 0 && delta_.size() == optional ) {
-      delta_ = new ArrayList<>();
-    }
-    return delta_;
   }
 
   public void setPropertyPredicate(PropertyPredicate p) {

--- a/src/foam/lib/formatter/FObjectFormatter.java
+++ b/src/foam/lib/formatter/FObjectFormatter.java
@@ -32,7 +32,7 @@ public interface FObjectFormatter
 
   public String stringifyDelta(FObject oldFObject, FObject newFObject);
 
-  public boolean outputDelta(FObject oldFObject, FObject newFObject);
+  public boolean maybeOutputDelta(FObject oldFObject, FObject newFObject);
 
   public void output(String val);
 

--- a/src/foam/lib/formatter/FObjectFormatter.java
+++ b/src/foam/lib/formatter/FObjectFormatter.java
@@ -32,7 +32,7 @@ public interface FObjectFormatter
 
   public String stringifyDelta(FObject oldFObject, FObject newFObject);
 
-  public void outputDelta(FObject oldFObject, FObject newFObject);
+  public boolean outputDelta(FObject oldFObject, FObject newFObject);
 
   public void output(String val);
 

--- a/src/foam/lib/formatter/JSONFObjectFormatter.java
+++ b/src/foam/lib/formatter/JSONFObjectFormatter.java
@@ -306,11 +306,11 @@ public class JSONFObjectFormatter
     return true;
   }
 
-  public boolean outputDelta(FObject oldFObject, FObject newFObject) {
-    return outputDelta(oldFObject, newFObject, null);
+  public boolean maybeOutputDelta(FObject oldFObject, FObject newFObject) {
+    return maybeOutputDelta(oldFObject, newFObject, null);
   }
 
-  public boolean outputDelta(FObject oldFObject, FObject newFObject, ClassInfo defaultClass) {
+  public boolean maybeOutputDelta(FObject oldFObject, FObject newFObject, ClassInfo defaultClass) {
     ClassInfo newInfo   = newFObject.getClassInfo();
     String    of        = newInfo.getObjClass().getSimpleName().toLowerCase();
     List      axioms    = getProperties(newInfo);

--- a/src/foam/lib/formatter/JSONFObjectFormatter.java
+++ b/src/foam/lib/formatter/JSONFObjectFormatter.java
@@ -306,10 +306,6 @@ public class JSONFObjectFormatter
     return true;
   }
 
-  public List getDelta(FObject oldFObject, FObject newFObject) {
-    return delta_ == null ? super.getDelta(oldFObject, newFObject) : delta_;
-  }
-
   public boolean outputDelta(FObject oldFObject, FObject newFObject) {
     return outputDelta(oldFObject, newFObject, null);
   }

--- a/src/foam/lib/formatter/JSONFObjectFormatter.java
+++ b/src/foam/lib/formatter/JSONFObjectFormatter.java
@@ -310,8 +310,8 @@ public class JSONFObjectFormatter
     return delta_ == null ? super.getDelta(oldFObject, newFObject) : delta_;
   }
 
-  public void outputDelta(FObject oldFObject, FObject newFObject) {
-    outputDelta(oldFObject, newFObject, null);
+  public boolean outputDelta(FObject oldFObject, FObject newFObject) {
+    return outputDelta(oldFObject, newFObject, null);
   }
 
   public boolean outputDelta(FObject oldFObject, FObject newFObject, ClassInfo defaultClass) {


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-2889

## Issues
- JSON output for model having multipart id doesn't contain the properties (of the multipart id) on update

## Changes
- Always output id although it can be transient or multipart id to ensure that the entry/record is identifiable on replay.
- Output delta without generating delta properties list
- Update HistoryDAO to remove the delta list dependency