### PR TITLE
One line crisis

### DIFF
--- a/src/foam/u2/view/MultiChoiceView.js
+++ b/src/foam/u2/view/MultiChoiceView.js
@@ -120,7 +120,7 @@ foam.CLASS({
 
             if ( ! isSelected && ! isFinal ) {
               choice[3] = this.mustSlot(choice[3]);
-              choice[3].set(foam.u2.DisplayMode.RW)
+              choice[3].set(foam.u2.DisplayMode.RW);
             }
           });
         } else {

--- a/src/foam/u2/view/MultiChoiceView.js
+++ b/src/foam/u2/view/MultiChoiceView.js
@@ -118,8 +118,9 @@ foam.CLASS({
               ? choice[4].get()
               : choice[4];
 
-            if ( ! isSelected && ! isFinal && foam.core.Slot.isInstance(choice[3]) ) {
-              choice[3].set(foam.u2.DisplayMode.RW);
+            if ( ! isSelected && ! isFinal ) {
+              choice[3] = this.mustSlot(choice[3]);
+              choice[3].set(foam.u2.DisplayMode.RW)
             }
           });
         } else {
@@ -132,7 +133,8 @@ foam.CLASS({
               ? choice[4].get()
               : choice[4];
 
-            if ( ! isSelected && ! isFinal && foam.core.Slot.isInstance(choice[3]) ) {
+            if ( ! isSelected && ! isFinal ) {
+              choice[3] = this.mustSlot(choice[3]);
               choice[3].set(foam.u2.DisplayMode.DISABLED);
             }
           });
@@ -252,6 +254,8 @@ foam.CLASS({
                     });
               });
 
+              this.choices = newChoices;
+
               self.selectedChoices$ = foam.core.ArraySlot.create({
                 slots: newChoices.map(choice => {
                   return this.mustSlot(choice[2]);
@@ -265,7 +269,6 @@ foam.CLASS({
                 });
                 return selectedChoices;
               });
-              this.choices = newChoices;
               return toRender;
             })
           )


### PR DESCRIPTION
When a previously saved invoice with capable payloads filled out was reopened -> if a nature code was already selected, it would allow you to click other nature code's as well (unexpected) but the wizard wouldn't let you press next until one is selected (by deselecting other one that  you selected).

### Before:
<img width="1680" alt="Screen Shot 2020-12-17 at 4 46 39 PM" src="https://user-images.githubusercontent.com/26717171/102547625-786b6980-4087-11eb-80dd-3d879d456750.png">

Not a critical error as you cannot go next in the wizard when selecting multiple using the bug when the max is 1:
<img width="1680" alt="Screen Shot 2020-12-17 at 4 48 01 PM" src="https://user-images.githubusercontent.com/26717171/102547810-bd8f9b80-4087-11eb-82d4-2ddbdfa230d9.png">

### Fix with this PR:
<img width="1680" alt="Screen Shot 2020-12-17 at 4 44 38 PM" src="https://user-images.githubusercontent.com/26717171/102547645-80c3a480-4087-11eb-9ba7-8d296d093ccd.png">

