### PR TITLE
Add server side support for choosing to write files based on size to …

### DIFF
--- a/src/foam/nanos/fs/File.js
+++ b/src/foam/nanos/fs/File.js
@@ -176,7 +176,7 @@ foam.CLASS({
 
           reader.onerror = reject;
 
-          reader.readAsText(this.data.blob)
+          reader.readAsText(this.data.blob);
         });
       },
       javaCode: `

--- a/src/foam/nanos/fs/FileDataDAO.js
+++ b/src/foam/nanos/fs/FileDataDAO.js
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.nanos.fs',
+  name: 'FileDataDAO',
+  extends: 'foam.dao.ProxyDAO',
+
+  javaImports: [
+    'foam.blob.*'
+  ],
+
+  properties: [
+    {
+      class: 'Long',
+      name: 'maxStringDataSize',
+      value: 1024 * 3
+    }
+  ],
+
+  methods: [
+    {
+      documentation: `Server side logic to save file to either file.dataString or to physical files system.`,
+      name: 'put_',
+      javaCode: `
+      File file = (File) obj;
+      if ( ! foam.util.SafetyUtil.isEmpty(file.getDataString()) ) {
+        return getDelegate().put_(x, obj);
+      }
+
+      Blob blob = file.getData();
+      if ( blob == null ) {
+        return getDelegate().put_(x, obj);
+      }
+
+      // save to data string
+      if ( file.getFilesize() <= getMaxStringDataSize() ) {
+        try {
+          java.io.ByteArrayOutputStream os = new java.io.ByteArrayOutputStream((int) file.getFilesize());
+          blob.read(os, 0, file.getFilesize());
+          String encodedString = java.util.Base64.getEncoder().encodeToString(os.toByteArray());
+          String type = file.getMimeType();
+          if ( foam.util.SafetyUtil.isEmpty(type) ) {
+            if ( ! foam.util.SafetyUtil.isEmpty(file.getFilename()) &&
+                 file.getFilename().lastIndexOf(".") != -1 &&
+                 file.getFilename().lastIndexOf(".") != 0 ) {
+              type = "text/" + file.getFilename().substring(file.getFilename().lastIndexOf(".")+1);
+            } else {
+              type = "text/html";
+            }
+          }
+          file.setDataString("data:"+type+";base64," + encodedString);
+          file.setData(null);
+          return getDelegate().put_(x, file);
+        } catch (Exception e) {
+          ((foam.dao.DAO) x.get("alarmDAO")).put(new foam.nanos.alarming.Alarm.Builder(x)
+            .setName("Failed to encode")
+            .setSeverity(foam.log.LogLevel.ERROR)
+            .setReason(foam.nanos.alarming.AlarmReason.UNSPECIFIED)
+            .setNote(file.getFilename())
+            .build());
+          throw new foam.core.FOAMException("Failed to encode file", e);
+        }
+      }
+
+      try {
+        // save to filesystem
+        BlobService blobStore = (BlobService) x.get("blobStore");
+        IdentifiedBlob result = (IdentifiedBlob) blobStore.put(blob);
+        file.setId(result.getId());
+        file.setData(null);
+        return getDelegate().put_(x, file);
+      } catch (Exception e) {
+        ((foam.dao.DAO) x.get("alarmDAO")).put(new foam.nanos.alarming.Alarm.Builder(x)
+          .setName("Failed to save")
+          .setSeverity(foam.log.LogLevel.ERROR)
+          .setNote(file.getFilename())
+          .build());
+        throw new foam.core.FOAMException("Failed to save file", e);
+      }
+      `
+    }
+  ]
+});

--- a/src/foam/nanos/fs/services.jrl
+++ b/src/foam/nanos/fs/services.jrl
@@ -19,23 +19,24 @@ p({
   "class":"foam.nanos.boot.NSpec",
   "name":"fileDAO",
   "serve":true,
-  "serviceScript":
-  """
+  "serviceScript":"""
     dao = new foam.dao.KeyValueDAO.Builder(x)
-      .setDelegate(new foam.dao.NullDAO(x, foam.nanos.fs.File.getOwnClassInfo()))
+      .setDelegate(new foam.nanos.fs.SupportFileTypeDAO(x,
+        new foam.nanos.fs.FileDataDAO.Builder(x)
+          .setDelegate(new foam.dao.NullDAO(x, foam.nanos.fs.File.getOwnClassInfo()))
+          .build()))
       .build();
-    dao = new foam.nanos.fs.SupportFileTypeDAO(x, dao);
+
     return new foam.dao.EasyDAO.Builder(x)
-      .setPm(true)
+      .setOf(foam.nanos.fs.File.getOwnClassInfo())
       .setGuid(true)
       .setDecorator(dao)
-      .setOf(foam.nanos.fs.File.getOwnClassInfo())
       .setJournalName("files")
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
+      .setPm(true)
       .build()
   """,
-  "client":
-  """
+  "client":"""
     {
       "of":"foam.nanos.fs.File",
       "cache":false,

--- a/src/services
+++ b/src/services
@@ -453,7 +453,18 @@ p({
   """
 })
 
-p({"class":"foam.nanos.boot.NSpec", "name":"blobService",                        "serve":true,  "client": "{ \"class\":\"foam.blob.RestBlobService\", \"serviceName\":\"service/httpBlobService\" }"})
+p({
+  "class":"foam.nanos.boot.NSpec",
+  "name":"blobService",
+  "serve":true,
+  "client": """
+    {
+      "class":"foam.blob.RestBlobService",
+      "serviceName":"service/httpBlobService"
+    }
+  """
+})
+
 p({"class":"foam.nanos.boot.NSpec", "name":"resetPasswordToken",                 "serve":true,  "authenticate": false, "serviceClass":"foam.nanos.auth.resetPassword.ResetPasswordTokenService","boxClass":"foam.nanos.auth.token.TokenServiceSkeleton","client":"{\"class\":\"foam.nanos.auth.token.ClientTokenService\"}"})
 
 p({

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -509,6 +509,7 @@ var classes = [
   'foam.nanos.demo.relationship.CourseType',
   'foam.nanos.demo.relationship.StudentCourseJunction',
   'foam.nanos.fs.File',
+  'foam.nanos.fs.FileDataDAO',
   'foam.nanos.fs.FileType',
   'foam.nanos.fs.SupportFileTypeDAO',
   'foam.crypto.hash.Hasher',


### PR DESCRIPTION
Add server side support for choosing to write files based on size to either the real file system or store directly in the File model.

Also, when BlobService is used the resulting 'id' must be set on the corresponding File model, else httpFileService requests, which use the blob id, will never be resolved.