### PR TITLE
[NP-2855] fix broken context menu in notification screen

### DIFF
--- a/src/foam/nanos/notification/Notification.js
+++ b/src/foam/nanos/notification/Notification.js
@@ -200,7 +200,7 @@ foam.CLASS({
       ],
       type: 'Boolean',
       javaCode: `
-        User user = ((Subject) x.get("subject")).getUser();
+        User user = ((Subject) x.get("subject")).getRealUser();
         return user != null && getUserId() == user.getId();
       `
     },


### PR DESCRIPTION
Address: https://nanopay.atlassian.net/browse/NP-2855
- The checkOwnership method  in notification gives wrong result, so the context menu is broken. So updated checkOwnership method in Notification.
<img width="1440" alt="Screen Shot 2020-12-01 at 9 58 15 AM" src="https://user-images.githubusercontent.com/38148986/100757618-987b0780-33bc-11eb-9d6b-4ba27acd3cca.png">
