### PR TITLE
fixed incorrectly enabled next button

### DIFF
--- a/src/foam/u2/crunch/EasyCrunchWizard.js
+++ b/src/foam/u2/crunch/EasyCrunchWizard.js
@@ -16,8 +16,7 @@ foam.CLASS({
   properties: [
     {
       class: 'Boolean',
-      name: 'allowSkipping',
-      value: true
+      name: 'allowSkipping'
     },
     {
       class: 'Boolean',

--- a/src/foam/u2/wizard/StepWizardConfig.js
+++ b/src/foam/u2/wizard/StepWizardConfig.js
@@ -15,8 +15,7 @@ foam.CLASS({
   properties: [
     {
       class: 'Boolean',
-      name: 'allowSkipping',
-      value: true
+      name: 'allowSkipping'
     },
     {
       class: 'Boolean',


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/NP-3075

fixed incorrectly enabled next button

 in stepWizardletController.js 's canGoNext always returning true.
validation message checking parts are fine but found out allowSkipping's default has been set as true. 


<img width="1119" alt="Screen Shot 2020-12-14 at 11 16 42 AM" src="https://user-images.githubusercontent.com/33228583/102105825-da18a300-3dfd-11eb-9223-29847993902a.png">
