### PR TITLE
DIG session context fix

### DIFF
--- a/src/foam/nanos/auth/UserAndGroupAuthService.js
+++ b/src/foam/nanos/auth/UserAndGroupAuthService.js
@@ -142,11 +142,15 @@ foam.CLASS({
           throw new AccessDeniedException(e);
         }
 
+        Session session = x.get(Session.class);
+        if ( session.getUserId() == user.getId() ) {
+          return user;
+        }
+
         // Freeze user
         user = (User) user.fclone();
         user.freeze();
-
-        Session session = x.get(Session.class);
+        
         session.setUserId(user.getId());
 
         if ( check(userX, "*") ) {

--- a/src/foam/nanos/auth/UserAndGroupAuthService.js
+++ b/src/foam/nanos/auth/UserAndGroupAuthService.js
@@ -143,6 +143,8 @@ foam.CLASS({
         }
 
         Session session = x.get(Session.class);
+
+        // Re use the session context if the current session context's user id matches the id of the user trying to log in
         if ( session.getUserId() == user.getId() ) {
           return user;
         }


### PR DESCRIPTION
If a user logs in with Basic auth but also supplies their session id, it will wrap a new session context around the old one.  This causes the log error where it prints the user & userid multiple times.  To fix this I have this solution to reuse the old session context if it's been properly setup (old session context's user id == login user id).  

Another potential solution would be to check the session context in `AuthWebAgent.authenticate` for the userId and return the session if the ids match and the user's password is valid, but that would skip any login logic we currently use (Such as the LoginAttempAuthService).