### PR TITLE
DIG Exception Update

### DIFF
--- a/src/foam/core/FOAMException.js
+++ b/src/foam/core/FOAMException.js
@@ -44,7 +44,8 @@ foam.CLASS({
     },
     {
       name: 'message_',
-      class: 'String'
+      class: 'String',
+      externalTransient: true
     }
   ],
   

--- a/src/foam/core/FOAMException.js
+++ b/src/foam/core/FOAMException.js
@@ -44,8 +44,7 @@ foam.CLASS({
     },
     {
       name: 'message_',
-      class: 'String',
-      externalTransient: true
+      class: 'String'
     }
   ],
   

--- a/src/foam/nanos/dig/DigUtil.java
+++ b/src/foam/nanos/dig/DigUtil.java
@@ -55,7 +55,14 @@ public class DigUtil {
 
       JSONParser jsonParser = new JSONParser();
       jsonParser.setX(x);
-      Outputter outputterJson = new Outputter(x).setPropertyPredicate(new AndPropertyPredicate(x, new PropertyPredicate[] {new NetworkPropertyPredicate(), new PermissionedPropertyPredicate()}));
+      foam.lib.json.Outputter outputterJson = new foam.lib.json.Outputter(x)
+        .setPropertyPredicate(
+          new foam.lib.AndPropertyPredicate(x, 
+            new foam.lib.PropertyPredicate[] {
+              new foam.lib.ExternalPropertyPredicate(),
+              new foam.lib.NetworkPropertyPredicate(), 
+              new foam.lib.PermissionedPropertyPredicate()}));
+
       outputterJson.setOutputDefaultValues(true);
       outputterJson.setOutputClassNames(true);
       outputterJson.setMultiLine(true);
@@ -96,12 +103,18 @@ public class DigUtil {
 
       JSONParser jsonParser = new JSONParser();
       jsonParser.setX(x);
-      Outputter outputterJson = new Outputter(x).setPropertyPredicate(new AndPropertyPredicate(new PropertyPredicate[] {new StoragePropertyPredicate(), new PermissionedPropertyPredicate()}));
-      outputterJson.setOutputDefaultValues(true);
-      outputterJson.setOutputClassNames(true);
-      outputterJson.setMultiLine(true);
-      outputterJson.outputJSONJFObject(object);
-      out.println(outputterJson.toString());
+      foam.lib.json.Outputter outputterJsonJ = new foam.lib.json.Outputter(x)
+        .setPropertyPredicate(
+          new foam.lib.AndPropertyPredicate(x, 
+            new foam.lib.PropertyPredicate[] {
+              new foam.lib.ExternalPropertyPredicate(),
+              new foam.lib.NetworkPropertyPredicate(),
+              new foam.lib.PermissionedPropertyPredicate()}));
+      outputterJsonJ.setOutputDefaultValues(true);
+      outputterJsonJ.setOutputClassNames(true);
+      outputterJsonJ.setMultiLine(true);
+      outputterJsonJ.outputJSONJFObject(object);
+      out.println(outputterJsonJ.toString());
 
     } else {
       throw new UnsupportedOperationException(

--- a/src/foam/nanos/dig/DigUtil.java
+++ b/src/foam/nanos/dig/DigUtil.java
@@ -6,6 +6,7 @@
 
 package foam.nanos.dig;
 
+import foam.core.FOAMException;
 import foam.core.FObject;
 import foam.core.X;
 import foam.lib.*;
@@ -35,6 +36,13 @@ public class DigUtil {
 
     resp.setStatus(Integer.parseInt(error.getStatus()));
     outputFObject(x, error, format);
+  }
+
+  public static void outputFOAMException(X x, FOAMException foamException, int status, Format format) {
+    HttpServletResponse resp = x.get(HttpServletResponse.class);
+
+    resp.setStatus(status);
+    outputFObject(x, foamException, format);
   }
 
   public static void outputFObject(X x, FObject object, Format format) {

--- a/src/foam/nanos/dig/DigWebAgent.java
+++ b/src/foam/nanos/dig/DigWebAgent.java
@@ -55,7 +55,7 @@ public class DigWebAgent
           break;
       }
     } catch (DigErrorMessage dem) {
-      logger.error(e);
+      logger.error(dem);
       DigUtil.outputException(x, dem, format);
     } catch (FOAMException fe) {
       logger.error(fe);

--- a/src/foam/nanos/dig/DigWebAgent.java
+++ b/src/foam/nanos/dig/DigWebAgent.java
@@ -55,10 +55,13 @@ public class DigWebAgent
           break;
       }
     } catch (DigErrorMessage dem) {
+      logger.error(e);
       DigUtil.outputException(x, dem, format);
     } catch (FOAMException fe) {
+      logger.error(fe);
       DigUtil.outputFOAMException(x, fe, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, format);
     } catch (Throwable t) {
+      logger.error(t);
       DigUtil.outputException(x, 
           new GeneralException.Builder(x)
             .setStatus(String.valueOf(HttpServletResponse.SC_INTERNAL_SERVER_ERROR))

--- a/src/foam/nanos/dig/DigWebAgent.java
+++ b/src/foam/nanos/dig/DigWebAgent.java
@@ -54,19 +54,16 @@ public class DigWebAgent
           driver.remove(x);
           break;
       }
+    } catch (FOAMException fe) {
+      DigUtil.outputFOAMException(x, fe, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, format);
     } catch (Throwable t) {
-      PrintWriter out = x.get(PrintWriter.class);
-      out.println("Error " + t.getMessage());
-      out.println("<pre>");
-        t.printStackTrace(out);
-      out.println("</pre>");
-      logger.error(t);
-
-      try {
-        resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, t.getMessage());
-      } catch ( java.io.IOException e ) {
-        logger.error("Failed to send HttpServletResponse CODE", e);
-      }
+      DigUtil.outputException(x, 
+          new GeneralException.Builder(x)
+            .setStatus(String.valueOf(HttpServletResponse.SC_INTERNAL_SERVER_ERROR))
+            .setMessage(t.getMessage())
+            .setMoreInfo(t.getClass().getName())
+            .build(), 
+          format);
     } finally {
       pm.log(x);
     }

