### PR TITLE
[NP-3255] fix CapabilityDAO Table

### DIFF
--- a/src/foam/nanos/crunch/ui/CapabilityWizardlet.js
+++ b/src/foam/nanos/crunch/ui/CapabilityWizardlet.js
@@ -25,7 +25,7 @@ foam.CLASS({
     {
       name: 'id',
       expression: function (capability) {
-        return 'capability,' + capability.id;
+        return capability ? 'capability,' + capability.id : 'capability undefined';
       }
     },
 

--- a/src/foam/nanos/crunch/ui/CapabilityWizardlet.js
+++ b/src/foam/nanos/crunch/ui/CapabilityWizardlet.js
@@ -25,7 +25,7 @@ foam.CLASS({
     {
       name: 'id',
       expression: function (capability) {
-        return capability ? 'capability,' + capability.id : 'capability undefined';
+        return capability ? capability.id : '';
       }
     },
 


### PR DESCRIPTION
Address: https://nanopay.atlassian.net/browse/NP-3255

Cause: 
 - capabilityWizardlet is created without setting capability property, and `capability` defaults to `undefined`. When `id` is accessed, its expression function is invoked and tries to access `capability.id`. This raises an error because it is trying to access `id` of `undefined`. 

Solution: 
- handle when capability is `undefined`.


----

Is UI supposed to look this way for the wizardlet column? Or will it be fixed?

![Screen Shot 2021-01-22 at 2 26 22 PM](https://user-images.githubusercontent.com/58435071/105536626-a4998c00-5cbe-11eb-8572-da9de00e27ca.png)
