### PR TITLE
fix first historyRecord miss in medusa

### DIFF
--- a/src/foam/dao/history/HistoryDAO.js
+++ b/src/foam/dao/history/HistoryDAO.js
@@ -135,7 +135,7 @@ foam.CLASS({
       FObject current = this.find_(x, obj);
       Object objectId = obj.getProperty("id");
 
-      if ( current == nul ) {
+      if ( current == null ) {
         // do "put" first if it is "create" action.
         FObject persistObject = super.put_(x, obj);
         objectId = persistObject.getProperty("id");

--- a/src/foam/dao/history/HistoryDAO.js
+++ b/src/foam/dao/history/HistoryDAO.js
@@ -134,10 +134,8 @@ foam.CLASS({
       User agent = subject.getRealUser();
       FObject current = this.find_(x, obj);
       Object objectId = obj.getProperty("id");
-      boolean isCreate = objectId == null || 
-                          current == null ||
-                          SafetyUtil.isEmpty(String.valueOf(objectId)) ||
-                          new Long(0L).equals(objectId);
+      boolean isCreate = current == null;
+
       if ( isCreate ) {
         // do "put" first if it is "create" action.
         FObject persistObject = super.put_(x, obj);

--- a/src/foam/dao/history/HistoryDAO.js
+++ b/src/foam/dao/history/HistoryDAO.js
@@ -133,7 +133,7 @@ foam.CLASS({
       User user = subject.getUser();
       User agent = subject.getRealUser();
       FObject current = this.find_(x, obj);
-      Object objectId = ((PropertyInfo) obj.getClassInfo().getAxiomByName("id")).f(obj);
+      Object objectId = obj.getProperty("id");
       boolean isCreate = objectId == null || 
                           current == null ||
                           SafetyUtil.isEmpty(String.valueOf(objectId)) ||
@@ -141,7 +141,7 @@ foam.CLASS({
       if ( isCreate ) {
         // do "put" first if it is "create" action.
         FObject persistObject = super.put_(x, obj);
-        objectId = ((PropertyInfo) persistObject.getClassInfo().getAxiomByName("id")).f(obj);
+        objectId = persistObject.getProperty("id");
         HistoryRecord historyRecord = new HistoryRecord();
         historyRecord.setObjectId(objectId);
         historyRecord.setUser(formatUserName(user));

--- a/src/foam/dao/history/HistoryDAO.js
+++ b/src/foam/dao/history/HistoryDAO.js
@@ -134,9 +134,8 @@ foam.CLASS({
       User agent = subject.getRealUser();
       FObject current = this.find_(x, obj);
       Object objectId = obj.getProperty("id");
-      boolean isCreate = current == null;
 
-      if ( isCreate ) {
+      if ( current == nul ) {
         // do "put" first if it is "create" action.
         FObject persistObject = super.put_(x, obj);
         objectId = persistObject.getProperty("id");


### PR DESCRIPTION
link ticket: https://nanopay.atlassian.net/browse/NP-2883
when  obj.getProperty(“id”) is null or 0 then it’s a create operation.
perform the delegate put, then pass the original obj and result from delegate to historyDAO