### PR TITLE
[NP-3116] Smarter completion indicator for wizardlets

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -870,6 +870,7 @@ FOAM_FILES([
   { name: "foam/u2/wizard/WizardPosition" },
   { name: "foam/u2/wizard/Wizardlet" },
   { name: "foam/u2/wizard/WizardletSection" },
+  { name: "foam/u2/wizard/WizardletIndicator" },
   { name: "foam/u2/wizard/BaseWizardlet" },
   { name: "foam/u2/wizard/WizardletView" },
   { name: "foam/u2/wizard/StepWizardConfig" },

--- a/src/foam/nanos/crunch/ui/CapabilityWizardlet.js
+++ b/src/foam/nanos/crunch/ui/CapabilityWizardlet.js
@@ -9,7 +9,9 @@ foam.CLASS({
   extends: 'foam.u2.wizard.BaseWizardlet',
 
   requires: [
+    'foam.nanos.crunch.CapabilityJunctionStatus',
     'foam.nanos.crunch.ui.UserCapabilityJunctionWAO',
+    'foam.u2.wizard.WizardletIndicator'
   ],
 
   properties: [
@@ -67,6 +69,19 @@ foam.CLASS({
       name: 'dataController',
       factory: function () {
         return this.UserCapabilityJunctionWAO.create({}, this.__context__);
+      }
+    },
+    {
+      name: 'indicator',
+      expression: function (status) {
+        if (
+          status == this.CapabilityJunctionStatus.GRANTED ||
+          status == this.CapabilityJunctionStatus.PENDING ||
+          status == this.CapabilityJunctionStatus.GRACE_PERIOD
+        ) {
+          return this.WizardletIndicator.COMPLETED;
+        }
+        return this.WizardletIndicator.PLEASE_FILL;
       }
     },
     {

--- a/src/foam/nanos/crunch/ui/CapabilityWizardlet.js
+++ b/src/foam/nanos/crunch/ui/CapabilityWizardlet.js
@@ -49,12 +49,18 @@ foam.CLASS({
       }
     },
     {
+      name: 'isAvailablePromise',
+      factory: () => Promise.resolve(),
+    },
+    {
       name: 'isAvailable',
       class: 'Boolean',
       value: true,
       postSet: function (ol, nu) {
-        if ( nu ) this.save();
-        else this.cancel();
+        if ( nu ) this.isAvailablePromise =
+          this.isAvailablePromise.then(() => this.save());
+        else this.isAvailablePromise =
+          this.isAvailablePromise.then(() => this.cancel());
       }
     },
     {

--- a/src/foam/nanos/crunch/ui/MinMaxCapabilityWizardlet.js
+++ b/src/foam/nanos/crunch/ui/MinMaxCapabilityWizardlet.js
@@ -86,10 +86,11 @@ foam.CLASS({
         if ( !n ){
           this.choiceWizardlets.forEach(cw => {
             cw.isAvailable = false
-            cw.cancel();
           });
 
-          this.cancel();
+          this.isAvailablePromise =
+            Promise.all(this.choiceWizardlets.map(cw => cw.isAvailablePromise))
+              .then(() => { this.cancel(); });
         } else {
           this.save();
         }

--- a/src/foam/nanos/crunch/ui/UserCapabilityJunctionWAO.js
+++ b/src/foam/nanos/crunch/ui/UserCapabilityJunctionWAO.js
@@ -24,8 +24,8 @@ foam.CLASS({
       return this.crunchService.updateJunction( null,
         wizardlet.capability.id, wizardlet.data, null
       ).then((ucj) => {
-        this.crunchService.pub('updateJunction');
         this.crunchService.pub('grantedJunction');
+        this.load_(wizardlet, ucj);
         return ucj;
       });
     },
@@ -41,22 +41,25 @@ foam.CLASS({
       return this.crunchService.getJunction(
         null, wizardlet.capability.id
       ).then(ucj => {
-        wizardlet.status = ucj.status;
+        this.load_(wizardlet, ucj);
+      });
+    },
+    function load_(wizardlet, ucj) {
+      wizardlet.status = ucj.status;
 
-        // No 'of'? No problem
-        if ( ! wizardlet.of ) return wizardlet;
+      // No 'of'? No problem
+      if ( ! wizardlet.of ) return;
 
-        // Load UCJ data to wizardlet
-        var loadedData = wizardlet.of.create({}, wizardlet);
-        if ( ucj.data ) loadedData.copyFrom(ucj.data);
+      // Load UCJ data to wizardlet
+      var loadedData = wizardlet.of.create({}, wizardlet);
+      if ( ucj.data ) loadedData.copyFrom(ucj.data);
 
         // Set transient 'capability' property if it exists
         var prop = wizardlet.of.getAxiomByName('capability');
         if ( prop ) prop.set(loadedData, wizardlet.capability);
 
-        // Finally, apply new data to wizardlet
-        wizardlet.data = loadedData;
-      });
+      // Finally, apply new data to wizardlet
+      wizardlet.data = loadedData;
     }
   ]
 });

--- a/src/foam/u2/crunch/EasyCrunchWizard.js
+++ b/src/foam/u2/crunch/EasyCrunchWizard.js
@@ -42,6 +42,8 @@ foam.CLASS({
       if ( this.skipMode )
         sequence.reconfigure('SkipGrantedAgent', {
           mode: this.skipMode });
+      if ( this.statelessWizard )
+        sequence.remove('WizardStateAgent');
     },
     async function execute () {
       // Subclasses which fetch information asynchronously can override this

--- a/src/foam/u2/wizard/BaseWizardlet.js
+++ b/src/foam/u2/wizard/BaseWizardlet.js
@@ -14,8 +14,9 @@ foam.CLASS({
 
   requires: [
     'foam.u2.detail.AbstractSectionedDetailView',
+    'foam.u2.wizard.WizardletIndicator',
     'foam.u2.wizard.WizardletSection',
-    'foam.u2.wizard.WAO',
+    'foam.u2.wizard.WAO'
   ],
 
   properties: [
@@ -104,6 +105,18 @@ foam.CLASS({
       flags: ['web'],
       factory: function () {
         this.WAO.create();
+      }
+    },
+    {
+      name: 'indicator',
+      class: 'Enum',
+      of: 'foam.u2.wizard.WizardletIndicator',
+      documentation: `
+        Describes how this wizardlet will appear in the list of steps.
+      `,
+      expression: function (isValid) {
+        return isValid ? this.WizardletIndicator.COMPLETED
+          : this.WizardletIndicator.PLEASE_FILL;
       }
     }
   ],

--- a/src/foam/u2/wizard/StepWizardletController.js
+++ b/src/foam/u2/wizard/StepWizardletController.js
@@ -292,7 +292,9 @@ foam.CLASS({
           .reduce(
             (p, i) => p.then(
               () => {
-                if ( this.wizardlets[i].isAvailable ) this.wizardlets[i].save();
+                if ( this.wizardlets[i].isAvailable ) {
+                  return this.wizardlets[i].save();
+                }
               }),
             Promise.resolve()
           ).then(() => {

--- a/src/foam/u2/wizard/StepWizardletController.js
+++ b/src/foam/u2/wizard/StepWizardletController.js
@@ -261,7 +261,7 @@ foam.CLASS({
     },
     function saveProgress() {
       var p = Promise.resolve();
-      return this.wizardlets.reduce(
+      return this.wizardlets.slice(0, this.highestIndex).reduce(
         (p, wizardlet) => p.then(() => wizardlet.save()), p
       );
     },

--- a/src/foam/u2/wizard/StepWizardletStepsView.js
+++ b/src/foam/u2/wizard/StepWizardletStepsView.js
@@ -52,7 +52,8 @@ foam.CLASS({
   requires: [
     'foam.u2.detail.AbstractSectionedDetailView',
     'foam.u2.tag.CircleIndicator',
-    'foam.u2.wizard.WizardPosition'
+    'foam.u2.wizard.WizardPosition',
+    'foam.u2.wizard.WizardletIndicator'
   ],
 
   messages: [
@@ -99,24 +100,9 @@ foam.CLASS({
                 .start().addClass(self.myClass('step-number-and-title'))
 
                   // Render circle indicator
-                  .start(this.CircleIndicator, {
-                    ...baseCircleIndicator,
-                    ...(isCurrent ? {
-                      borderColor: this.theme.black,
-                      borderColorHover: this.theme.black
-                    } : !afterCurrent && wizardlet.validate() ? {
-                      borderColor: this.theme.approval3,
-                      backgroundColor: this.theme.approval3,
-                      borderColorHover: this.theme.approval3,
-                      icon: this.theme.glyphs.checkmark.getDataUrl({
-                        fill: this.theme.white
-                      }),
-                      label: ''
-                    } : {
-                      borderColor: this.theme.grey2,
-                      borderColorHover: this.theme.grey2
-                    })
-                  })
+                  .start(this.CircleIndicator, this.configureIndicator(
+                    wizardlet, isCurrent, 1 + 2 - wSkipped
+                  ))
                     .addClass('circle')
                   .end()
 
@@ -188,6 +174,37 @@ foam.CLASS({
             : this.theme.grey2
         })
         .translate(title, title);
+    },
+    function configureIndicator(wizardlet, isCurrent, number) {
+      var args = {
+        size: 24, borderThickness: 2,
+      };
+      if ( wizardlet.indicator == this.WizardletIndicator.COMPLETED ) {
+        args = {
+          ...args,
+          borderColor: this.theme.approval3,
+          backgroundColor: this.theme.approval3,
+          borderColorHover: this.theme.approval3,
+          icon: this.theme.glyphs.checkmark.getDataUrl({
+            fill: this.theme.white
+          }),
+        };
+      } else {
+        args = {
+          ...args,
+          borderColor: this.theme.grey2,
+          borderColorHover: this.theme.grey2,
+          label: '' + number
+        };
+      }
+      if ( isCurrent ) {
+        args = {
+          ...args,
+          borderColor: this.theme.black,
+          borderColorHover: this.theme.black
+        };
+      }
+      return args;
     }
   ]
 });

--- a/src/foam/u2/wizard/StepWizardletStepsView.js
+++ b/src/foam/u2/wizard/StepWizardletStepsView.js
@@ -89,11 +89,6 @@ foam.CLASS({
               continue;
             }
 
-            let baseCircleIndicator = {
-              size: 24,
-              borderThickness: 2,
-              label: '' + (1 + w - wSkipped),
-            };
             elem = elem
               .start()
                 .addClass(self.myClass('item'))
@@ -101,7 +96,7 @@ foam.CLASS({
 
                   // Render circle indicator
                   .start(this.CircleIndicator, this.configureIndicator(
-                    wizardlet, isCurrent, 1 + 2 - wSkipped
+                    wizardlet, isCurrent, (1 + w - wSkipped)
                   ))
                     .addClass('circle')
                   .end()

--- a/src/foam/u2/wizard/WizardletIndicator.js
+++ b/src/foam/u2/wizard/WizardletIndicator.js
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.ENUM({
+  package: 'foam.u2.wizard',
+  name: 'WizardletIndicator',
+  values: [
+    {
+      name: 'PLEASE_FILL'
+    },
+    {
+      name: 'COMPLETED'
+    }
+  ]
+});


### PR DESCRIPTION
This addresses NP-3116, making the check mark on the left remain when you click back or re-open a wizard in `SHOW` skipMode. (https://nanopay.atlassian.net/browse/NP-3116)

The new functionality shows the completed state (the checkmark) based on the actual status of the capability after saving. Wizardlets are now reloaded after saving, so if for any reason the object sent back from the server is different, those updates will be reflected in the UI. This PR fixes a couple promise links to make this possible.

<img width="919" alt="Screen Shot 2020-12-18 at 1 22 35 PM" src="https://user-images.githubusercontent.com/7225168/102647678-26cce880-4134-11eb-8bd0-aef1975728a7.png">
