### PR TITLE
Support nested string literals

### DIFF
--- a/src/foam/u2/detail/SectionView.js
+++ b/src/foam/u2/detail/SectionView.js
@@ -67,6 +67,10 @@ foam.CLASS({
     {
       class: 'Function',
       name: 'getNestedPropValue',
+      documentation: `
+        Finds the value of an object in reference to the property path provided
+        ex. 'obj.innerobj.name' will return the value of 'name' belonging to 'innerobj'.
+      `,
       factory: function() {
         return (obj, path) => {
           if ( ! path ) return obj;

--- a/src/foam/u2/detail/SectionView.js
+++ b/src/foam/u2/detail/SectionView.js
@@ -58,8 +58,8 @@ foam.CLASS({
       name: 'evaluateMessage',
       documentation: `Evaluates model messages without executing potentially harmful values`,
       factory: function() {
+        var obj = this.data.clone();
         return (msg) => msg.replace(/\${(.*?)}/g, (x, str) => {
-          var obj = this.data.clone();
           return this.getNestedPropValue(obj, str);
         });
       }

--- a/src/foam/u2/detail/SectionView.js
+++ b/src/foam/u2/detail/SectionView.js
@@ -58,7 +58,21 @@ foam.CLASS({
       name: 'evaluateMessage',
       documentation: `Evaluates model messages without executing potentially harmful values`,
       factory: function() {
-        return (msg) => msg.replace(/\${(.*?)}/g, (x,g) => this.data[g]);
+        return (msg) => msg.replace(/\${(.*?)}/g, (x, str) => {
+          var obj = this.data.clone();
+          return this.getNestedPropValue(obj, str);
+        });
+      }
+    },
+    {
+      class: 'Function',
+      name: 'getNestedPropValue',
+      factory: function() {
+        return (obj, path) => {
+          if ( ! path ) return obj;
+          const props = path.split('.');
+          return this.getNestedPropValue(obj[props.shift()], props.join('.'))
+        }
       }
     }
   ],


### PR DESCRIPTION
Messages with references to nested object are now supported when using the title & subtitle helper function 
ex(' message: '${capability.name} ${capability.description}' )

@kgrgreer `getNestedPropValue` is there anything like this already? If not then I believe it'd be useful to have it on FObject or where ever you feel it makes sense.