### PR TITLE
ServiceProviderAwareDAO - Create

### DIFF
--- a/src/foam/nanos/auth/ServiceProviderAwareDAO.js
+++ b/src/foam/nanos/auth/ServiceProviderAwareDAO.js
@@ -153,8 +153,7 @@ foam.CLASS({
       if ( isCreate ) {
         if ( SafetyUtil.isEmpty(sp.getSpid()) ) {
           sp.setSpid(getSpid(x));
-        } else if ( ! sp.getSpid().equals(getSpid(x)) &&
-                    ! auth.check(x, "serviceprovider.create." + sp.getSpid()) ) {
+        } else if ( ! auth.check(x, "serviceprovider.read." + sp.getSpid()) ) {
           throw new AuthorizationException();
         }
       } else if ( ! sp.getSpid().equals(oldSp.getSpid()) &&


### PR DESCRIPTION
On put, replace auth check of serviceprovider.create with read, as
the caller is not creating serviceproviders, but rather just putting
into a DAO that is serviceprovideraware, and one can put into a
DAO that they themselves have read access on.  This also corrects for
the case when the spid is set and user is the system.