### PR TITLE
Rename blob directory from files to largefiles to not conflict with Fi…

### DIFF
--- a/src/foam/blob/Blob.js
+++ b/src/foam/blob/Blob.js
@@ -546,9 +546,9 @@ foam.CLASS({
       transient: true,
       documentation: 'Directory of where files are stored after hashing',
       expression: function(root) {
-        return root + '/files';
+        return root + '/largefiles';
       },
-      javaFactory: 'return File.separator + "files";'
+      javaFactory: 'return File.separator + "largefiles";'
     },
     {
       class: 'Boolean',


### PR DESCRIPTION
Rename blob directory from files to largefiles to not conflict with FileDAO journal name.
Not an issue under Medusa. 