### PR TITLE
[NP3064]let scroll bar for the steps scroll with the current step

### DIFF
--- a/src/foam/u2/wizard/StepWizardletStepsView.js
+++ b/src/foam/u2/wizard/StepWizardletStepsView.js
@@ -168,6 +168,7 @@ foam.CLASS({
             if ( isCurrent ) afterCurrent = true;
           }
 
+          elem.onload.sub(self.setScrollPos);
           return elem;
         }))
     },
@@ -189,5 +190,24 @@ foam.CLASS({
         })
         .translate(title, title);
     }
+  ],
+
+  listeners: [
+    {
+      name: 'setScrollPos',
+      code: function() {
+        let currI = 0;
+        for ( let w = 0 ; w < this.data.wizardlets.length ; w++ ) {
+          let wizardlet = this.data.wizardlets[w];
+          if (wizardlet === this.data.currentWizardlet){
+            currI = Math.max(w - 1, 0);
+          }
+        }
+
+        var padding = this.childNodes[0].childNodes[0].el().offsetTop;
+        var scrollTop = this.childNodes[0].childNodes[currI].el().offsetTop;
+        this.parentNode.el().scrollTop = scrollTop - padding;
+      }
+    },
   ]
 });


### PR DESCRIPTION
address: https://nanopay.atlassian.net/browse/NP-3064

- Let scroll bar on the left side scroll with the current step
- When reopen a wizard, make scroll bar scroll to the current step
<img width="1437" alt="Screen Shot 2020-12-18 at 4 35 12 PM" src="https://user-images.githubusercontent.com/38148986/102664073-0c086d00-4150-11eb-9228-b4bea08968d9.png">
