### PR TITLE
Make help text scrollable (w/o scroll bar)

### DIFF
--- a/src/foam/u2/detail/SectionedDetailPropertyView.js
+++ b/src/foam/u2/detail/SectionedDetailPropertyView.js
@@ -55,6 +55,18 @@ foam.CLASS({
       border-top-right-radius: 0px;
       direction: ltr;
       padding: 2px;
+      max-height: 100px;
+      overflow: hidden;
+    }
+
+    ^helper-text p {
+      padding: 3px;
+      margin: 0;
+      /* css trick for hiding scroll bar in all browsers */
+      margin-right: -50px; /* Maximum width of scrollbar */
+      padding-right: 50px; /* Maximum width of scrollbar */
+      height: 100%;
+      overflow-y: scroll;
     }
 
     ^arrow-right {
@@ -263,7 +275,7 @@ foam.CLASS({
                       .addClass(self.myClass('tooltip-container'))
                       .start()
                         .addClass(self.myClass('helper-text'))
-                        .start('p').style({ 'padding': '3px' })
+                        .start('p')
                           .add(prop.help)
                         .end()
                       .end()


### PR DESCRIPTION
### problem:
**Help texts flicker in wizard if help text is too big/ space is too small**


<img width="1055" alt="Screen Shot 2020-12-16 at 11 00 28 PM" src="https://user-images.githubusercontent.com/58435071/102442540-95a22880-3ff2-11eb-958b-9aa306a83643.png">

<img width="1113" alt="Screen Shot 2020-12-16 at 10 59 56 PM" src="https://user-images.githubusercontent.com/58435071/102442535-92a73800-3ff2-11eb-846d-bb6fb5642f02.png">

(couldn't capture the exact behaviour, but the app repeatedly shows and hides the help text)


### fix:
**make the help text scrollable (but hides the scroll bar for cleaner ui)**

<img width="1116" alt="Screen Shot 2020-12-16 at 10 56 34 PM" src="https://user-images.githubusercontent.com/58435071/102442313-2593a280-3ff2-11eb-860e-0426f13b79c7.png">

<img width="1107" alt="Screen Shot 2020-12-16 at 10 56 46 PM" src="https://user-images.githubusercontent.com/58435071/102442774-2da01200-3ff3-11eb-8f4a-2c23fab2a897.png">

