### PR TITLE
Fix tests

### DIFF
--- a/src/foam/nanos/auth/test/ServiceProviderAuthorizerTest.js
+++ b/src/foam/nanos/auth/test/ServiceProviderAuthorizerTest.js
@@ -25,7 +25,7 @@ foam.CLASS({
         User nonAdminUser = new User();
         DAO bareUserDAO = (DAO) x.get("bareUserDAO");
         DAO serviceProviderDAO = (DAO) x.get("serviceProviderDAO");
-        ServiceProvider serviceProvider = new ServiceProvider.Builder(x).setId("test").build();
+        ServiceProvider serviceProvider = new ServiceProvider.Builder(x).setId("testspid").build();
         boolean threw;
 
         nonAdminUser = (User) bareUserDAO.put(nonAdminUser);


### PR DESCRIPTION
Rename serviceProvide id from "test" to "testspid" since the "test" spid is still needed for other tests outside of ServiceProviderAuthorizerTest.