### PR TITLE
[NP-3322] Slot property for changes to `errors_` on members of an FObjectArray

### DIFF
--- a/src/foam/core/FObjectArray.js
+++ b/src/foam/core/FObjectArray.js
@@ -35,9 +35,7 @@ foam.CLASS({
 
           // Safely combine error lists and update error_$
           var setErrors = errorLists => {
-            errors_$.set(errorLists
-              .map(v => v || [])
-              .flat(1));
+            errors_$.set(errorLists.flat(1).filter(v => v));
           };
           // Handle an array property update
           var subToArray = val => {

--- a/src/foam/core/FObjectArray.js
+++ b/src/foam/core/FObjectArray.js
@@ -37,7 +37,7 @@ foam.CLASS({
           var setErrors = errorLists => {
             errors_$.set(errorLists
               .map(v => (v && Array.isArray(v)) ? v : [])
-              .reduce((arry, v) => arry.concat(v), []));
+              .flat(1));
           };
           // Handle an array property update
           var subToArray = val => {

--- a/src/foam/core/FObjectArray.js
+++ b/src/foam/core/FObjectArray.js
@@ -36,7 +36,7 @@ foam.CLASS({
           // Safely combine error lists and update error_$
           var setErrors = errorLists => {
             errors_$.set(errorLists
-              .map(v => (v && Array.isArray(v)) ? v : [])
+              .map(v => v || [])
               .flat(1));
           };
           // Handle an array property update


### PR DESCRIPTION
I realized in order to propagate `capablePayload` errors it is necessary to listen for array changes and re-bind to the `errors_$` slot of each item in the array. Since the behaviour itself is generic I figure having it on FObjectArray could be very helpful for similar cases in the future.