### PR TITLE
Using MedusaRegistry, have Secondary wait on it's MDAO update.

### DIFF
--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -225,6 +225,26 @@ foam.CLASS({
           }
         }
 
+        if ( getServiceProviderAware() ) {
+          delegate = new foam.nanos.auth.ServiceProviderAwareDAO.Builder(getX())
+            .setDelegate(delegate)
+            .build();
+
+          // auto add index on spid
+          DAO dao = (DAO) getMdao();
+          if ( dao != null &&
+               dao instanceof foam.dao.MDAO ) {
+            PropertyInfo pInfo = (PropertyInfo) this.getOf().getAxiomByName("spid");
+            if ( pInfo != null ) {
+              ((foam.dao.MDAO)dao).addIndex(pInfo);
+            } else {
+              logger.warning(getName(), "Index not added. Property not found. spid");
+            }
+          } else {
+            logger.warning(getName(), "Index not added on spid, no access to MDAO");
+          }
+        }
+
         delegate = getOuterDAO(delegate);
 
         if ( getDecorator() != null ) {
@@ -283,26 +303,6 @@ foam.CLASS({
         if ( getRuler() ) {
           String name = foam.util.SafetyUtil.isEmpty(getRulerDaoKey()) ? getName() : getRulerDaoKey();
           delegate = new foam.nanos.ruler.RulerDAO(getX(), delegate, name);
-        }
-
-        if ( getServiceProviderAware() ) {
-          delegate = new foam.nanos.auth.ServiceProviderAwareDAO.Builder(getX())
-            .setDelegate(delegate)
-            .build();
-
-          // auto add index on spid
-          DAO dao = (DAO) getMdao();
-          if ( dao != null &&
-               dao instanceof foam.dao.MDAO ) {
-            PropertyInfo pInfo = (PropertyInfo) this.getOf().getAxiomByName("spid");
-            if ( pInfo != null ) {
-              ((foam.dao.MDAO)dao).addIndex(pInfo);
-            } else {
-              logger.warning(getName(), "Index not added. Property not found. spid");
-            }
-          } else {
-            logger.warning(getName(), "Index not added on spid, no access to MDAO");
-          }
         }
 
         if ( getCreatedAware() )

--- a/src/foam/nanos/medusa/MedusaConsensusDAO.js
+++ b/src/foam/nanos/medusa/MedusaConsensusDAO.js
@@ -213,14 +213,14 @@ This is the heart of Medusa.`,
           dagger.setGlobalIndex(x, entry.getIndex());
         }
 
-        entry.setPromoted(true);
-        entry = (MedusaEntry) getDelegate().put_(x, entry);
-
         try {
           entry = mdao(x, entry);
         } catch( IllegalArgumentException e ) {
           // nop - already reported - occurs when a DAO is removed.
         }
+
+        entry.setPromoted(true);
+        entry = (MedusaEntry) getDelegate().put_(x, entry);
 
         // Notify any blocked Primary puts
         MedusaRegistry registry = (MedusaRegistry) x.get("medusaRegistry");
@@ -420,6 +420,14 @@ This is the heart of Medusa.`,
             } else {
               getLogger().warning("Unsupported operation", entry.getDop().getLabel());
               throw new UnsupportedOperationException(entry.getDop().getLabel());
+            }
+
+            // Secondaries will block on registry
+            if ( ! replaying.getReplaying() &&
+                 ! config.getIsPrimary() ) {
+              MedusaRegistry registry = (MedusaRegistry) x.get("medusaRegistry");
+              getLogger().debug("mdao", entry.getDop(), entry.getId(), "registry", "register");
+              registry.register(x, (Long) entry.getId());
             }
           }
         }

--- a/src/foam/nanos/script/ScriptRunnerDAO.js
+++ b/src/foam/nanos/script/ScriptRunnerDAO.js
@@ -81,7 +81,7 @@ foam.CLASS({
               Script s = (Script) script.fclone();
               try {
                 s.setStatus(ScriptStatus.RUNNING);
-                s = (Script) getDelegate().put_(x, s);
+                s = (Script) getDelegate().put_(x, s).fclone();
                 getLogger().debug("agency", s.getId(), "start");
                 s.runScript(x);
                 getLogger().debug("agency", s.getId(), "end");
@@ -92,7 +92,7 @@ foam.CLASS({
                 s.setStatus(ScriptStatus.ERROR);
                 getDelegate().put_(x, s);
                 getLogger().error("agency", s.getId(), t);
-             }
+              }
             }
           }, "Run script: " + script.getId());
         return script;


### PR DESCRIPTION
Earlier, secondary was 'putting' the response from the primary, which was wrong.  When this was removed it revealed a flaw whereby the secondary was not blocking until it's MDAO was updated. 

Using MedusaRegistry, have Secondary wait on it's MDAO update. 
Revert ServiceProviderAware location in EasyDAO.
Add clone to address frozen object in Script.