### PR TITLE
Add properties to hide MinMaxCapabilityWizardlet

### DIFF
--- a/src/foam/nanos/crunch/ui/MinMaxCapabilityWizardlet.js
+++ b/src/foam/nanos/crunch/ui/MinMaxCapabilityWizardlet.js
@@ -103,7 +103,8 @@ foam.CLASS({
       class: 'FObjectArray',
       of: 'foam.u2.wizard.WizardletSection',
       factory: function() {
-        return [
+        // TODO: If 'of' is set for a MinMax it should be added as a section
+        return this.hideChoiceView ? [] : [
           this.WizardletSection.create({
             isAvailable: true,
             title: this.capability.name,
@@ -118,6 +119,14 @@ foam.CLASS({
           })
         ];
       }
+    },
+    {
+      name: 'consumePrerequisites',
+      class: 'Boolean'
+    },
+    {
+      name: 'hideChoiceView',
+      class: 'Boolean'
     }
   ],
 
@@ -125,6 +134,7 @@ foam.CLASS({
     function addPrerequisite(wizardlet) {
       wizardlet.isAvailable = false;
       this.choiceWizardlets.push(wizardlet);
+      return this.consumePrerequisites;
     }
   ]
 });

--- a/src/foam/nanos/crunch/ui/MinMaxCapabilityWizardlet.js
+++ b/src/foam/nanos/crunch/ui/MinMaxCapabilityWizardlet.js
@@ -122,11 +122,19 @@ foam.CLASS({
     },
     {
       name: 'consumePrerequisites',
+      documentation: `
+        When true, report 'true' on calls to addPrerequisite to indicate that
+        prerequisite wizardlets were handled by this wizardlet. This effectively
+        prevents prerequisite wizardlets from displaying in a CRUNCH wizard.
+      `,
       class: 'Boolean'
     },
     {
       name: 'hideChoiceView',
-      class: 'Boolean'
+      documentation: `
+        When true, do not display the choice selection section.
+      `,
+      class: 'Boolean
     }
   ],
 


### PR DESCRIPTION
This PR adds new properties;
- **consumePrerequisites**: Prevent prerequisite wizardlets from displaying in the wizard
- **hideChoiceView**: Prevent default MinMax view displaying.

Example

```
p({
  class:"foam.nanos.crunch.MinMaxCapability",
  id:"my.minmax.capability",
  name:"My MinMax Capability",
  min:1,
  max:1,
  version:"0",
  beforeWizardlet: {
    class: "foam.nanos.crunch.ui.MinMaxCapabilityWizardlet",
    consumePrerequisites: true,
    hideChoiceView: true,
  },
  enabled:true
})
```