### PR TITLE
Move ServiceProviderAwareDAO below (closer to mdao) Decorators to all…

### DIFF
--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -218,6 +218,12 @@ foam.CLASS({
           }
         }
 
+        if ( getServiceProviderAware() ) {
+          delegate = new foam.nanos.auth.ServiceProviderAwareDAO.Builder(getX())
+            .setDelegate(delegate)
+            .build();
+        }
+
         delegate = getOuterDAO(delegate);
 
         if ( getDecorator() != null ) {
@@ -271,12 +277,6 @@ foam.CLASS({
 
         if ( getDeletedAware() ) {
           System.out.println("DEPRECATED: Will be completely removed after services journal migration script. No functionality as of now.");
-        }
-
-        if ( getServiceProviderAware() ) {
-          delegate = new foam.nanos.auth.ServiceProviderAwareDAO.Builder(getX())
-            .setDelegate(delegate)
-            .build();
         }
 
         if ( getRuler() ) {


### PR DESCRIPTION
…ow decorators to

potentially set the spid, or call through the correct user before we hit the
ServiceProviderAwareDAO

Affects Notifications for example. The Notification.put his the NotificationExpansionDAO which in turn calls doNotifiy on each user which saves the notification for each user.  Previously the ServiceProvicerAwareDAO was intercepting the put before the NotificationExpansionDAO. 