### PR TITLE
NP-3217 ServiceProviderAwareDAO broken

### DIFF
--- a/src/foam/box/SessionServerBox.java
+++ b/src/foam/box/SessionServerBox.java
@@ -125,9 +125,7 @@ public class SessionServerBox
           // Allow admin to login in locally during startup
           if ( session.getUserId() > 0 ) {
             User user = (User) ((DAO) getX().get("localUserDAO")).find_(getX(), session.getUserId());
-            if ( user != null &&
-                 ( user.getGroup() == "system" ||
-                   user.getGroup() == "admin" ) ) {
+            if ( user.isAdmin() ) {
               session.setClusterable(false);
               session = (Session) sessionDAO.put(session);
             }

--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -263,11 +263,7 @@ foam.CLASS({
         }
 
         if ( getServiceProviderAware() ) {
-          foam.nanos.auth.ServiceProviderAwareDAO dao = new foam.nanos.auth.ServiceProviderAwareDAO.Builder(getX()).setDelegate(delegate).build();
-          if ( getServiceProviderAwarePropertyInfos() != null ) {
-            dao.setPropertyInfos(getServiceProviderAwarePropertyInfos());
-          }
-          delegate = dao;
+          delegate = new foam.nanos.auth.ServiceProviderAwareDAO.Builder(getX()).setDelegate(delegate).build();
         }
 
         if ( getLifecycleAware() ) {

--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -262,10 +262,6 @@ foam.CLASS({
             delegate = new foam.dao.ValidatingDAO(getX(), delegate, foam.core.ValidatableValidator.instance());
         }
 
-        if ( getServiceProviderAware() ) {
-          delegate = new foam.nanos.auth.ServiceProviderAwareDAO.Builder(getX()).setDelegate(delegate).build();
-        }
-
         if ( getLifecycleAware() ) {
           delegate = new foam.nanos.auth.LifecycleAwareDAO.Builder(getX())
             .setDelegate(delegate)
@@ -275,6 +271,12 @@ foam.CLASS({
 
         if ( getDeletedAware() ) {
           System.out.println("DEPRECATED: Will be completely removed after services journal migration script. No functionality as of now.");
+        }
+
+        if ( getServiceProviderAware() ) {
+          delegate = new foam.nanos.auth.ServiceProviderAwareDAO.Builder(getX())
+            .setDelegate(delegate)
+            .build();
         }
 
         if ( getRuler() ) {

--- a/src/foam/nanos/auth/ServiceProviderAwareDAO.js
+++ b/src/foam/nanos/auth/ServiceProviderAwareDAO.js
@@ -10,147 +10,173 @@ foam.CLASS({
   extends: 'foam.dao.ProxyDAO',
 
   documentation: `A DAO decorator which:
-- filters find and select by the 'owning' ServiceProvider ID (spid),
 - enforces spid permissions on update and create,
-- restricts or filters by spid on remove.
-The DAO can act on models which explicitly implement ServiceProviderAware,
-or where a Reference/Relationship model implements ServiceProviderAware.
-Where the ServiceProviderAware is found through a Reference or Relationship,
-the DAO uses a Map of class and PropertyInfos to traverse the Reference,
-Relationship hierarchy.`,
+- filters find, remove, and select by spids the caller has read permission on.
+`,
 
   javaImports: [
     'foam.core.FObject',
     'foam.core.PropertyInfo',
     'foam.core.X',
     'foam.dao.DAO',
-    'foam.dao.ProxyDAO',
-    'foam.dao.ProxySink',
-    'foam.dao.Sink',
+    'foam.dao.ArraySink',
     'foam.mlang.MLang',
     'foam.mlang.predicate.Predicate',
     'foam.nanos.app.AppConfig',
-    'foam.util.SafetyUtil'
+    'foam.nanos.logger.Logger',
+    'foam.nanos.theme.Theme',
+    'foam.nanos.theme.Themes',
+    'foam.util.SafetyUtil',
+    'java.util.ArrayList',
+    'java.util.Arrays',
+    'java.util.List',
+    'java.util.stream.Collectors',
   ],
 
   properties: [
     {
-      documentation: `A Map propertyInfo[] key on class name.  For some class,
-the propertyInfos are the Reference or Relationship property from which to find
-the next step in the hierachy on route the instance which implements
-ServiceProviderAware`,
-      name: 'propertyInfos',
-      class: 'Map'
-    }
+      name: 'propertyInfo',
+      class: 'Object',
+      of: 'foam.core.PropertyInfo',
+      javaFactory: `
+      return (PropertyInfo) getOf().getAxiomByName("spid");
+      `
+    },
   ],
 
   methods: [
     {
+      name: 'getPredicate',
+      args: [
+        {
+          name: 'x',
+          type: 'Context'
+        }
+      ],
+      type: 'foam.mlang.predicate.Predicate',
+      javaCode: `
+      Logger logger = (Logger) x.get("logger");
+      AuthService auth = (AuthService) x.get("auth");
+      ArrayList<ServiceProvider> serviceProviders = (ArrayList) ((ArraySink) ((DAO) getX().get("localServiceProviderDAO")).select(new ArraySink())).getArray();
+logger.info(this.getClass().getSimpleName(), "serviceproviders found", serviceProviders.size());
+      List<String> ids = serviceProviders.stream()
+                            .map(ServiceProvider::getId)
+                            .filter(id -> auth.check(x, "serviceprovider.read."+id))
+                            .collect(Collectors.toList());
+      String spid = (String) x.get("spid");
+      Subject subject = (Subject) x.get("subject");
+      if ( subject != null ) {
+        User user = subject.getUser();
+        if ( user != null &&
+             ! SafetyUtil.isEmpty(user.getSpid()) ) {
+          spid = user.getSpid();
+        }
+      }
+logger.info(this.getClass().getSimpleName(), "serviceproviders read", ids.size(), getPropertyInfo(), spid);
+      if ( ids.size() == 1 ) {
+        return MLang.EQ(getPropertyInfo(), ids.get(0));
+      } else if ( ids.size() > 1 ) {
+        return MLang.IN(getPropertyInfo(), ids.toArray(new String[0]));
+      }
+      logger.error(this.getClass().getSimpleName(), "Permission denied");
+      throw new AuthorizationException();
+      `
+    },
+    {
+      name: 'getSpid',
+      args: [
+        {
+          name: 'x',
+          type: 'Context'
+        }
+      ],
+      type: 'String',
+      javaCode: `
+      Subject subject = (Subject) x.get("subject");
+      if ( subject != null ) {
+        User user = subject.getUser();
+        if ( user != null &&
+             ! SafetyUtil.isEmpty(user.getSpid()) ) {
+          return user.getSpid();
+        }
+      }
+      String spid = (String) x.get("spid");
+      if ( ! SafetyUtil.isEmpty(spid) ) {
+       return spid;
+      }
+      Theme theme = ((Themes) x.get("themes")).findTheme(x);
+      if ( theme != null &&
+           ! SafetyUtil.isEmpty(theme.getSpid()) ) {
+        return theme.getSpid();
+      }
+      return ((AppConfig) x.get("appConfig")).getDefaultSpid();
+      `
+    },
+    {
       name: 'put_',
       javaThrows: ['AuthorizationException'],
       javaCode: `
-    if ( ! ( obj instanceof ServiceProviderAware ) ) {
-      return super.put_(x, obj);
-    }
-
-    Object id = obj.getProperty("id");
-    FObject oldObj = getDelegate().inX(x).find(id);
-    boolean isCreate = id == null || oldObj == null;
-
-    ServiceProviderAware sp = (ServiceProviderAware) obj;
-    ServiceProviderAware oldSp = (ServiceProviderAware) oldObj;
-    AuthService auth = (AuthService) x.get("auth");
-
-    if ( isCreate ) {
-      if ( SafetyUtil.isEmpty(sp.getSpid()) ||
-           ( ! SafetyUtil.isEmpty(sp.getSpid()) &&
-             ! auth.check(x, "serviceprovider.create." + sp.getSpid()) ) ) {
-        User user = ((Subject) x.get("subject")).getUser();
-        if ( user != null &&
-             ! SafetyUtil.isEmpty(user.getSpid()) ) {
-          sp.setSpid(user.getSpid());
-        } else {
-          sp.setSpid(((AppConfig) x.get("appConfig")).getDefaultSpid());
-        }
+      if ( ! ( obj instanceof ServiceProviderAware ) ) {
+        return super.put_(x, obj);
       }
-    } else if ( ! sp.getSpid().equals(oldSp.getSpid()) &&
-                ! (auth.check(x, "serviceprovider.update." + oldSp.getSpid()) &&
-                   auth.check(x, "serviceprovider.update." + sp.getSpid())) ) {
-      throw new AuthorizationException("You do not have permission to update ServiceProvider (spid) property.");
-    } else if ( sp.getSpid().equals(oldSp.getSpid()) &&
-                ! auth.check(x, "serviceprovider.read." + sp.getSpid()) ) {
-      throw new AuthorizationException("You do not have permission to update data on other ServiceProvider.");
-    }
 
-    return super.put_(x, obj);
+      Object id = obj.getProperty("id");
+      FObject oldObj = getDelegate().inX(x).find(id);
+      boolean isCreate = id == null || oldObj == null;
+
+      ServiceProviderAware sp = (ServiceProviderAware) obj;
+      ServiceProviderAware oldSp = (ServiceProviderAware) oldObj;
+      AuthService auth = (AuthService) x.get("auth");
+
+      if ( isCreate ) {
+        sp.setSpid(getSpid(x));
+      } else if ( ! sp.getSpid().equals(oldSp.getSpid()) &&
+                  ! (auth.check(x, "serviceprovider.update." + oldSp.getSpid()) &&
+                     auth.check(x, "serviceprovider.update." + sp.getSpid())) ) {
+        throw new AuthorizationException("You do not have permission to update ServiceProvider (spid) property.");
+      } else if ( sp.getSpid().equals(oldSp.getSpid()) &&
+                  ! auth.check(x, "serviceprovider.read." + sp.getSpid()) ) {
+        throw new AuthorizationException();
+      }
+
+      return super.put_(x, obj);
       `
     },
     {
       name: 'find_',
       javaCode: `
-    FObject result = getDelegate().find_(x, id);
-    if ( result == null ||
-         ((AuthService) x.get("auth")).check(x, "*") ) {
-      return result;
-    }
-
-    if ( new ServiceProviderAwareSupport().match(x, getPropertyInfos(), result) ) {
-      return result;
-    }
-
-    return null;
+      if ( ((AuthService) x.get("auth")).check(x, "serviceprovider.read."+ServiceProviderAware.GLOBAL_SPID) ) {
+        return getDelegate().find_(x, id);
+      }
+      return getDelegate().where(getPredicate(x)).find_(x, id);
+      `
+    },
+    {
+      name: 'remove_',
+      javaCode: `
+      if ( ((AuthService) x.get("auth")).check(x, "serviceprovider.delete."+ServiceProviderAware.GLOBAL_SPID) ||
+           ((AuthService) x.get("auth")).check(x, "serviceprovider.delete."+((ServiceProviderAware) obj).getSpid()) ) {
+        return getDelegate().remove_(x, obj);
+      }
+      throw new AuthorizationException();
       `
     },
     {
       name: 'select_',
       javaCode: `
-    if ( ((AuthService) x.get("auth")).check(x, "*") ) {
-      return super.select_(x, sink, skip, limit, order, predicate);
-    }
-
-    Predicate spidPredicate = predicate;
-
-    String spid = (String) x.get("spid");
-    if ( spid != null ) { // spid may be null during account creation.
-      if ( ServiceProviderAware.class.isAssignableFrom(getOf().getObjClass()) ) {
-
-        PropertyInfo spidProperty = ((PropertyInfo) getOf().getAxiomByName("spid"));
-        spidPredicate = MLang.OR(
-          MLang.EQ(spidProperty, spid),
-          new ServiceProviderAwarePredicate(x, null, getPropertyInfos())
-        );
-
-        if ( predicate != null ) {
-          spidPredicate = MLang.AND(
-            spidPredicate,
-            predicate
-          );
-        }
-      } else if ( getPropertyInfos() != null &&
-                  getPropertyInfos().size() > 0 ) {
-        spidPredicate = new ServiceProviderAwarePredicate(x, predicate, getPropertyInfos());
+      if ( ((AuthService) x.get("auth")).check(x, "serviceprovider.read."+ServiceProviderAware.GLOBAL_SPID) ) {
+        return super.select_(x, sink, skip, limit, order, predicate);
       }
-    }
 
-    return getDelegate().select_(
-      x,
-      sink,
-      skip,
-      limit,
-      order,
-      spidPredicate
-    );
-     `
-    },
-    {
-      name: 'cmd_',
-      documentation: 'Process ServiceProviderAwareSupport action which performs spid matching on "OBJ" in the context.',
-      javaCode: `
-        if ( obj instanceof ServiceProviderAwareSupport ) {
-          return ((ServiceProviderAwareSupport) obj).match(x, getPropertyInfos(), x.get("OBJ"));
-        }
+      Predicate spidPredicate = getPredicate(x);
+      if ( predicate != null ) {
+        spidPredicate = MLang.AND(
+          spidPredicate,
+          predicate
+        );
+      }
 
-        return getDelegate().cmd_(x, obj);
+      return getDelegate().select_(x, sink, skip, limit, order, spidPredicate);
       `
     }
   ]

--- a/src/foam/nanos/auth/SystemAuthService.js
+++ b/src/foam/nanos/auth/SystemAuthService.js
@@ -13,7 +13,7 @@ foam.CLASS({
       name: 'check',
       javaCode: `
         foam.nanos.auth.User user = ((foam.nanos.auth.Subject) x.get("subject")).getUser();
-        return user != null && ( user.getId() == foam.nanos.auth.User.SYSTEM_USER_ID || user.getGroup().equals("admin") || user.getGroup().equals("system") ) || getDelegate().check(x, permission);
+        return user != null && user.isAdmin() || getDelegate().check(x, permission);
       `
     }
   ]

--- a/src/foam/nanos/auth/User.js
+++ b/src/foam/nanos/auth/User.js
@@ -647,8 +647,7 @@ foam.CLASS({
 
         // Prevent privilege escalation by only allowing a user's group to be
         // set to one that the user doing the put has permission to update.
-        boolean hasGroupUpdatePermission = auth.check(x, "group.update." + this.getGroup());
-        if ( ! hasGroupUpdatePermission ) {
+        if ( ! auth.check(x, "group.update." + this.getGroup()) ) {
           throw new AuthorizationException("You do not have permission to set that user's group to '" + this.getGroup() + "'.");
         }
       `

--- a/src/foam/nanos/auth/test/PreventPrivilegeEscalationTest.java
+++ b/src/foam/nanos/auth/test/PreventPrivilegeEscalationTest.java
@@ -28,6 +28,7 @@ public class PreventPrivilegeEscalationTest
   User testUser = null;
   Logger logger_;
   String TEST_MESSAGE = "";
+  String spid_;
 
   @Override
   public void runTest(X x) {
@@ -40,6 +41,9 @@ public class PreventPrivilegeEscalationTest
     testGroup = null;
     testUser = null;
     logger_ = new foam.nanos.logger.PrefixLogger(new Object[] {"PreventPriviledgeEscalation"}, (Logger) x.get("logger"));
+    spid_ = generateId();
+
+    ((DAO) x.get("localServiceProviderDAO")).put(new ServiceProvider.Builder(x).setId(spid_).build());
 
     // Run the tests.
     try {
@@ -60,12 +64,12 @@ public class PreventPrivilegeEscalationTest
     } catch (Throwable e) {
       logger_.error(e);
       e.printStackTrace();
-      test(false, "An unexpected exception was thrown. Some tests might not have been executed.");
+      test(false, "An unexpected exception was thrown. Some tests might not have been executed. "+e.getMessage());
     }
   }
 
   String generateId() {
-    return java.util.UUID.randomUUID().toString();
+    return java.util.UUID.randomUUID().toString().split("-")[0];
   }
 
   // Generate a test user and a group with the given permissions for them to be in.
@@ -80,6 +84,8 @@ public class PreventPrivilegeEscalationTest
     groupDAO.put(testGroup);
 
     groupPermissionJunctionDAO.where(foam.mlang.MLang.EQ(GroupPermissionJunction.SOURCE_ID, groupId)).removeAll();
+
+    permissionIds.add("serviceprovider.read."+spid_);
 
     for ( String id : permissionIds ) {
       localPermissionDAO.where(foam.mlang.MLang.EQ(Permission.ID, id)).removeAll();
@@ -97,7 +103,7 @@ public class PreventPrivilegeEscalationTest
       .setId(999999999L)
       .setEmail("ppet@example.com")
       .setGroup(groupId)
-      .setSpid("spid")
+      .setSpid(spid_)
       .setLifecycleState(foam.nanos.auth.LifecycleState.ACTIVE)
       .build();
     testUser = (User) bareUserDAO.put(testUser);
@@ -274,7 +280,7 @@ public class PreventPrivilegeEscalationTest
     // Create a user for the test user to put.
     User u = new User.Builder(x)
       .setGroup("admin")
-      .setSpid("spid")
+      .setSpid(spid_)
       .setEmail("ppet+admin@example.com")
       .setDesiredPassword("!@#$ppet1234")
       .build();
@@ -315,7 +321,7 @@ public class PreventPrivilegeEscalationTest
     // Create a user for the test user to put.
     User u = new User.Builder(x)
       .setGroup("basicUser")
-      .setSpid("spid")
+      .setSpid(spid_)
       .setEmail("ppet1+admin@example.com")
       .setFirstName("ppet")
       .setLastName("ppet")

--- a/src/foam/nanos/auth/test/ServiceProviderAwareTest.js
+++ b/src/foam/nanos/auth/test/ServiceProviderAwareTest.js
@@ -38,25 +38,39 @@ foam.CLASS({
     'javax.security.auth.AuthPermission'
   ],
 
+  properties: [
+    {
+      name: 'spid1',
+      class: 'String',
+      javaFactory: 'return java.util.UUID.randomUUID().toString().toLowerCase().split("-")[0];'
+    },
+    {
+      name: 'spid2',
+      class: 'String',
+      javaFactory: 'return java.util.UUID.randomUUID().toString().toLowerCase().split("-")[0];'
+    }
+  ],
+  
   methods: [
     {
       name: 'runTest',
       javaCode: `
         AuthService auth = (AuthService) x.get("auth");
-        ((DAO) x.get("localServiceProviderDAO")).put(new ServiceProvider.Builder(x).setId("spid").build());
-        ((DAO) x.get("localServiceProviderDAO")).put(new ServiceProvider.Builder(x).setId("other").build());
+System.out.println("UUID: "+getSpid1());
+        ((DAO) x.get("localServiceProviderDAO")).put(new ServiceProvider.Builder(x).setId(getSpid1()).build());
+        ((DAO) x.get("localServiceProviderDAO")).put(new ServiceProvider.Builder(x).setId(getSpid2()).build());
         ((DAO) x.get("localGroupDAO")).put(new Group.Builder(x).setId("test").build());
         ((DAO) x.get("localGroupDAO")).put(new Group.Builder(x).setId("test2").build());
-        ((DAO) x.get("localGroupDAO")).put(new Group.Builder(x).setId("other").build());
+        ((DAO) x.get("localGroupDAO")).put(new Group.Builder(x).setId(getSpid2()).build());
         ((DAO) x.get("localGroupDAO")).put(new Group.Builder(x).setId("fail").build());
 
         DAO groupPermissionJunctionDAO = (DAO) x.get("localGroupPermissionJunctionDAO");
         groupPermissionJunctionDAO.where(EQ(GroupPermissionJunction.SOURCE_ID, "test")).removeAll();
-        groupPermissionJunctionDAO.put(new GroupPermissionJunction.Builder(x).setSourceId("test").setTargetId("serviceprovider.read.spid").build());
-        groupPermissionJunctionDAO.put(new GroupPermissionJunction.Builder(x).setSourceId("test2").setTargetId("serviceprovider.read.spid").build());
+        groupPermissionJunctionDAO.put(new GroupPermissionJunction.Builder(x).setSourceId("test").setTargetId("serviceprovider.read."+getSpid1()).build());
+        groupPermissionJunctionDAO.put(new GroupPermissionJunction.Builder(x).setSourceId("test2").setTargetId("serviceprovider.read."+getSpid1()).build());
 
         foam.nanos.app.AppConfig appConfig = (foam.nanos.app.AppConfig) ((FObject) x.get("appConfig")).fclone();
-        appConfig.setDefaultSpid("spid");
+        appConfig.setDefaultSpid(getSpid1());
         X y = x.put("appConfig", appConfig);
 
         testReference(y);
@@ -82,30 +96,27 @@ foam.CLASS({
         X y = x.put("userDAO", userDAO);
         y = y.put("localUserDAO", userDAO);
 
-        DAO delegate = new MDAO(DummySp.getOwnClassInfo());
         DAO dao =
-          new foam.dao.SequenceNumberDAO.Builder(y)
-          .setDelegate(
           new foam.nanos.auth.AuthorizationDAO.Builder(y)
           .setAuthorizer(new foam.nanos.auth.StandardAuthorizer(DummySp.class.getSimpleName().toLowerCase()))
-          .setDelegate(
-            new ServiceProviderAwareDAO.Builder(y)
-              .setDelegate(delegate)
+          .setDelegate(new ServiceProviderAwareDAO.Builder(y)
+            .setDelegate(new foam.dao.SequenceNumberDAO.Builder(y)
+              .setDelegate(new MDAO(DummySp.getOwnClassInfo()))
               .build())
-          .build())
-        .build();
+            .build())
+          .build();
         y = y.put("dummySpDAO", dao);
         y = y.put("localDummySpDAO", dao);
 
        User ctxUser = new User.Builder(y)
           .setId(99995)
           .setEmail("test@example.com")
-          .setSpid("spid")
+          .setSpid(getSpid1())
           .setGroup("admin")
           .setLifecycleState(LifecycleState.ACTIVE)
           .build();
         ctxUser = (User) userDAODelegate.put(ctxUser);
-        test(ctxUser.getSpid().equals("spid"), "admin.spid = "+ctxUser.getSpid());
+        test(ctxUser.getSpid().equals(getSpid1()), "admin.spid = "+ctxUser.getSpid());
         y = Auth.sudo(y, ctxUser);
         userDAO = userDAO.inX(y);
         dao = dao.inX(y);
@@ -119,7 +130,7 @@ foam.CLASS({
           .setLifecycleState(LifecycleState.ACTIVE)
           .build();
         user1 = (User) userDAO.put_(y, user1);
-        test(user1.getSpid().equals("spid"), "user1.spid = "+user1.getSpid());
+        test(user1.getSpid().equals(getSpid1()), "user1.spid = "+user1.getSpid());
 
         User user2 = new User.Builder(y)
           .setId(89995)
@@ -130,7 +141,7 @@ foam.CLASS({
           .setLifecycleState(LifecycleState.ACTIVE)
           .build();
         user2 = (User) userDAO.put_(y, user2);
-        test(user2.getSpid().equals("spid"), "user2.spid = "+user2.getSpid());
+        test(user2.getSpid().equals(getSpid1()), "user2.spid = "+user2.getSpid());
 
         User user3 = new User.Builder(y)
           .setId(89994)
@@ -141,19 +152,19 @@ foam.CLASS({
           .setLifecycleState(LifecycleState.ACTIVE)
           .build();
         user3 = (User) userDAO.put_(y, user3);
-        test(user3.getSpid().equals("spid"), "user3.spid = "+user3.getSpid());
+        test(user3.getSpid().equals(getSpid1()), "user3.spid = "+user3.getSpid());
 
         User user4 = new User.Builder(y)
         .setId(89993)
         .setFirstName("user_four")
         .setLastName("lastname")
         .setEmail("user4@example.com")
-        .setGroup("other")
+        .setGroup(getSpid2())
         .setLifecycleState(LifecycleState.ACTIVE)
-        .setSpid("other")
+        .setSpid(getSpid2())
         .build();
         user4 = (User) userDAO.put_(y, user4);
-        test(user4.getSpid().equals("other"), "user4.spid = "+user4.getSpid());
+        test(user4.getSpid().equals(getSpid2()), "user4.spid = "+user4.getSpid());
 
         DummySp ns1 = new DummySp.Builder(y).setOwner(user1.getId()).build();
         ns1 = (DummySp) dao.put(ns1).fclone();
@@ -173,7 +184,7 @@ foam.CLASS({
 
         ArraySink sink = new ArraySink();
         dao.select(sink);
-        List nss = sink.getArray();
+        List<DummySp> nss = sink.getArray();
         test (nss.size() == 1, "ReferenceTest DAO select. expected: 1, found: "+nss.size());
 
         ns = (DummySp) dao.find(ns2.getId());
@@ -218,12 +229,14 @@ foam.CLASS({
 
         // change spid
         groupPermissionJunctionDAO.put(new GroupPermissionJunction.Builder(y).setSourceId("test").setTargetId("dummysp.update." + ns3.getId()).build());
-        groupPermissionJunctionDAO.put(new GroupPermissionJunction.Builder(y).setSourceId("test").setTargetId("serviceprovider.update.spid").build());
-        groupPermissionJunctionDAO.put(new GroupPermissionJunction.Builder(y).setSourceId("test").setTargetId("serviceprovider.update.other").build());
+        groupPermissionJunctionDAO.put(new GroupPermissionJunction.Builder(y).setSourceId("test").setTargetId("serviceprovider.update."+getSpid1()).build());
+        groupPermissionJunctionDAO.put(new GroupPermissionJunction.Builder(y).setSourceId("test").setTargetId("serviceprovider.update."+getSpid2()).build());
+        test(ns3.getSpid().equals(getSpid1()), "before ns3.spid = "+ns3.getSpid());
         ns3 = (DummySp) ns3.fclone();
-        ns3.setSpid("other"); 
-        dao.put(ns3);
-
+        ns3.setSpid(getSpid2()); 
+        ns3 = (DummySp) dao.put(ns3);
+        test(ns3.getSpid().equals(getSpid2()), "after ns3.spid = "+ns3.getSpid());
+      
         y = Auth.sudo(y, user1);
         dao = dao.inX(y);
 
@@ -259,12 +272,16 @@ foam.CLASS({
         }
 
         // test that it is found by a user on the new spid 
-        groupPermissionJunctionDAO.put(new GroupPermissionJunction.Builder(x).setSourceId("other").setTargetId("serviceprovider.read.other").build());
-        groupPermissionJunctionDAO.put(new GroupPermissionJunction.Builder(x).setSourceId("other").setTargetId("service.DummySpDAO").build());
-        groupPermissionJunctionDAO.put(new GroupPermissionJunction.Builder(x).setSourceId("other").setTargetId("dummysp.read.*").build());
+        groupPermissionJunctionDAO.put(new GroupPermissionJunction.Builder(x).setSourceId(getSpid2()).setTargetId("serviceprovider.read."+getSpid2()).build());
+        groupPermissionJunctionDAO.put(new GroupPermissionJunction.Builder(x).setSourceId(getSpid2()).setTargetId("service.DummySpDAO").build());
+        groupPermissionJunctionDAO.put(new GroupPermissionJunction.Builder(x).setSourceId(getSpid2()).setTargetId("dummysp.read.*").build());
         sink = new ArraySink();
         dao.select(sink);
         nss = sink.getArray();
+        foam.nanos.logger.Logger logger = (foam.nanos.logger.Logger) x.get("logger");
+        for ( DummySp ds : nss ) {
+          logger.info(ds);
+        }
         test (nss.size() == 1, "ReferenceTest DAO select filtered on spid. expected: 1, found: "+nss.size());
 
         // delete/remove

--- a/src/foam/nanos/auth/test/ServiceProviderAwareTest.js
+++ b/src/foam/nanos/auth/test/ServiceProviderAwareTest.js
@@ -25,6 +25,7 @@ foam.CLASS({
     'foam.util.Auth',
     'foam.util.SafetyUtil',
     'foam.nanos.auth.AuthorizationException',
+    'foam.nanos.auth.ServiceProvider',
     'foam.nanos.auth.ServiceProviderAware',
     'foam.nanos.auth.ServiceProviderAwareDAO',
     'foam.nanos.auth.ServiceProviderAwareSink',
@@ -42,9 +43,14 @@ foam.CLASS({
       name: 'runTest',
       javaCode: `
         AuthService auth = (AuthService) x.get("auth");
+        ((DAO) x.get("localServiceProviderDAO")).put(new ServiceProvider.Builder(x).setId("spid").build());
         ((DAO) x.get("localGroupDAO")).put(new Group.Builder(x).setId("test").build());
         ((DAO) x.get("localGroupDAO")).put(new Group.Builder(x).setId("test2").build());
         ((DAO) x.get("localGroupDAO")).put(new Group.Builder(x).setId("fail").build());
+
+        DAO groupPermissionJunctionDAO = (DAO) x.get("localGroupPermissionJunctionDAO");
+        groupPermissionJunctionDAO.put(new GroupPermissionJunction.Builder(x).setSourceId("test").setTargetId("serviceprovider.read.spid").build());
+        groupPermissionJunctionDAO.put(new GroupPermissionJunction.Builder(x).setSourceId("test2").setTargetId("serviceprovider.read.spid").build());
 
         foam.nanos.app.AppConfig appConfig = (foam.nanos.app.AppConfig) ((FObject) x.get("appConfig")).fclone();
         appConfig.setDefaultSpid("spid");

--- a/src/foam/nanos/crunch/UserCapabilityJunctionDAO.js
+++ b/src/foam/nanos/crunch/UserCapabilityJunctionDAO.js
@@ -21,7 +21,7 @@ foam.CLASS({
   ],
 
   messages: [
-    { name: 'ERROR_ONE', message: 'UserCapabilityJunctions should be disabled via status change.' },
+    { name: 'ERROR_ONE', message: 'UserCapabilityJunctions should be disabled via LifecycleState change.' },
     { name: 'ERROR_TWO', message: 'User\'s capability cannot be reassigned.' },
     { name: 'ERROR_THREE', message: 'Capability cannot be changed.' },
     { name: 'ERROR_FOUR', message: 'Capability data type mismatch ' },

--- a/src/foam/nanos/crunch/UserCapabilityJunctionRefine.js
+++ b/src/foam/nanos/crunch/UserCapabilityJunctionRefine.js
@@ -14,6 +14,10 @@ foam.CLASS({
     capability to user.
   `,
 
+  implements: [
+    'foam.nanos.auth.LifecycleAware'
+  ],
+
   requires: [
     'foam.nanos.crunch.CapabilityJunctionPayload'
   ],
@@ -115,6 +119,14 @@ foam.CLASS({
       javaSetter: `
         getPayload().setStatus(val);
       `
+    },
+    {
+      name: 'lifecycleState',
+      class: 'Enum',
+      of: 'foam.nanos.auth.LifecycleState',
+      value: 'ACTIVE',
+      visibility: 'RO',
+      includeInDigest: true,
     },
     {
       class: 'Reference',

--- a/src/foam/nanos/crunch/services.jrl
+++ b/src/foam/nanos/crunch/services.jrl
@@ -76,13 +76,14 @@ p({
   "name":"userCapabilityJunctionDAO",
   "serve":true,
   "serviceScript":"""
-    dao = new foam.dao.EasyDAO.Builder(x)
+    return new foam.dao.EasyDAO.Builder(x)
       .setAuthorize(false)
       .setInnerDAO(x.get("bareUserCapabilityJunctionDAO"))
       .setOf(foam.nanos.crunch.UserCapabilityJunction.getOwnClassInfo())
+      .setDecorator(new foam.nanos.crunch.UserCapabilityJunctionDAO.Builder(x)
+        .setDelegate(new foam.dao.NullDAO(x, foam.nanos.crunch.UserCapabilityJunction.getOwnClassInfo()))
+        .build())
       .build();
-    userCap =  new foam.nanos.crunch.UserCapabilityJunctionDAO.Builder(x).setDelegate(dao).build();
-    return userCap;
   """,
   "client":"{\"of\":\"foam.nanos.crunch.UserCapabilityJunction\", \"remoteListenerSupport\": false}"
 })

--- a/src/foam/nanos/notification/EmailSetting.js
+++ b/src/foam/nanos/notification/EmailSetting.js
@@ -75,8 +75,6 @@ foam.CLASS({
         }
 
         EmailMessage message = new EmailMessage();
-        Logger logger = (Logger) x.get("logger");
-        logger.info("EmailSetting", "spid from user", user.getSpid());
         message.setSpid(user.getSpid());
         message.setTo(new String[] { user.getEmail() });
         notification = (Notification) notification.fclone();
@@ -104,7 +102,7 @@ foam.CLASS({
             EmailsUtility.sendEmailFromTemplate(x, user, message, notification.getEmailName(), notification.getEmailArgs());
           }
         } catch(Throwable t) {
-          //Logger logger = (Logger) x.get("logger");
+          Logger logger = (Logger) x.get("logger");
           logger.error("Error sending notification email message: " + message + ". Error: " + t);
         }
       `

--- a/src/foam/nanos/notification/EmailSetting.js
+++ b/src/foam/nanos/notification/EmailSetting.js
@@ -75,6 +75,9 @@ foam.CLASS({
         }
 
         EmailMessage message = new EmailMessage();
+        Logger logger = (Logger) x.get("logger");
+        logger.info("EmailSetting", "spid from user", user.getSpid());
+        message.setSpid(user.getSpid());
         message.setTo(new String[] { user.getEmail() });
         notification = (Notification) notification.fclone();
 
@@ -101,7 +104,7 @@ foam.CLASS({
             EmailsUtility.sendEmailFromTemplate(x, user, message, notification.getEmailName(), notification.getEmailArgs());
           }
         } catch(Throwable t) {
-          Logger logger = (Logger) x.get("logger");
+          //Logger logger = (Logger) x.get("logger");
           logger.error("Error sending notification email message: " + message + ". Error: " + t);
         }
       `

--- a/src/foam/nanos/notification/Notification.js
+++ b/src/foam/nanos/notification/Notification.js
@@ -223,8 +223,7 @@ foam.CLASS({
       writePermissionRequired: true,
       documentation: `
         Need to override getter to return "" because its trying to
-        return null (probably as a result of moving order of files
-        in nanos), which breaks tests
+        return null which breaks tests
       `,
       javaGetter: `
         if ( ! spidIsSet_ ) {

--- a/src/foam/nanos/notification/Notification.js
+++ b/src/foam/nanos/notification/Notification.js
@@ -12,7 +12,8 @@ foam.CLASS({
     'foam.nanos.auth.Authorizable',
     'foam.nanos.auth.CreatedAware',
     'foam.nanos.auth.CreatedByAware',
-    'foam.nanos.medusa.Clusterable'
+    'foam.nanos.medusa.Clusterable',
+    'foam.nanos.auth.ServiceProviderAware'
   ],
 
   documentation: 'Notification model responsible for system and integrated messaging notifications.',
@@ -33,7 +34,28 @@ foam.CLASS({
     'foam.log.LogLevel'
   ],
 
-  tableColumns: ['id', 'body', 'notificationType', 'broadcasted', 'userId.id', 'groupId.id' ],
+  tableColumns: [
+    'id',
+    'body',
+    'notificationType',
+    'broadcasted',
+    'userId.id',
+    'groupId.id'
+  ],
+
+  sections: [
+    {
+      name: 'default_',
+      order: 1
+    },
+    {
+      name: 'systemInformation',
+      help: 'Properties that are used internally by the system.',
+      title: 'System Information',
+      order: 2,
+      permissionRequired: true
+    },
+  ],
 
   axioms: [
     {
@@ -190,6 +212,26 @@ foam.CLASS({
       name: 'clusterable',
       value: true,
       includeInDigest: false
+    },
+    {
+      class: 'Reference',
+      of: 'foam.nanos.auth.ServiceProvider',
+      name: 'spid',
+      includeInDigest: true,
+      tableWidth: 120,
+      section: 'systemInformation',
+      writePermissionRequired: true,
+      documentation: `
+        Need to override getter to return "" because its trying to
+        return null (probably as a result of moving order of files
+        in nanos), which breaks tests
+      `,
+      javaGetter: `
+        if ( ! spidIsSet_ ) {
+          return "";
+        }
+        return spid_;
+      `
     }
   ],
 

--- a/src/foam/nanos/notification/email/EmailMessage.js
+++ b/src/foam/nanos/notification/email/EmailMessage.js
@@ -13,7 +13,8 @@ foam.CLASS({
   implements: [
     'foam.nanos.auth.CreatedAware',
     'foam.nanos.auth.CreatedByAware',
-    'foam.nanos.auth.LastModifiedByAware'
+    'foam.nanos.auth.LastModifiedByAware',
+    'foam.nanos.auth.ServiceProviderAware'
   ],
 
   tableColumns: [
@@ -33,7 +34,14 @@ foam.CLASS({
       name: 'templateInformation',
       title: 'Template Arguments',
       order: 2
-    }
+    },
+    {
+      name: 'systemInformation',
+      help: 'Properties that are used internally by the system.',
+      title: 'System Information',
+      order: 3,
+      permissionRequired: true
+    },
   ],
 
   properties: [
@@ -149,6 +157,26 @@ foam.CLASS({
       includeInDigest: true,
       section: 'templateInformation',
       view: { class: 'foam.u2.view.MapView' }
+    },
+    {
+      class: 'Reference',
+      of: 'foam.nanos.auth.ServiceProvider',
+      name: 'spid',
+      includeInDigest: true,
+      tableWidth: 120,
+      section: 'systemInformation',
+      writePermissionRequired: true,
+      documentation: `
+        Need to override getter to return "" because its trying to
+        return null (probably as a result of moving order of files
+        in nanos), which breaks tests
+      `,
+      javaGetter: `
+        if ( ! spidIsSet_ ) {
+          return "";
+        }
+        return spid_;
+      `
     }
   ]
 });

--- a/src/foam/nanos/script/TestRunnerScript.js
+++ b/src/foam/nanos/script/TestRunnerScript.js
@@ -75,8 +75,8 @@ foam.CLASS({
         // turn off logging to get rid of clutter.
         LogLevelFilterLogger loggerFilter = (LogLevelFilterLogger) x.get("logger");
         loggerFilter.setLogDebug(false);
-        loggerFilter.setLogInfo(true);
-        loggerFilter.setLogWarning(true);
+        loggerFilter.setLogInfo(false);
+        loggerFilter.setLogWarning(false);
 
         TestRunnerConfig config = (TestRunnerConfig) x.get("testRunnerConfig");
         String testSuite = config != null ? config.getTestSuite() : null;

--- a/src/foam/nanos/script/TestRunnerScript.js
+++ b/src/foam/nanos/script/TestRunnerScript.js
@@ -75,8 +75,8 @@ foam.CLASS({
         // turn off logging to get rid of clutter.
         LogLevelFilterLogger loggerFilter = (LogLevelFilterLogger) x.get("logger");
         loggerFilter.setLogDebug(false);
-        loggerFilter.setLogInfo(false);
-        loggerFilter.setLogWarning(false);
+        loggerFilter.setLogInfo(true);
+        loggerFilter.setLogWarning(true);
 
         TestRunnerConfig config = (TestRunnerConfig) x.get("testRunnerConfig");
         String testSuite = config != null ? config.getTestSuite() : null;

--- a/src/foam/nanos/theme/Theme.js
+++ b/src/foam/nanos/theme/Theme.js
@@ -20,7 +20,7 @@ foam.CLASS({
 //    'foam.nanos.auth.CreatedByAware',
     'foam.nanos.auth.EnabledAware',
     'foam.nanos.auth.LastModifiedAware',
-    'foam.nanos.auth.ServiceProviderAware',
+//    'foam.nanos.auth.ServiceProviderAware',
 //    'foam.nanos.auth.LastModifiedByAware'
   ],
 

--- a/src/foam/nanos/theme/Theme.js
+++ b/src/foam/nanos/theme/Theme.js
@@ -16,12 +16,16 @@ foam.CLASS({
 
   implements: [
     'foam.nanos.auth.CreatedAware',
-// REVIEW: implementation properties are class: 'Long' as we have a cyclic reference with User, and hence can't use class: 'Reference'. But even as Long, enable these interfaces causes genjava failures: ERROR: Unhandled promise rejection TypeError: Cannot read property 'id' of null
-//    'foam.nanos.auth.CreatedByAware',
+    // REVIEW: implementation properties are class: 'Long' as we have a cyclic reference with User, and hence can't use class: 'Reference'. But even as Long, enable these interfaces causes genjava failures: ERROR: Unhandled promise rejection TypeError: Cannot read property 'id' of null
+    // 'foam.nanos.auth.CreatedByAware',
     'foam.nanos.auth.EnabledAware',
     'foam.nanos.auth.LastModifiedAware',
-//    'foam.nanos.auth.ServiceProviderAware',
-//    'foam.nanos.auth.LastModifiedByAware'
+    // 'foam.nanos.auth.LastModifiedByAware',
+
+    // NOTE: this class cannot implement ServiceProviderAware as it itself is used
+    // during ServiceProviderAwareDAO operations as a fallback to determine the
+    // spid based on url and theme.
+    // 'foam.nanos.auth.ServiceProviderAware'
   ],
 
   requires: [

--- a/src/foam/nanos/ticket/Ticket.js
+++ b/src/foam/nanos/ticket/Ticket.js
@@ -16,7 +16,8 @@ foam.CLASS({
     'foam.nanos.auth.CreatedAware',
     'foam.nanos.auth.CreatedByAware',
     'foam.nanos.auth.LastModifiedAware',
-    'foam.nanos.auth.LastModifiedByAware'
+    'foam.nanos.auth.LastModifiedByAware',
+    'foam.nanos.auth.ServiceProviderAware'
   ],
 
   requires: [
@@ -259,6 +260,25 @@ foam.CLASS({
       tableCellFormatter: function(value, obj) {
         this.add(obj.title);
       }
+    },
+    {
+      class: 'Reference',
+      of: 'foam.nanos.auth.ServiceProvider',
+      name: 'spid',
+      includeInDigest: true,
+      section: 'systemInformation',
+      writePermissionRequired: true,
+      documentation: `
+        Need to override getter to return "" because its trying to
+        return null (probably as a result of moving order of files
+        in nanos), which breaks tests
+      `,
+      javaGetter: `
+        if ( ! spidIsSet_ ) {
+          return "";
+        }
+        return spid_;
+      `
     }
   ],
 

--- a/src/foam/nanos/ticket/Ticket.js
+++ b/src/foam/nanos/ticket/Ticket.js
@@ -270,8 +270,7 @@ foam.CLASS({
       writePermissionRequired: true,
       documentation: `
         Need to override getter to return "" because its trying to
-        return null (probably as a result of moving order of files
-        in nanos), which breaks tests
+        return null which breaks tests
       `,
       javaGetter: `
         if ( ! spidIsSet_ ) {

--- a/src/foam/util/Emails/EmailsUtility.java
+++ b/src/foam/util/Emails/EmailsUtility.java
@@ -63,6 +63,10 @@ public class EmailsUtility {
     }
     userX = userX.put("appConfig", appConfig);
 
+    if ( SafetyUtil.isEmpty(emailMessage.getSpid()) ) {
+      emailMessage.setSpid(user.getSpid());
+    }
+
     SupportConfig supportConfig = theme.getSupportConfig();
     EmailConfig supportEmailConfig = supportConfig.getEmailConfig();
 

--- a/src/scripts
+++ b/src/scripts
@@ -16,13 +16,13 @@ p({
     });
 
     x.serviceProviderDAO.select(function (s) {
-      perm = 'spid.read.' + s.id;
+      perm = 'serviceprovider.read.' + s.id;
       p = foam.nanos.auth.Permission.create({ id: perm });
       x.permissionDAO.put(p);
-      perm = 'spid.update.' + s.id;
+      perm = 'serviceprovider.update.' + s.id;
       p = foam.nanos.auth.Permission.create({ id: perm });
       x.permissionDAO.put(p);
-      perm = 'spid.remove.' + s.id;
+      perm = 'serviceprovider.remove.' + s.id;
       p = foam.nanos.auth.Permission.create({ id: perm });
       x.permissionDAO.put(p);
     });


### PR DESCRIPTION
Address ServiceProviderAwareDAO DAO operations were not refactored for move of spid to models.

Required making UserCapabilityJunction LIfecycleAware to support remove/delete of UCJs.

Fixing ServiceProviderAwareDAO resulted User/Contact/Business remove/removeAll test
failing on the cascade remove (mark delete) on associated UCJs.  For some reason
this cascade remove was not occuring before.

The LifecycleAwareDAO will mark removed UCJs as LifecycleState.DELETED.
The remainder of CRUNCH still needs to be updated to handled these deleted ucjs.
