### PR TITLE
[NP-3439] Fix FObjectView placeholder regression

### DIFF
--- a/src/foam/u2/view/FObjectView.js
+++ b/src/foam/u2/view/FObjectView.js
@@ -37,7 +37,7 @@ foam.CLASS({
       name: 'objectClass',
       label: '',
       visibility: function(allowCustom, classIsFinal, choices, data, placeholder) {
-        if ( ! allowCustom && choices.length <= 1 && ! placeholder ) return foam.u2.DisplayMode.HIDDEN;
+        if ( ! allowCustom && choices.length <= 1 && ! this.hasOwnProperty('placeholder') ) return foam.u2.DisplayMode.HIDDEN;
         if ( classIsFinal && this.dataWasProvided_ ) return foam.u2.DisplayMode.HIDDEN;
         return foam.u2.DisplayMode.RW;
       },
@@ -117,7 +117,7 @@ foam.CLASS({
     {
       class: 'String',
       name: 'placeholder',
-      factory: function() {
+      expression: function() {
         return this.PLACEHOLDER_TEXT;
       },
       documentation: 'If no placeholder, the choiceView will select the first element',
@@ -234,7 +234,7 @@ foam.CLASS({
       );
 
       if ( this.data ) { this.objectClass = dataToClass(this.data); }
-      if ( ! this.data && ! this.objectClass && this.choices.length && !this.placeholder ) this.objectClass = this.choices[0][0];
+      if ( ! this.data && ! this.objectClass && this.choices.length && ! this.hasOwnProperty('placeholder') ) this.objectClass = this.choices[0][0];
 
       this.
         start(this.OBJECT_CLASS).


### PR DESCRIPTION
PR #4637 adds default placeholder text to FObjectView. Unfortunately FObjectView has conditional behaviour based on whether placeholder is set, which means the factory causes a regression. I was able to fix this by replacing `this.placeholder` checks with `this.hasOwnProperty('placeholder')`, along with changing `factory` to `expression`.