### PR TITLE
[NP-3188] Add FlatteningWizardlet

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -635,6 +635,7 @@ FOAM_FILES([
   { name: "foam/u2/crunch/CapabilityStore", flags: ['web'] },
   { name: "foam/u2/crunch/CapabilityInterceptView", flags: ['web'] },
   { name: "foam/u2/crunch/PermissionsStringArrayView", flags: ['web'] },
+  { name: "foam/u2/crunch/FlatteningCapabilityWizardlet" },
   { name: "foam/u2/crunch/lab/CapabilityGraphNodeView", flags: ['web'] },
   { name: "foam/u2/crunch/lab/CrunchLab", flags: ['web'] },
   { name: "foam/apploader/ModelRefines" },

--- a/src/foam/nanos/crunch/ServerCrunchService.java
+++ b/src/foam/nanos/crunch/ServerCrunchService.java
@@ -19,6 +19,7 @@ import foam.nanos.auth.Subject;
 import foam.nanos.auth.User;
 import foam.nanos.crunch.lite.Capable;
 import foam.nanos.crunch.CapabilityJunctionPayload;
+import foam.nanos.crunch.ui.PrerequisiteAwareWizardlet;
 import foam.nanos.crunch.ui.WizardState;
 import foam.nanos.logger.Logger;
 import foam.nanos.pm.PM;
@@ -109,7 +110,11 @@ public class ServerCrunchService extends ContextAwareSupport implements CrunchSe
           .filter(c -> ! alreadyListed.contains(c))
           .toArray(String[]::new);
 
-      if ( cap instanceof MinMaxCapability && ! rootId.equals(sourceCapabilityId) ) {
+      var prereqAware = cap.getWizardlet() instanceof PrerequisiteAwareWizardlet || (
+        cap.getBeforeWizardlet() != null &&
+        cap.getBeforeWizardlet() instanceof PrerequisiteAwareWizardlet
+      );
+      if ( prereqAware && ! rootId.equals(sourceCapabilityId) ) {
         List minMaxArray = new ArrayList<>();
 
         // Manually grab the direct  prereqs to the  MinMaxCapability

--- a/src/foam/u2/crunch/FlatteningCapabilityWizardlet.js
+++ b/src/foam/u2/crunch/FlatteningCapabilityWizardlet.js
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.u2.crunch',
+  name: 'FlatteningCapabilityWizardlet',
+  extends: 'foam.nanos.crunch.ui.CapabilityWizardlet',
+  implements: [ 'foam.nanos.crunch.ui.PrerequisiteAwareWizardlet' ],
+  documentation: `
+    Displays prerequisite capabilities in the same wizardlet.
+  `,
+
+  properties: [
+    {
+      name: 'before',
+      class: 'Boolean'
+    },
+    {
+      name: 'delegates',
+      class: 'FObjectArray',
+      of: 'foam.nanos.crunch.ui.CapabilityWizardlet'
+    },
+    {
+      name: 'sections',
+      flags: ['web'],
+      transient: true,
+      class: 'FObjectArray',
+      of: 'foam.u2.wizard.WizardletSection',
+      factory: function () {
+        var sections = foam.u2.detail.AbstractSectionedDetailView.create({
+          of: this.of,
+        }, this).sections.map(section => this.WizardletSection.create({
+          section: section,
+          data$: this.data$,
+          isAvailable$: section.createIsAvailableFor(
+            this.data$,
+          )
+        }));
+
+        var prereqSections = this.delegates.reduce((sections, delegate) => {
+          return sections.concat(delegate.sections);
+        }, []);
+        return this.before ? sections.concat(prereqSections)
+          : prereqSections.concat(sections);
+      }
+    },
+  ],
+
+  methods: [
+    function addPrerequisite(wizardlet) {
+      // Add prerequisite to delegate wizardlets
+      this.delegates.push(wizardlet);
+
+      // Return true to prevent wizardlet from being pushed normally
+      return true;
+    }
+  ]
+});

--- a/src/foam/u2/crunch/wizardflow/CreateWizardletsAgent.js
+++ b/src/foam/u2/crunch/wizardflow/CreateWizardletsAgent.js
@@ -52,6 +52,7 @@ foam.CLASS({
 
       var addPrerequisite = (wizardlet) => {
         var defaultPrerequisiteHandling = true;
+        var preventPush = false;
 
         if ( this.isPrerequisiteAware(rootWizardlet) ) {
           rootWizardlet.addPrerequisite(wizardlet);
@@ -59,24 +60,27 @@ foam.CLASS({
         }
 
         if ( beforeWizardlet && this.isPrerequisiteAware(beforeWizardlet) ) {
-          beforeWizardlet.addPrerequisite(wizardlet);
+          preventPush = beforeWizardlet.addPrerequisite(wizardlet);
           defaultPrerequisiteHandling = false;
         }
 
         if ( defaultPrerequisiteHandling )
           wizardlet.isAvailable$.follow(rootWizardlet.isAvailable$);
+
+        return preventPush;
       }
 
       for ( let capability of capabilityPrereqs ) {
         if ( Array.isArray(capability) ) {
           let subWizardlets = await this.parseArrayToWizardlets(capability);
-          addPrerequisite(subWizardlets[subWizardlets.length - 1]);
-          wizardlets.push(...subWizardlets);
+          let preventPush =
+            addPrerequisite(subWizardlets[subWizardlets.length - 1]);
+          if ( ! preventPush ) wizardlets.push(...subWizardlets);
           continue;
         }
         let wizardlet = this.getWizardlet(capability);
-        addPrerequisite(wizardlet);
-        wizardlets.push(wizardlet);
+        let preventPush = addPrerequisite(wizardlet);
+        if ( ! preventPush ) wizardlets.push(wizardlet);
       }
 
       if ( beforeWizardlet ) wizardlets.unshift(beforeWizardlet);

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -728,6 +728,9 @@ var classes = [
   'foam.nanos.crunch.CrunchService',
   'foam.nanos.crunch.ReputDependentUCJs',
 
+  //u2 additions
+  'foam.u2.crunch.FlatteningCapabilityWizardlet',
+
   // spid
   'foam.nanos.auth.CreateUserCapabilityJunctionOnSpidSet',
   'foam.nanos.auth.SetUserServiceProviderJunctionRuleAction',


### PR DESCRIPTION
The `FlatteningWizardlet` "flattens" prerequisites of a capability into a single wizardlet. It's worth noting that there were a few previous design decisions that made this relatively easy:

- PrerequisiteAwareWizardlet interface made it easy to inform the backend that prerequisites need to be grouped
- The interface also made it easy to specify when capabilities shouldn't be added to the main wizard
- Abstraction of wizardlet sections made it easy to return a concatenation of sections