### PR TITLE
[NP=3319] stepWizardController bug fix

### DIFF
--- a/src/foam/u2/wizard/StepWizardController.js
+++ b/src/foam/u2/wizard/StepWizardController.js
@@ -92,7 +92,7 @@ foam.CLASS({
       name: 'currentSection',
       expression: function(currentWizardlet, wizardPosition$sectionIndex) {
         return this.currentWizardlet.currentSection = currentWizardlet
-            .sections[wizardPosition$sectionIndex] ?? null;
+          .sections[wizardPosition$sectionIndex] ?? null;
       }
     },
     {

--- a/src/foam/u2/wizard/StepWizardController.js
+++ b/src/foam/u2/wizard/StepWizardController.js
@@ -92,7 +92,7 @@ foam.CLASS({
       name: 'currentSection',
       expression: function(currentWizardlet, wizardPosition$sectionIndex) {
         return this.currentWizardlet.currentSection = currentWizardlet
-            .sections[wizardPosition$sectionIndex];
+            .sections[wizardPosition$sectionIndex] ?? null;
       }
     },
     {


### PR DESCRIPTION
**address**: https://nanopay.atlassian.net/browse/NP-3319?atlOrigin=eyJpIjoiNmU1NGI4YTAzOTU0NGI5NGJmNGUxNjhiOGI0MDVjNmMiLCJwIjoiamlyYS1zbGFjay1pbnQifQ

**cause**:  In `stepWizardController`, `currentSection` expression is triggered before `currentWizardlet` expression when `wizardPosition` is updated. This is problematic because we are accessing `currentWizardlet` which has not been updated (to previous wizardlet) with new section index. If `currentWizardlet` doesn't have a section at new section index, it returns undefined.

**solution**: In the case above, return null. Alternatively, Arthur suggested that we make the `currentWizardlet` expression gets triggered before `currentSection` expression. I believe this seems more intuitive, so if anyone knows we can set the priority for expressions, please let us know.