--- a/src/foam/nanos/dig/DigWebAgent.java
+++ b/src/foam/nanos/dig/DigWebAgent.java
@@ -17,7 +17,7 @@ import java.io.PrintWriter;
 import javax.servlet.http.HttpServletResponse;
 
 public class DigWebAgent
-  implements WebAgent
+  implements WebAgent, SendErrorHandler
 {
   public DigWebAgent() {}
 
@@ -54,6 +54,8 @@ public class DigWebAgent
           driver.remove(x);
           break;
       }
+    } catch (DigErrorMessage dem) {
+      DigUtil.outputException(x, dem, format);
     } catch (FOAMException fe) {
       DigUtil.outputFOAMException(x, fe, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, format);
     } catch (Throwable t) {
@@ -67,5 +69,18 @@ public class DigWebAgent
     } finally {
       pm.log(x);
     }
+  }
+
+  public void sendError(X x, int status, String message) {
+    DigUtil.outputException(x, 
+      new GeneralException.Builder(x)
+        .setStatus(String.valueOf(status))
+        .setMessage(message)
+        .build(), 
+      Format.JSON);
+  }
+
+  public boolean redirectToLogin(X x) {
+    return false;
   }
 }

--- a/src/foam/nanos/dig/drivers/DigFormatDriver.js
+++ b/src/foam/nanos/dig/drivers/DigFormatDriver.js
@@ -113,6 +113,9 @@ foam.CLASS({
         HttpServletResponse resp = x.get(HttpServletResponse.class);
         resp.setStatus(HttpServletResponse.SC_OK);
       }
+      catch (RuntimeException re) {
+        throw re;
+      }
       catch (java.lang.Exception e) {
         throw new RuntimeException(e);
       }

--- a/src/foam/nanos/dig/drivers/DigFormatDriver.js
+++ b/src/foam/nanos/dig/drivers/DigFormatDriver.js
@@ -79,8 +79,10 @@ foam.CLASS({
     {
       name: 'put',
       args: [ { name: 'x', type: 'X' } ],
+      javaThrows: [
+        'java.lang.Exception'
+      ],
       javaCode: `
-      try {
         DAO dao = getDAO(x);
         if ( dao == null )
           return;
@@ -112,13 +114,6 @@ foam.CLASS({
         
         HttpServletResponse resp = x.get(HttpServletResponse.class);
         resp.setStatus(HttpServletResponse.SC_OK);
-      }
-      catch (RuntimeException re) {
-        throw re;
-      }
-      catch (java.lang.Exception e) {
-        throw new RuntimeException(e);
-      }
       `
     },
     {

--- a/src/foam/nanos/dig/exception/AuthorizationException.js
+++ b/src/foam/nanos/dig/exception/AuthorizationException.js
@@ -21,6 +21,7 @@ foam.CLASS({
         cls.extras.push(`
           public AuthorizationException(String message) {
             super(message);
+            setMessage(message);
           } 
         `
         );

--- a/src/foam/nanos/dig/exception/AuthorizationException.js
+++ b/src/foam/nanos/dig/exception/AuthorizationException.js
@@ -14,6 +14,20 @@ foam.CLASS({
     permission to access.
   `,
 
+  axioms: [
+    {
+      name: 'javaExtras',
+      buildJavaClass: function(cls) {
+        cls.extras.push(`
+          public AuthorizationException(String message) {
+            super(message);
+          } 
+        `
+        );
+      }
+    }
+  ],
+
   properties: [
     {
       class: 'String',

--- a/src/foam/nanos/dig/exception/DAONotFoundException.js
+++ b/src/foam/nanos/dig/exception/DAONotFoundException.js
@@ -8,6 +8,20 @@ foam.CLASS({
   name: 'DAONotFoundException',
   extends: 'foam.nanos.dig.exception.DigErrorMessage',
 
+  axioms: [
+    {
+      name: 'javaExtras',
+      buildJavaClass: function(cls) {
+        cls.extras.push(`
+          public DAONotFoundException(String message) {
+            super(message);
+          } 
+        `
+        );
+      }
+    }
+  ],
+
   properties: [
     {
       class: 'String',

--- a/src/foam/nanos/dig/exception/DAOPutException.js
+++ b/src/foam/nanos/dig/exception/DAOPutException.js
@@ -8,6 +8,20 @@ foam.CLASS({
   name: 'DAOPutException',
   extends: 'foam.nanos.dig.exception.DigErrorMessage',
 
+  axioms: [
+    {
+      name: 'javaExtras',
+      buildJavaClass: function(cls) {
+        cls.extras.push(`
+          public DAOPutException(String message) {
+            super(message);
+          } 
+        `
+        );
+      }
+    }
+  ],
+
   properties: [
     {
       class: 'String',

--- a/src/foam/nanos/dig/exception/DAOPutException.js
+++ b/src/foam/nanos/dig/exception/DAOPutException.js
@@ -15,6 +15,7 @@ foam.CLASS({
         cls.extras.push(`
           public DAOPutException(String message) {
             super(message);
+            setMessage(message);
           } 
         `
         );

--- a/src/foam/nanos/dig/exception/DigErrorMessage.js
+++ b/src/foam/nanos/dig/exception/DigErrorMessage.js
@@ -7,6 +7,22 @@ foam.CLASS({
   package: 'foam.nanos.dig.exception',
   name: 'DigErrorMessage',
   implements: ['foam.core.Exception'],
+  extends: 'foam.core.FOAMException',
+  javaGenerateConvenienceConstructor: false,
+
+  axioms: [
+    {
+      name: 'javaExtras',
+      buildJavaClass: function(cls) {
+        cls.extras.push(`
+          public DigErrorMessage(String message) {
+            super(message);
+          } 
+        `
+        );
+      }
+    }
+  ],
 
   properties: [
     {
@@ -32,6 +48,15 @@ foam.CLASS({
     {
       class: 'String',
       name: 'moreInfo'
+    }
+  ],
+
+  methods:  [
+    {
+        name: 'getClientRethrowException',
+        type: 'RuntimeException',
+        visibility: 'public',
+        javaCode: `return this;`
     }
   ]
 });

--- a/src/foam/nanos/dig/exception/DigErrorMessage.js
+++ b/src/foam/nanos/dig/exception/DigErrorMessage.js
@@ -17,6 +17,7 @@ foam.CLASS({
         cls.extras.push(`
           public DigErrorMessage(String message) {
             super(message);
+            setMessage(message);
           } 
         `
         );

--- a/src/foam/nanos/dig/exception/DigSuccessMessage.js
+++ b/src/foam/nanos/dig/exception/DigSuccessMessage.js
@@ -8,6 +8,20 @@ foam.CLASS({
   name: 'DigSuccessMessage',
   extends: 'foam.nanos.dig.exception.DigErrorMessage',
 
+  axioms: [
+    {
+      name: 'javaExtras',
+      buildJavaClass: function(cls) {
+        cls.extras.push(`
+          public DigSuccessMessage(String message) {
+            super(message);
+          } 
+        `
+        );
+      }
+    }
+  ],
+
   properties: [
     {
       class: 'String',

--- a/src/foam/nanos/dig/exception/DigSuccessMessage.js
+++ b/src/foam/nanos/dig/exception/DigSuccessMessage.js
@@ -15,6 +15,7 @@ foam.CLASS({
         cls.extras.push(`
           public DigSuccessMessage(String message) {
             super(message);
+            setMessage(message);
           } 
         `
         );

--- a/src/foam/nanos/dig/exception/EmptyDataException.js
+++ b/src/foam/nanos/dig/exception/EmptyDataException.js
@@ -8,6 +8,20 @@ foam.CLASS({
   name: 'EmptyDataException',
   extends: 'foam.nanos.dig.exception.DigErrorMessage',
 
+  axioms: [
+    {
+      name: 'javaExtras',
+      buildJavaClass: function(cls) {
+        cls.extras.push(`
+          public EmptyDataException(String message) {
+            super(message);
+          } 
+        `
+        );
+      }
+    }
+  ],
+
   properties: [
     {
       class: 'String',

--- a/src/foam/nanos/dig/exception/EmptyDataException.js
+++ b/src/foam/nanos/dig/exception/EmptyDataException.js
@@ -15,6 +15,7 @@ foam.CLASS({
         cls.extras.push(`
           public EmptyDataException(String message) {
             super(message);
+            setMessage(message);
           } 
         `
         );

--- a/src/foam/nanos/dig/exception/EmptyParameterException.js
+++ b/src/foam/nanos/dig/exception/EmptyParameterException.js
@@ -15,6 +15,7 @@ foam.CLASS({
         cls.extras.push(`
           public EmptyParameterException(String message) {
             super(message);
+            setMessage(message);
           } 
         `
         );

--- a/src/foam/nanos/dig/exception/EmptyParameterException.js
+++ b/src/foam/nanos/dig/exception/EmptyParameterException.js
@@ -8,6 +8,20 @@ foam.CLASS({
   name: 'EmptyParameterException',
   extends: 'foam.nanos.dig.exception.DigErrorMessage',
 
+  axioms: [
+    {
+      name: 'javaExtras',
+      buildJavaClass: function(cls) {
+        cls.extras.push(`
+          public EmptyParameterException(String message) {
+            super(message);
+          } 
+        `
+        );
+      }
+    }
+  ],
+
   properties: [
     {
       class: 'String',

--- a/src/foam/nanos/dig/exception/ExternalAPIException.js
+++ b/src/foam/nanos/dig/exception/ExternalAPIException.js
@@ -5,7 +5,7 @@
 
 foam.CLASS({
   package: 'foam.nanos.dig.exception',
-  name: 'DAONotFoundException',
+  name: 'ExternalAPIException',
   extends: 'foam.nanos.dig.exception.DigErrorMessage',
 
   axioms: [
@@ -13,7 +13,7 @@ foam.CLASS({
       name: 'javaExtras',
       buildJavaClass: function(cls) {
         cls.extras.push(`
-          public DAONotFoundException(String message) {
+          public ExternalAPIException(String message) {
             super(message);
             setMessage(message);
           } 
@@ -27,17 +27,22 @@ foam.CLASS({
     {
       class: 'String',
       name: 'status',
-      value: '404'
+      value: '500'
     },
     {
       class: 'Int',
       name: 'code',
-      value: 1000
+      value: 1010
     },
     {
       class: 'String',
       name: 'type',
-      value: 'NotFound'
+      value: 'External API Failure'
+    },
+    {
+      class: 'String',
+      name: 'message',
+      value: 'External API Failure'
     }
   ]
 });

--- a/src/foam/nanos/dig/exception/GeneralException.js
+++ b/src/foam/nanos/dig/exception/GeneralException.js
@@ -8,6 +8,20 @@ foam.CLASS({
   name: 'GeneralException',
   extends: 'foam.nanos.dig.exception.DigErrorMessage',
 
+  axioms: [
+    {
+      name: 'javaExtras',
+      buildJavaClass: function(cls) {
+        cls.extras.push(`
+          public GeneralException(String message) {
+            super(message);
+          } 
+        `
+        );
+      }
+    }
+  ],
+
   properties: [
     {
       class: 'String',

--- a/src/foam/nanos/dig/exception/GeneralException.js
+++ b/src/foam/nanos/dig/exception/GeneralException.js
@@ -15,6 +15,7 @@ foam.CLASS({
         cls.extras.push(`
           public GeneralException(String message) {
             super(message);
+            setMessage(message);
           } 
         `
         );

--- a/src/foam/nanos/dig/exception/ParsingErrorException.js
+++ b/src/foam/nanos/dig/exception/ParsingErrorException.js
@@ -15,6 +15,7 @@ foam.CLASS({
         cls.extras.push(`
           public ParsingErrorException(String message) {
             super(message);
+            setMessage(message);
           } 
         `
         );

--- a/src/foam/nanos/dig/exception/ParsingErrorException.js
+++ b/src/foam/nanos/dig/exception/ParsingErrorException.js
@@ -8,6 +8,20 @@ foam.CLASS({
   name: 'ParsingErrorException',
   extends: 'foam.nanos.dig.exception.DigErrorMessage',
 
+  axioms: [
+    {
+      name: 'javaExtras',
+      buildJavaClass: function(cls) {
+        cls.extras.push(`
+          public ParsingErrorException(String message) {
+            super(message);
+          } 
+        `
+        );
+      }
+    }
+  ],
+
   properties: [
     {
       class: 'String',

--- a/src/foam/nanos/dig/exception/UnknownIdException.js
+++ b/src/foam/nanos/dig/exception/UnknownIdException.js
@@ -15,6 +15,7 @@ foam.CLASS({
         cls.extras.push(`
           public UnknownIdException(String message) {
             super(message);
+            setMessage(message);
           } 
         `
         );

--- a/src/foam/nanos/dig/exception/UnknownIdException.js
+++ b/src/foam/nanos/dig/exception/UnknownIdException.js
@@ -8,6 +8,20 @@ foam.CLASS({
   name: 'UnknownIdException',
   extends: 'foam.nanos.dig.exception.DigErrorMessage',
 
+  axioms: [
+    {
+      name: 'javaExtras',
+      buildJavaClass: function(cls) {
+        cls.extras.push(`
+          public UnknownIdException(String message) {
+            super(message);
+          } 
+        `
+        );
+      }
+    }
+  ],
+
   properties: [
     {
       class: 'String',

--- a/src/foam/nanos/dig/exception/UnsupportException.js
+++ b/src/foam/nanos/dig/exception/UnsupportException.js
@@ -8,6 +8,20 @@ foam.CLASS({
   name: 'UnsupportException',
   extends: 'foam.nanos.dig.exception.DigErrorMessage',
 
+  axioms: [
+    {
+      name: 'javaExtras',
+      buildJavaClass: function(cls) {
+        cls.extras.push(`
+          public UnsupportException(String message) {
+            super(message);
+          } 
+        `
+        );
+      }
+    }
+  ],
+
   properties: [
     {
       class: 'String',

--- a/src/foam/nanos/dig/exception/UnsupportException.js
+++ b/src/foam/nanos/dig/exception/UnsupportException.js
@@ -15,6 +15,7 @@ foam.CLASS({
         cls.extras.push(`
           public UnsupportException(String message) {
             super(message);
+            setMessage(message);
           } 
         `
         );

--- a/src/foam/nanos/http/NanoRouter.java
+++ b/src/foam/nanos/http/NanoRouter.java
@@ -156,6 +156,10 @@ public class NanoRouter
       if ( service instanceof WebAgent ) {
         WebAgent pmService = (WebAgent) service;
 
+        SendErrorHandler sendErrorHandler = null;
+        if ( service instanceof SendErrorHandler )
+          sendErrorHandler = (SendErrorHandler) service;
+
         if ( spec.getParameters() ) {
           service = new HttpParametersWebAgent((WebAgent) service);
         }
@@ -167,7 +171,7 @@ public class NanoRouter
         // NOTE: Authentication must be last as HttpParametersWebAgent will consume the authentication parameters.
         //
         if ( spec.getAuthenticate() ) {
-          service = new AuthWebAgent("service.run." + spec.getName(), (WebAgent) service);
+          service = new AuthWebAgent("service.run." + spec.getName(), (WebAgent) service, sendErrorHandler);
         }
       }
     }

--- a/src/foam/nanos/http/SendErrorHandler.js
+++ b/src/foam/nanos/http/SendErrorHandler.js
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.INTERFACE({
+  package: 'foam.nanos.http',
+  name: 'SendErrorHandler',
+
+  methods: [
+    {
+      name: 'sendError',
+      type: 'Void',
+      args: [
+        {
+          name: 'x',
+          type: 'Context'
+        },
+        {
+          name: 'status',
+          type: 'int'
+        },
+        {
+          name: 'message',
+          type: 'String'
+        }
+      ]
+    },
+    {
+      name: 'redirectToLogin',
+      type: 'Boolean',
+      args: [
+        {
+          name: 'x',
+          type: 'Context'
+        }
+      ]
+    }
+  ]
+});

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -263,6 +263,7 @@ FOAM_FILES([
   { name: 'foam/nanos/http/WebAgent' },
   { name: "foam/nanos/http/ProxyWebAgent" },
   { name: "foam/nanos/http/HttpParameters" },
+  { name: 'foam/nanos/http/SendErrorHandler' },
   { name: "foam/nanos/http/DefaultHttpParameters" },
   { name: "foam/nanos/doc/DocumentationView" },
   { name: 'foam/nanos/demo/relationship/CourseType' },

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -314,6 +314,7 @@ var classes = [
   'foam.nanos.auth.EnabledCheckAuthService',
   'foam.nanos.http.HttpParameters',
   'foam.nanos.http.DefaultHttpParameters',
+  'foam.nanos.http.SendErrorHandler',
   'foam.nanos.session.LocalSetting',
   'foam.nanos.session.LocalSettingSessionDAO',
   'foam.nanos.session.Session',
@@ -628,6 +629,7 @@ var classes = [
   'foam.support.model.SupportEmail',
   'foam.support.model.Ticket',
 
+  'foam.nanos.dig.exception.ExternalAPIException',
   'foam.nanos.dig.exception.EmptyParameterException',
   'foam.nanos.dig.exception.GeneralException',
 


### PR DESCRIPTION
Updating DIG to return errors in the expected format instead of always HTML

Here is an example of a DIG exception response:
```
{
    "class": "foam.nanos.dig.exception.ExternalAPIException",
    "status": "500",
    "code": 1010,
    "type": "External API Failure",
    "message": "Flinks failed to provide a valid response when provided with login ID: 2ff467b7-bcde-4346-8996-08d69b30c4d8",
    "developerMessage": "",
    "moreInfo": ""
}
```