### PR TITLE
missing user fclone

### DIFF
--- a/src/foam/nanos/auth/SetUserServiceProviderJunctionRuleAction.js
+++ b/src/foam/nanos/auth/SetUserServiceProviderJunctionRuleAction.js
@@ -64,7 +64,7 @@ foam.CLASS({
               throw new RuntimeException("You are not authorized to perform this update");
 
             // get the
-            User user = (User) ucj.findSourceId(x);
+            User user = (User) ucj.findSourceId(x).fclone();
             ServiceProvider serviceProvider = (ServiceProvider) target;
 
             // if is create, check if any old user-serviceprovider junctions exist, and remove it and its grant path   


### PR DESCRIPTION
```
021-01-15T15:22:27.025-0500,main,ERROR,Object is frozen.,java.lang.UnsupportedOperationException: Object is frozen.
	at foam.core.FObject.assertNotFrozen(FObject.java:554)
	at foam.nanos.auth.User.setSpid(User.java:5381)
	at foam.nanos.auth.SetUserServiceProviderJunctionRuleAction$2.execute(SetUserServiceProviderJunctionRuleAction.java:84)
```
object frozen. fclone() to unfreeze.