### PR TITLE
fix enum wrong default value

### DIFF
--- a/src/foam/core/Enum.js
+++ b/src/foam/core/Enum.js
@@ -384,7 +384,7 @@ foam.CLASS({
         return n
       },
       expression: function(type) {
-        return type && foam.lookup(type).VALUES[0];
+        return type && ( foam.lookup(type).forOrdinal(0) || foam.lookup(type).VALUES[0] );
       }
     },
     {


### PR DESCRIPTION
assuming we always want to return ordinal 0 for default value of enum properties unless otherwise specified, then
this should return forordinal(0) instead of values[0] since the values are not necessarily installed in the correct order

fixes issue encountered where values[0] for paymentstatus is ordinal 6 when i built locally without setting default value explicitly but is ordinal 0 on ci's build, similar issue also happens for invoicestatus