### PR TITLE
[NP-2966] unify close X button

### DIFF
--- a/src/foam/nanos/notification/NotificationMessageModal.js
+++ b/src/foam/nanos/notification/NotificationMessageModal.js
@@ -16,11 +16,10 @@ foam.CLASS({
         background-color: #fff;
         width: 60vw;
         max-height: 80vh;
-        padding: 24px;
         overflow-y: scroll;
       }
       ^ .main {
-        padding: 8px 24px 0px;
+        padding: 8px 48px 24px;
       }
       ^ .bold-label {
         font-size: 16px;

--- a/src/foam/u2/ModalHeader.js
+++ b/src/foam/u2/ModalHeader.js
@@ -12,8 +12,7 @@ foam.CLASS({
   documentation: 'Modal Container close/title use in modal class to append title & close buttons.',
 
   imports: [
-    'stack',
-    'closeDialog'
+    'stack'
   ],
 
   properties: [
@@ -27,8 +26,7 @@ foam.CLASS({
       align-items: center;
 
       width: 100%; /* This is to fit the width of its parent container */
-      padding-top: 8px;
-      padding-bottom: 24px;
+      padding: 32px 24px 24px;
       box-sizing: border-box;
       border-bottom: solid 1px #CBCFD4;
     }
@@ -39,13 +37,6 @@ foam.CLASS({
       color: #1E1F21;
       margin: 0;
       flex: 1;
-    }
-    ^close{
-      background: 0;
-      width: 24px;
-      height: 24px;
-      padding: 0 !important;
-      cursor: pointer;
     }
     ^ .foam-u2-ActionView-closeModal{
       background: transparent !important;
@@ -60,19 +51,7 @@ foam.CLASS({
 
     this
       .addClass(this.myClass())
-      .start().addClass(this.myClass('title')).add(this.title).end()
-      .start(this.CLOSE_MODAL).addClass(this.myClass('close')).end();
-    }
-  ],
-
-  actions: [
-    {
-      name: 'closeModal',
-      icon: 'images/ic-cancelblack.svg',
-      label: '',
-      code: function(X) {
-        X.closeDialog();
-      }
+      .start().addClass(this.myClass('title')).add(this.title).end();
     }
   ]
 });

--- a/src/foam/u2/crunch/wizardflow/ConfigureFlowAgent.js
+++ b/src/foam/u2/crunch/wizardflow/ConfigureFlowAgent.js
@@ -44,7 +44,7 @@ foam.CLASS({
           ? function (viewSpec, onClose) {
             ctrl.add(
               self.Popup.create({
-                closeable: false,
+                closeable: viewSpec.closeable ? viewSpec.closeable : false,
                 ...(onClose ? { onClose: onClose } : {}),
               })
                 .tag(viewSpec)

--- a/src/foam/u2/crunch/wizardflow/StepWizardAgent.js
+++ b/src/foam/u2/crunch/wizardflow/StepWizardAgent.js
@@ -51,19 +51,26 @@ foam.CLASS({
   methods: [
     function execute() {
       return new Promise((resolve, reject) => {
+        var data = this.StepWizardletController.create({
+          wizardlets: this.wizardlets,
+          config: this.wizardConfig,
+          submitted$: this.submitted$,
+        });
         this.pushView({
           ...this.view,
-          data: this.StepWizardletController.create({
-            wizardlets: this.wizardlets,
-            config: this.wizardConfig,
-            submitted$: this.submitted$,
-          }),
+          data: data,
+          closeable: true,
           onClose: (x) => {
             this.popView(x)
             resolve();
           }
-        }, () => {
-          resolve();
+        }, (x) => {
+          data.saveProgress().then(() => {
+            resolve();
+          }).catch(e => {
+            console.error(e);
+            x.ctrl.notify(this.ERROR_MSG_DRAFT, '', this.LogLevel.ERROR, true);
+          });
         });
       });
     }

--- a/src/foam/u2/dialog/Popup.js
+++ b/src/foam/u2/dialog/Popup.js
@@ -43,8 +43,8 @@ foam.CLASS({
     }
     ^X {
       position: absolute;
-      top: 32px;
-      right: 24px;
+      top: 8px;
+      right: 16px;
       z-index: 1000;
       background: none !important;
       width: 24px !important;
@@ -74,6 +74,7 @@ foam.CLASS({
     ^inner {
       z-index: 3;
       max-width: 80vw;
+      position: relative;
       /* The following line fixes a stacking problem in certain browsers. */
       will-change: opacity;
     }

--- a/src/foam/u2/dialog/Popup.js
+++ b/src/foam/u2/dialog/Popup.js
@@ -41,6 +41,19 @@ foam.CLASS({
       top: 0;
       z-index: 1000;
     }
+    ^X {
+      position: absolute;
+      top: 32px;
+      right: 24px;
+      z-index: 1000;
+      background: none !important;
+      width: 24px !important;
+      height: 24px !important;
+      cursor: pointer;
+      transition: ease 0.2s;
+      padding: 0;
+      border: none !important;
+    }
     ^container {
       align-items: center;
       display: flex;
@@ -92,6 +105,11 @@ foam.CLASS({
           .call(function() { content = this; })
           .addClass(this.myClass('inner'))
           .style({ 'background-color': this.backgroundColor })
+          .startContext({ data: this })
+            .start(this.CLOSE_MODAL).show(this.closeable$)
+              .addClass(this.myClass('X'))
+            .end()
+          .endContext()
         .end()
       .end();
 
@@ -108,6 +126,17 @@ foam.CLASS({
     function close() {
       if ( this.onClose ) this.onClose();
       this.remove();
+    }
+  ],
+
+  actions: [
+    {
+      name: 'closeModal',
+      icon: 'images/ic-cancelblack.svg',
+      label: '',
+      code: function(X) {
+        this.close();
+      }
     }
   ]
 });

--- a/src/foam/u2/view/EditColumnsView.js
+++ b/src/foam/u2/view/EditColumnsView.js
@@ -68,15 +68,6 @@ foam.CLASS({
       .addClass(this.myClass())
         .show(this.selectColumnsExpanded$)
         .addClass(this.myClass('drop-down-bg'))
-        .start()
-          .style({
-            'right': '40px',
-            'top': '80px',
-            'position': 'fixed'
-          })
-          .startContext({data: this})
-            .add(this.CLOSE_BUTTON)
-          .endContext()
           .start()
             .style({
               'border-radius': '5px',
@@ -91,7 +82,6 @@ foam.CLASS({
             })
             .add(this.columnConfigPropView)
           .end()
-        .end()
       .on('click', this.closeDropDown.bind(this))
       .end();
     }

--- a/src/foam/u2/wizard/StepWizardletView.js
+++ b/src/foam/u2/wizard/StepWizardletView.js
@@ -167,7 +167,7 @@ foam.CLASS({
     {
       name: 'hideX',
       class: 'Boolean',
-      value: false
+      value: true
     },
     {
       name: 'backDisabled',


### PR DESCRIPTION
Address:
https://nanopay.atlassian.net/browse/NP-2966

- Unify close X button and move it into Popup.js
- Remove the close confirm popup for stepWizardletView by setting the default value of hideX(which is the inside X) as true. Let stepWizardletView be saved each time it is closed. 
- Standardize modal header -- White, header text, 24px black X
- Remove X button in EditColumnsView

<img width="1434" alt="Screen Shot 2020-12-08 at 8 43 18 PM" src="https://user-images.githubusercontent.com/38148986/101562963-65c1a800-3996-11eb-9110-4ab8016506a0.png">
<img width="1436" alt="Screen Shot 2020-12-08 at 8 43 31 PM" src="https://user-images.githubusercontent.com/38148986/101562962-65291180-3996-11eb-8c0d-db79eb0e095a.png">
<img width="1436" alt="Screen Shot 2020-12-08 at 8 43 41 PM" src="https://user-images.githubusercontent.com/38148986/101562960-65291180-3996-11eb-9a54-f00e709299bf.png">
<img width="1440" alt="Screen Shot 2020-12-08 at 8 44 05 PM" src="https://user-images.githubusercontent.com/38148986/101562957-64907b00-3996-11eb-9383-feb4364afdee.png">
<img width="1438" alt="Screen Shot 2020-12-08 at 8 44 16 PM" src="https://user-images.githubusercontent.com/38148986/101562954-63f7e480-3996-11eb-88d3-a837bd8f7b1b.png">
<img width="1440" alt="Screen Shot 2020-12-08 at 8 44 48 PM" src="https://user-images.githubusercontent.com/38148986/101562946-60fcf400-3996-11eb-8d2f-2b445ee06226.png">
