### PR TITLE
[NP-2896] fix cap store cards cut off issue

### DIFF
--- a/src/foam/u2/crunch/CapabilityStore.js
+++ b/src/foam/u2/crunch/CapabilityStore.js
@@ -124,10 +124,6 @@ foam.CLASS({
     }
   `,
 
-  constants: {
-    MAX_NUM_DISPLAYBLE_CARDS: 4
-  },
-
   properties: [
     {
       name: 'visibleCapabilityDAO',

--- a/src/foam/u2/crunch/CapabilityStore.js
+++ b/src/foam/u2/crunch/CapabilityStore.js
@@ -174,8 +174,7 @@ foam.CLASS({
     },
     {
       name: 'cardsOverflow',
-      class: 'Boolean',
-      value: false
+      class: 'Boolean'
     },
     'wizardOpened'
   ],

--- a/src/foam/u2/crunch/CapabilityStore.js
+++ b/src/foam/u2/crunch/CapabilityStore.js
@@ -248,6 +248,7 @@ foam.CLASS({
               })
             .end());
         }
+
         spot.start().start('span')
           .start('img').addClass(self.myClass('left-arrow')).show(this.cardsOverflow$)
             .attr('src', 'images/arrow-back-24px.svg')
@@ -279,6 +280,7 @@ foam.CLASS({
             })
           .end()
         .end();
+
         window.addEventListener('resize', checkCardsOverflow);
         checkCardsOverflow();
         self.onDetach(() => {

--- a/src/foam/u2/crunch/CapabilityStore.js
+++ b/src/foam/u2/crunch/CapabilityStore.js
@@ -227,7 +227,6 @@ foam.CLASS({
         //     });
         //   })
         .end();
-        window.addEventListener('resize', this.onResize);
     },
 
     function renderFeatured() { // Featured Capabilities in carousel view
@@ -257,9 +256,14 @@ foam.CLASS({
             })
           .end()
         .end();
+        var ele;
+        function checkCardsOverflow(evt) {
+          if ( ! ele.el() ) return;
+          self.cardsOverflow = ele.el().scrollWidth > ele.el().clientWidth;
+        }
         spot.add(self.slot(
           function(carouselCounter, totalNumCards) {
-            var ele = self.E().addClass(self.myClass('feature-column-grid'));
+            ele = self.E().addClass(self.myClass('feature-column-grid'));
             for ( var k = 0 ; k < totalNumCards ; k++ ) {
               let cc = carouselCounter % totalNumCards; // this stops any out of bounds indecies
               let index = ( cc + totalNumCards + k ) % totalNumCards; // this ensures circle indecies
@@ -275,7 +279,11 @@ foam.CLASS({
             })
           .end()
         .end();
-        self.onResize();
+        window.addEventListener('resize', checkCardsOverflow);
+        checkCardsOverflow();
+        self.onDetach(() => {
+          window.removeEventListener('resize', checkCardsOverflow);
+        });
       });
       return spot;
     },
@@ -406,14 +414,6 @@ foam.CLASS({
         // Attempting to reset menuDAO incase of menu permission grantings.
         this.menuDAO.cmd_(this, foam.dao.CachingDAO.PURGE);
         this.menuDAO.cmd_(this, foam.dao.AbstractDAO.RESET_CMD);
-      }
-    },
-    {
-      name: 'onResize',
-      code: function() {
-        var scrollWidth = this.document.querySelector(`.foam-u2-crunch-CapabilityStore-feature-column-grid`).scrollWidth;
-        var clientWidth = this.document.querySelector(`.foam-u2-crunch-CapabilityStore-feature-column-grid`).clientWidth;
-        this.cardsOverflow = scrollWidth > clientWidth;
       }
     }
   ]

--- a/src/foam/u2/crunch/CapabilityStore.js
+++ b/src/foam/u2/crunch/CapabilityStore.js
@@ -78,8 +78,8 @@ foam.CLASS({
 
     ^feature-column-grid {
       display: inline-flex;
-      width: 94%;
-      overflow: hidden;
+      width: calc(100% - 48px);
+      overflow-x: scroll;
     }
 
     ^featureSection {
@@ -93,7 +93,8 @@ foam.CLASS({
     }
 
     ^left-arrow {
-      width: 3%;
+      width: 24px;
+      height: 24px;
       float: left;
       display: flex;
       cursor: pointer;
@@ -102,7 +103,8 @@ foam.CLASS({
     }
 
     ^right-arrow {
-      width: 3%;
+      width: 24px;
+      height: 24px;
       float: right;
       display: flex;
       cursor: pointer;
@@ -174,6 +176,11 @@ foam.CLASS({
       value: [],
       documentation: 'stores the styling of each featureCapability'
     },
+    {
+      name: 'cardsOverflow',
+      class: 'Boolean',
+      value: false
+    },
     'wizardOpened'
   ],
 
@@ -225,6 +232,7 @@ foam.CLASS({
         //     });
         //   })
         .end();
+        window.addEventListener('resize', this.onResize);
     },
 
     function renderFeatured() { // Featured Capabilities in carousel view
@@ -246,16 +254,14 @@ foam.CLASS({
               })
             .end());
         }
-        self.callIf(self.totalNumCards > self.MAX_NUM_DISPLAYBLE_CARDS, function() {
-          return spot.start('span')
-            .start('img').addClass(self.myClass('left-arrow'))
-              .attr('src', 'images/arrow-back-24px.svg')
-              .on('click', function() {
-                self.carouselCounter--;
-              })
-            .end()
-          .end();
-        });
+        spot.start().start('span')
+          .start('img').addClass(self.myClass('left-arrow')).show(this.cardsOverflow$)
+            .attr('src', 'images/arrow-back-24px.svg')
+            .on('click', function() {
+              self.carouselCounter--;
+            })
+          .end()
+        .end();
         spot.add(self.slot(
           function(carouselCounter, totalNumCards) {
             var ele = self.E().addClass(self.myClass('feature-column-grid'));
@@ -266,16 +272,15 @@ foam.CLASS({
             }
             return ele;
           }));
-        self.callIf(self.totalNumCards > self.MAX_NUM_DISPLAYBLE_CARDS, function() {
-          return spot.start('span')
-            .start('img').addClass(self.myClass('right-arrow'))
-              .attr('src', 'images/arrow-forward-24px.svg')
-              .on('click', function() {
-                self.carouselCounter++;
-              })
-            .end()
-          .end();
-        })
+        spot.start('span')
+          .start('img').addClass(self.myClass('right-arrow')).show(this.cardsOverflow$)
+            .attr('src', 'images/arrow-forward-24px.svg')
+            .on('click', function() {
+              self.carouselCounter++;
+            })
+          .end()
+        .end();
+        self.onResize();
       });
       return spot;
     },
@@ -406,6 +411,14 @@ foam.CLASS({
         // Attempting to reset menuDAO incase of menu permission grantings.
         this.menuDAO.cmd_(this, foam.dao.CachingDAO.PURGE);
         this.menuDAO.cmd_(this, foam.dao.AbstractDAO.RESET_CMD);
+      }
+    },
+    {
+      name: 'onResize',
+      code: function() {
+        var scrollWidth = this.document.querySelector(`.foam-u2-crunch-CapabilityStore-feature-column-grid`).scrollWidth;
+        var clientWidth = this.document.querySelector(`.foam-u2-crunch-CapabilityStore-feature-column-grid`).clientWidth;
+        this.cardsOverflow = scrollWidth > clientWidth;
       }
     }
   ]


### PR DESCRIPTION
address: https://nanopay.atlassian.net/browse/NP-2896

- Remove hard coding of MAX_NUM_DISPLAYBLE_CARDS
- Add/remove the arrows based on if the cards overflow
- When the cards overflow, add arrows and enable scroll bar

<img width="702" alt="Screen Shot 2020-12-17 at 5 07 32 PM" src="https://user-images.githubusercontent.com/38148986/102550983-ccc51800-408c-11eb-8b9d-f6a0bdd04ba2.png">
<img width="1127" alt="Screen Shot 2020-12-17 at 5 07 24 PM" src="https://user-images.githubusercontent.com/38148986/102550990-cdf64500-408c-11eb-810c-c9f1f189d6ff.png">

