### PR TITLE
Fixed Bug Not Allowing Editing Previous Choices of Previously Saved Invoice

### DIFF
--- a/src/foam/nanos/crunch/ui/CapableWAO.js
+++ b/src/foam/nanos/crunch/ui/CapableWAO.js
@@ -34,7 +34,7 @@ foam.CLASS({
         ).then(payload => {
           this.load_(wizardlet, payload);
           if ( wizardlet.isValid ) {
-            wizardlet.status = this.CapabilityJunctionStatus.PENDING;
+            wizardlet.status = this.CapabilityJunctionStatus.ACTION_REQUIRED;
           }
           return payload;
         });


### PR DESCRIPTION
This change was ported over from UCJ, is not relevant in the case of Capable because the statuses of capable payloads should not be evaluated until the complete invoice is submitted. In draft state, it should not be evaluated and thereby set to pending.

Draft state does not exist in UCJ so hence the difference.