### PR TITLE
Inform the virtual dom of attribute changes

### DIFF
--- a/src/foam/u2/AttrSlot.js
+++ b/src/foam/u2/AttrSlot.js
@@ -49,7 +49,7 @@ foam.CLASS({
     function sub(l) {
       var self = this;
       const valueUpdateListener = function() {
-        self.value = self.get();
+        self.set(self.get());
       };
 
       if ( ! this.hasListeners() ) {

--- a/src/foam/u2/Element.js
+++ b/src/foam/u2/Element.js
@@ -1321,7 +1321,7 @@ foam.CLASS({
         var attr  = this.getAttributeNode(name);
 
         if ( attr ) {
-          attr[name] = value;
+          attr.value = value;
         } else {
           attr = { name: name, value: value };
           this.attributes.push(attr);
@@ -2092,8 +2092,10 @@ foam.CLASS({
           var name  = attr.name;
           var value = attr.value;
 
-          out(' ', name);
-          if ( value !== false ) out('="', foam.String.isInstance(value) ? value.replace(/"/g, '&quot;') : value, '"');
+          if ( value !== false ) {
+            out(' ', name);
+            out('="', foam.String.isInstance(value) ? value.replace(/"/g, '&quot;') : value, '"');
+          }
         }
       }
 


### PR DESCRIPTION
In our fork we can load and unload u2 elements and I just ran into a bug where virtual dom wasn't finding out about attribute changes. For us, it was causing some weirdness when re-rendering. Your code is a little different than ours so maybe you don't care about this but I figured I'd throw it your way :)