### PR TITLE
Pending review included in cap store polling listener 

### DIFF
--- a/src/foam/nanos/crunch/ui/UserCapabilityJunctionWAO.js
+++ b/src/foam/nanos/crunch/ui/UserCapabilityJunctionWAO.js
@@ -25,6 +25,7 @@ foam.CLASS({
         wizardlet.capability.id, wizardlet.data, null
       ).then((ucj) => {
         this.crunchService.pub('updateJunction');
+        this.crunchService.pub('grantedJunction');
         return ucj;
       });
     },

--- a/src/foam/nanos/menu/VerticalMenu.js
+++ b/src/foam/nanos/menu/VerticalMenu.js
@@ -75,8 +75,8 @@ foam.CLASS({
     {
       class: 'foam.dao.DAOProperty',
       name: 'dao_',
-      factory: function() {
-        return this.menuDAO.orderBy(this.Menu.ORDER);
+      expression: function(menuDAO) {
+        return menuDAO.orderBy(this.Menu.ORDER);
       }
     },
     {
@@ -109,7 +109,7 @@ foam.CLASS({
             .addClass('tree-view-height-manager')
             .tag({
               class: 'foam.u2.view.TreeView',
-              data: self.dao_,
+              data$: self.dao_$,
               relationship: foam.nanos.menu.MenuMenuChildrenRelationship,
               startExpanded: true,
               query: self.menuSearch$,

--- a/src/foam/u2/crunch/CapabilityFeatureView.js
+++ b/src/foam/u2/crunch/CapabilityFeatureView.js
@@ -86,8 +86,7 @@ foam.CLASS({
        this.SUPER();
        this.onDetach(this.crunchService.sub('updateJunction', this.daoUpdate));
        this.daoUpdate();
-       if ( this.cjStatus == this.CapabilityJunctionStatus.PENDING || this.cjStatus == this.CapabilityJunctionStatus.PENDING_REVIEW ) 
-          this.onDetach(this.cjStatus$.sub(this.statusUpdate));
+       this.onDetach(this.cjStatus$.sub(this.statusUpdate));
     },
 
     function initE() {
@@ -170,7 +169,6 @@ foam.CLASS({
               this.cjStatus = this.CapabilityJunctionStatus.PENDING_REVIEW;
             }
           }
-          this.onDetach(this.cjStatus$.sub(this.statusUpdate));
         });
       }
     },

--- a/src/foam/u2/crunch/CapabilityFeatureView.js
+++ b/src/foam/u2/crunch/CapabilityFeatureView.js
@@ -86,7 +86,8 @@ foam.CLASS({
        this.SUPER();
        this.onDetach(this.crunchService.sub('updateJunction', this.daoUpdate));
        this.daoUpdate();
-       if ( this.cjStatus != this.CapabilityJunctionStatus.PENDING ) this.onDetach(this.cjStatus$.sub(this.statusUpdate));
+       if ( this.cjStatus != this.CapabilityJunctionStatus.PENDING && this.cjStatus != this.CapabilityJunctionStatus.PENDING_REVIEW ) 
+          this.onDetach(this.cjStatus$.sub(this.statusUpdate));
     },
 
     function initE() {
@@ -175,7 +176,8 @@ foam.CLASS({
     {
       name: 'statusUpdate',
       code: function() {
-        if ( this.cjStatus != this.CapabilityJunctionStatus.PENDING ) {
+        if ( this.cjStatus != this.CapabilityJunctionStatus.PENDING &&
+              this.cjStatus != this.CapabilityJunctionStatus.PENDING_REVIEW ) {
           return;
         }
         this.crunchService.getJunction(null, this.data.id).then(ucj => {

--- a/src/foam/u2/crunch/CapabilityFeatureView.js
+++ b/src/foam/u2/crunch/CapabilityFeatureView.js
@@ -86,7 +86,7 @@ foam.CLASS({
        this.SUPER();
        this.onDetach(this.crunchService.sub('updateJunction', this.daoUpdate));
        this.daoUpdate();
-       if ( this.cjStatus != this.CapabilityJunctionStatus.PENDING && this.cjStatus != this.CapabilityJunctionStatus.PENDING_REVIEW ) 
+       if ( this.cjStatus == this.CapabilityJunctionStatus.PENDING || this.cjStatus == this.CapabilityJunctionStatus.PENDING_REVIEW ) 
           this.onDetach(this.cjStatus$.sub(this.statusUpdate));
     },
 
@@ -170,6 +170,7 @@ foam.CLASS({
               this.cjStatus = this.CapabilityJunctionStatus.PENDING_REVIEW;
             }
           }
+          this.onDetach(this.cjStatus$.sub(this.statusUpdate));
         });
       }
     },

--- a/src/foam/u2/crunch/CapabilityStore.js
+++ b/src/foam/u2/crunch/CapabilityStore.js
@@ -39,6 +39,7 @@ foam.CLASS({
     'capabilityDAO',
     'crunchController',
     'crunchService',
+    'menuDAO',
     'registerElement'
   ],
 
@@ -391,16 +392,21 @@ foam.CLASS({
   ],
 
   listeners: [
-    async function onChange() {
-      let a = await this.crunchService.getEntryCapabilities();
-      this.visibleCapabilityDAO = this.ArrayDAO.create({
-        array: a.array
-      });
-      await this.crunchService.getAllJunctionsForUser();
-      this.daoUpdate();
-      // Attempting to reset menuDAO incase of menu permission grantings.
-      this.menuDAO.cmd_(this, foam.dao.CachingDAO.PURGE);
-      this.menuDAO.cmd_(this, foam.dao.AbstractDAO.RESET_CMD);
+    {
+      name: 'onChange',
+      isMerged: true,
+      mergeDelay: 2000,
+      code: async function() {
+        let a = await this.crunchService.getEntryCapabilities();
+        this.visibleCapabilityDAO = this.ArrayDAO.create({
+          array: a.array
+        });
+        await this.crunchService.getAllJunctionsForUser();
+        this.daoUpdate();
+        // Attempting to reset menuDAO incase of menu permission grantings.
+        this.menuDAO.cmd_(this, foam.dao.CachingDAO.PURGE);
+        this.menuDAO.cmd_(this, foam.dao.AbstractDAO.RESET_CMD);
+      }
     }
   ]
 });

--- a/src/foam/u2/crunch/CapabilityStore.js
+++ b/src/foam/u2/crunch/CapabilityStore.js
@@ -391,16 +391,16 @@ foam.CLASS({
   ],
 
   listeners: [
-    {
-      name: 'onChange',
-      isMerged: true,
-      code: function() {
-        this.crunchService.getEntryCapabilities().then(a => {
-          this.visibleCapabilityDAO = this.ArrayDAO.create({
-            array: a.array
-          });
-        });
-      }
+    async function onChange() {
+      let a = await this.crunchService.getEntryCapabilities();
+      this.visibleCapabilityDAO = this.ArrayDAO.create({
+        array: a.array
+      });
+      await this.crunchService.getAllJunctionsForUser();
+      this.daoUpdate();
+      // Attempting to reset menuDAO incase of menu permission grantings.
+      this.menuDAO.cmd_(this, foam.dao.CachingDAO.PURGE);
+      this.menuDAO.cmd_(this, foam.dao.AbstractDAO.RESET_CMD);
     }
   ]
 });


### PR DESCRIPTION
Cards on capability store update based on UCJ changes. 
Required behaviour explained here: https://nanopay.atlassian.net/browse/NP-3131

NOTE extended issues: 

Flickering is persistent on most status changes - onChange is called multiple times based on a published event of 'updateJunction'. Possible loop caused by ucj listeners or expression in conjunction with the fetches occurring in the onChange listeners.

Menus aren't updated when menu read permissions are granted.