### PR TITLE
Ref view ucj

### DIFF
--- a/src/foam/nanos/crunch/UserCapabilityJunctionRefine.js
+++ b/src/foam/nanos/crunch/UserCapabilityJunctionRefine.js
@@ -41,6 +41,11 @@ foam.CLASS({
     'data'
   ],
 
+  messages: [
+    { name: 'VIEW_TITLE_USER', message: 'Users' },
+    { name: 'VIEW_TITLE_CAP', message: 'Capabilities' }
+  ],
+
   sections: [
     { name: 'ucjExpirySection' }
   ],
@@ -59,16 +64,23 @@ foam.CLASS({
       name: 'sourceId',
       label: 'User',
       includeInDigest: true,
-      view: function(_, X) {
+      view: function(_, x) {
         return {
-          class: 'foam.u2.view.RichChoiceView',
-          search: true,
-          sections: [
-            {
-              heading: 'Users',
-              dao: X.userDAO
-            }
-          ]
+          class: 'foam.u2.view.ModeAltView',
+          readView: {
+            class: 'foam.u2.view.ReadReferenceView',
+            of: 'foam.nanos.auth.User'
+          },
+          writeView: {
+            class: 'foam.u2.view.RichChoiceView',
+            search: true,
+            sections: [
+              {
+                heading: x.data.VIEW_TITLE_USER,
+                dao: x.userDAO
+              }
+            ]
+          }
         };
       }
     },
@@ -80,14 +92,21 @@ foam.CLASS({
       includeInDigest: true,
       view: function(_, X) {
         return {
-          class: 'foam.u2.view.RichChoiceView',
-          search: true,
-          sections: [
-            {
-              heading: 'Capabilities',
-              dao: X.capabilityDAO
-            }
-          ]
+          class: 'foam.u2.view.ModeAltView',
+          readView: {
+            class: 'foam.u2.view.ReadReferenceView',
+            of: 'foam.nanos.crunch.Capability'
+          },
+          writeView: {
+            class: 'foam.u2.view.RichChoiceView',
+            search: true,
+            sections: [
+              {
+                heading: X.data.VIEW_TITLE_CAP,
+                dao: X.capabilityDAO
+              }
+            ]
+          }
         };
       },
       tableCellFormatter: function(value, obj, axiom) {

--- a/src/foam/u2/view/ModeAltView.js
+++ b/src/foam/u2/view/ModeAltView.js
@@ -49,7 +49,7 @@ foam.CLASS({
     function initArgs(args) {
       this.SUPER.apply(this, arguments);
       if ( args ) {
-        this.args = foam.util.clone(args);
+        this.args = foam.Object.shallowClone(args);
         delete this.args['class'];
         delete this.args['readView'];
         delete this.args['writeView'];


### PR DESCRIPTION
THIS PR reveals some bugs.
- 
![image](https://user-images.githubusercontent.com/10802216/105716075-5a95ed80-5eec-11eb-96e3-0d15d5e9a5d7.png)
Which might be caused by having 2 properties with ModeAltView. Although commenting out one of the view property.property will get you somewhere - the bug of max call stack still persists.

So then comment out one of the property views ... you then get
![image](https://user-images.githubusercontent.com/10802216/105716427-caa47380-5eec-11eb-8856-766f14248a75.png)

