### PR TITLE
Capability Store Improvements

### DIFF
--- a/src/foam/u2/crunch/CapabilityStore.js
+++ b/src/foam/u2/crunch/CapabilityStore.js
@@ -189,7 +189,7 @@ foam.CLASS({
     },
     function initE() {
       this.SUPER();
-      this.crunchService.sub('updateJunction', this.onChange);
+      this.onDetach(this.crunchService.sub('updateJunction', this.onChange));
       var self = this;
       window.cstore = self;
 

--- a/src/foam/u2/crunch/CapabilityStore.js
+++ b/src/foam/u2/crunch/CapabilityStore.js
@@ -189,7 +189,7 @@ foam.CLASS({
     },
     function initE() {
       this.SUPER();
-
+      this.crunchService.sub('updateJunction', this.onChange);
       var self = this;
       window.cstore = self;
 
@@ -201,7 +201,9 @@ foam.CLASS({
         .start('p').addClass(this.myClass('label-subtitle'))
           .add(this.SUBTITLE)
         .end()
-        .add(self.renderFeatured())
+        .add(this.slot(function(featuredCapabilities){
+          return self.renderFeatured();
+        }))
         // NOTE: TEMPORARILY REMOVED
         // .add(self.accountAndAccountingCard())
         // .start(self.Tabs)
@@ -227,58 +229,54 @@ foam.CLASS({
     function renderFeatured() { // Featured Capabilities in carousel view
       var self = this;
       var spot = self.E();
-      return this.E().start()// .style({ 'height': 'fit-content', 'overflow-y': 'visible' })
-        .addClass(this.myClass('container'))
-        .add(this.slot(function(featuredCapabilities) {
-          featuredCapabilities.select().then(result => {
-            var arr = result.array;
-            self.totalNumCards = arr.length;
-            self.featureCardArray = [];
-            for ( let i = 0 ; i < self.totalNumCards ; i++ ) { // build featured cards as elements
-              self.featureCardArray.push(
-                () => self.Element.create().start()
-                  .addClass(self.myClass('perFeature'))
-                  .start(self.CapabilityFeatureView, { data: arr[i] })
-                    .addClass(self.myClass('featureSection'))
-                  .end()
-                  .on('click', () => {
-                    self.openWizard(arr[i].id);
-                  })
-                .end());
+      this.featuredCapabilities.select().then(result => {
+        var arr = result.array;
+        self.totalNumCards = arr.length;
+        self.featureCardArray = [];
+        for ( let i = 0 ; i < self.totalNumCards ; i++ ) { // build featured cards as elements
+          self.featureCardArray.push(
+            () => self.Element.create().start()
+              .addClass(self.myClass('perFeature'))
+              .start(self.CapabilityFeatureView, { data: arr[i] })
+                .addClass(self.myClass('featureSection'))
+              .end()
+              .on('click', () => {
+                self.openWizard(arr[i].id);
+              })
+            .end());
+        }
+        self.callIf(self.totalNumCards > self.MAX_NUM_DISPLAYBLE_CARDS, function() {
+          return spot.start('span')
+            .start('img').addClass(self.myClass('left-arrow'))
+              .attr('src', 'images/arrow-back-24px.svg')
+              .on('click', function() {
+                self.carouselCounter--;
+              })
+            .end()
+          .end();
+        });
+        spot.add(self.slot(
+          function(carouselCounter, totalNumCards) {
+            var ele = self.E().addClass(self.myClass('feature-column-grid'));
+            for ( var k = 0 ; k < totalNumCards ; k++ ) {
+              let cc = carouselCounter % totalNumCards; // this stops any out of bounds indecies
+              let index = ( cc + totalNumCards + k ) % totalNumCards; // this ensures circle indecies
+              ele = ele.add(self.featureCardArray[index].call(self));
             }
-            self.callIf(self.totalNumCards > self.MAX_NUM_DISPLAYBLE_CARDS, function() {
-              return spot.start('span')
-                .start('img').addClass(self.myClass('left-arrow'))
-                  .attr('src', 'images/arrow-back-24px.svg')
-                  .on('click', function() {
-                    self.carouselCounter--;
-                  })
-                .end()
-              .end();
-            });
-            spot.add(self.slot(
-              function(carouselCounter, totalNumCards) {
-                var ele = self.E().addClass(self.myClass('feature-column-grid'));
-                for ( var k = 0 ; k < totalNumCards ; k++ ) {
-                  let cc = carouselCounter % totalNumCards; // this stops any out of bounds indecies
-                  let index = ( cc + totalNumCards + k ) % totalNumCards; // this ensures circle indecies
-                  ele = ele.add(self.featureCardArray[index].call(self));
-                }
-                return ele;
-              }));
-            self.callIf(self.totalNumCards > self.MAX_NUM_DISPLAYBLE_CARDS, function() {
-              return spot.start('span')
-                .start('img').addClass(self.myClass('right-arrow'))
-                  .attr('src', 'images/arrow-forward-24px.svg')
-                  .on('click', function() {
-                    self.carouselCounter++;
-                  })
-                .end()
-              .end();
-            })
-          });
-          return spot;
-       })).end();
+            return ele;
+          }));
+        self.callIf(self.totalNumCards > self.MAX_NUM_DISPLAYBLE_CARDS, function() {
+          return spot.start('span')
+            .start('img').addClass(self.myClass('right-arrow'))
+              .attr('src', 'images/arrow-forward-24px.svg')
+              .on('click', function() {
+                self.carouselCounter++;
+              })
+            .end()
+          .end();
+        })
+      });
+      return spot;
     },
 
     function accountAndAccountingCard() {
@@ -390,6 +388,16 @@ foam.CLASS({
           this.wizardOpened = false;
         });
       
+    }
+  ],
+
+  listeners: [
+    {
+      name: 'onChange',
+      isMerged: true,
+      code: function() {
+        this.init();
+      }
     }
   ]
 });


### PR DESCRIPTION
Removes the need for refresh wizardlets to update cap store. Capability wizardlet save method publishes an 'updatejunction'  on the crunchService which is now subbed to on the cap store allowing for a dynamic view without the need to refresh.

However, the capability store wasn't correctly rendering its capability cards, making it difficult to make use of the listener to update capabilities shown in store. Went ahead and fixed that and added a listener on the publish of 'updateJunction'.

