### PR TITLE
[NP-3050] Add CapabilityGrantMode

### DIFF
--- a/src/foam/nanos/crunch/Capability.js
+++ b/src/foam/nanos/crunch/Capability.js
@@ -198,6 +198,12 @@ foam.CLASS({
       documentation: 'Predicate of the visibility for capabilities in the capability store/keyword sections'
     },
     {
+      name: 'grantMode',
+      class: 'Enum',
+      of: 'foam.nanos.crunch.CapabilityGrantMode',
+      value: foam.nanos.crunch.CapabilityGrantMode.AUTOMATIC
+    },
+    {
       name: 'reviewRequired',
       class: 'Boolean',
       permissionRequired: true
@@ -383,7 +389,7 @@ foam.CLASS({
           for ( var capId : prereqs ) {
             var cap = (Capability) capabilityDAO.find(capId);
             if ( cap == null || ! cap.getEnabled() ) continue;
-            
+
             UserCapabilityJunction prereqUcj = crunchService.getJunctionForSubject(x, capId, subject);
 
             prereqChainedStatus = getPrereqChainedStatus(x, ucj, prereqUcj);
@@ -410,30 +416,30 @@ foam.CLASS({
         CapabilityJunctionStatus prereqStatus = prereq.getStatus();
 
         switch ( (CapabilityJunctionStatus) prereqStatus ) {
-          case AVAILABLE : 
+          case AVAILABLE :
             status = CapabilityJunctionStatus.ACTION_REQUIRED;
             break;
-          case ACTION_REQUIRED : 
+          case ACTION_REQUIRED :
             status = CapabilityJunctionStatus.ACTION_REQUIRED;
             break;
-          case PENDING : 
-            status = reviewRequired && 
-              ( status == CapabilityJunctionStatus.APPROVED || 
+          case PENDING :
+            status = reviewRequired &&
+              ( status == CapabilityJunctionStatus.APPROVED ||
                 status == CapabilityJunctionStatus.GRANTED
-              ) ? 
+              ) ?
                 CapabilityJunctionStatus.APPROVED : CapabilityJunctionStatus.PENDING;
             break;
-          case APPROVED : 
-            status = reviewRequired && 
-              ( status == CapabilityJunctionStatus.APPROVED || 
+          case APPROVED :
+            status = reviewRequired &&
+              ( status == CapabilityJunctionStatus.APPROVED ||
                 status == CapabilityJunctionStatus.GRANTED
-              ) ? 
+              ) ?
                 CapabilityJunctionStatus.APPROVED : CapabilityJunctionStatus.PENDING;
               break;
           case EXPIRED :
             status = CapabilityJunctionStatus.ACTION_REQUIRED;
             break;
-          default : 
+          default :
             status = CapabilityJunctionStatus.GRANTED;
         }
         return status;

--- a/src/foam/nanos/crunch/CapabilityGrantMode.js
+++ b/src/foam/nanos/crunch/CapabilityGrantMode.js
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.ENUM({
+  package: 'foam.nanos.crunch',
+  name: 'CapabilityGrantMode',
+  values: [
+    {
+      name: 'AUTOMATIC',
+      background: '#8effb2',
+      documentation: `
+        The capability can be granted by saving a junction with valid data,
+        provided it has all of its prerequisites satisfied and the capability
+        is available. This action can be performed by any user of the system.
+      `
+    },
+    {
+      name: 'MANUAL',
+      background: '#ffe48e',
+      documentation: `
+        The capability will not be automatically granted. It must be granted
+        explicitly by a user with permission to grant capabilities, or by a
+        rule outside of CRUNCH.
+      `
+    }
+  ]
+});

--- a/src/foam/nanos/crunch/CapabilityGrantMode.js
+++ b/src/foam/nanos/crunch/CapabilityGrantMode.js
@@ -29,6 +29,10 @@ foam.ENUM({
         The capability will not be automatically granted. It must be granted
         explicitly by a user with permission to grant capabilities, or by a
         rule outside of CRUNCH.
+
+        When performing a manual grant, set the status to APPROVED. This will
+        allow prerequisites in PENDING to block granting of the capability
+        until they are also APPROVED or GRANTED.
       `
     }
   ]

--- a/src/foam/nanos/crunch/CapabilityGrantMode.js
+++ b/src/foam/nanos/crunch/CapabilityGrantMode.js
@@ -7,6 +7,11 @@
 foam.ENUM({
   package: 'foam.nanos.crunch',
   name: 'CapabilityGrantMode',
+  documentation: `
+    Set grantMode of a capability to MANUAL if you do not wish for the
+    capability to be granted automatically by a user action. This is useful
+    when an event outside of CRUNCH is expected to grant the capability.
+  `,
   values: [
     {
       name: 'AUTOMATIC',

--- a/src/foam/nanos/crunch/ruler/ValidateUCJDataOnPut.js
+++ b/src/foam/nanos/crunch/ruler/ValidateUCJDataOnPut.js
@@ -20,6 +20,7 @@ foam.CLASS({
     'foam.nanos.auth.User',
     'foam.nanos.crunch.AgentCapabilityJunction',
     'foam.nanos.crunch.Capability',
+    'foam.nanos.crunch.CapabilityGrantMode',
     'foam.nanos.crunch.CapabilityJunctionStatus',
     'foam.nanos.crunch.UserCapabilityJunction',
     'foam.nanos.logger.Logger'
@@ -36,14 +37,15 @@ foam.CLASS({
             UserCapabilityJunction ucj = (UserCapabilityJunction) obj;
 
             boolean isRenewable = ucj.getIsRenewable(); // ucj either expired, in grace period, or in renewal period
-            
-            if ( ( ucj.getStatus() == CapabilityJunctionStatus.GRANTED && ! isRenewable ) || 
-              ucj.getStatus() == CapabilityJunctionStatus.PENDING || 
-              ucj.getStatus() == CapabilityJunctionStatus.APPROVED ) 
+
+            if ( ( ucj.getStatus() == CapabilityJunctionStatus.GRANTED && ! isRenewable ) ||
+              ucj.getStatus() == CapabilityJunctionStatus.PENDING ||
+              ucj.getStatus() == CapabilityJunctionStatus.APPROVED )
               return;
 
             Capability capability = (Capability) ucj.findTargetId(systemX);
 
+            if ( capability.getGrantMode() != CapabilityGrantMode.AUTOMATIC ) return;
             if ( ! isRenewable ) ucj.setStatus(CapabilityJunctionStatus.ACTION_REQUIRED);
 
             if ( capability.getOf() == null ) {

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -27,6 +27,7 @@ FOAM_FILES([
   { name: 'foam/nanos/fs/fileDropZone/FilePreview', flags: ['web'] },
   { name: 'foam/nanos/fs/fileDropZone/FileCard', flags: ['web'] },
   { name: "foam/nanos/crunch/AssociatedEntity" },
+  { name: "foam/nanos/crunch/CapabilityGrantMode" },
   { name: "foam/nanos/crunch/Capability" },
   { name: "foam/nanos/auth/ServiceProvider" },
   { name: 'foam/nanos/fs/TextSaveView', flags: ['web'] },

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -667,6 +667,7 @@ var classes = [
   'foam.nanos.crunch.crunchtest.TestCapable',
   //models
   'foam.nanos.crunch.Renewable',
+  'foam.nanos.crunch.CapabilityGrantMode',
   'foam.nanos.crunch.Capability',
   'foam.nanos.crunch.CapabilityIntercept',
   'foam.nanos.crunch.MinMaxCapability',


### PR DESCRIPTION
Set `grantMode` of a capability to `MANUAL` if you do not wish for the capability to be granted automatically by a user action. This is useful when an event outside of CRUNCH is expected to grant the capability.