### PR TITLE
NP-3483 MedusaRegistry Purge

### DIFF
--- a/src/foam/nanos/medusa/MedusaAdapterDAO.js
+++ b/src/foam/nanos/medusa/MedusaAdapterDAO.js
@@ -207,6 +207,8 @@ It then marshalls it to the primary mediator, and waits on a response.`,
         MedusaRegistry registry = (MedusaRegistry) x.get("medusaRegistry");
         registry.wait(x, (Long) cmd.getMedusaEntryId());
         getLogger().debug("update", dop.getLabel(), cmd.getMedusaEntryId(), "registry", "unwait");
+      } else {
+        getLogger().debug("update", dop.getLabel(), cmd.getMedusaEntryId(), "promoted");
       }
       FObject result = cmd.getData();
       if ( DOP.PUT == dop ) {

--- a/src/foam/nanos/medusa/MedusaConsensusDAO.js
+++ b/src/foam/nanos/medusa/MedusaConsensusDAO.js
@@ -423,6 +423,10 @@ This is the heart of Medusa.`,
             }
 
             // Secondaries will block on registry
+            // NOTE: See PromotedPurgeAgent for Registry cleanup.  These
+            // registry.register requests will remain until a 'waiter', or
+            // until purged, which is the case for idle Secondaries and
+            // non-active Regions.
             if ( ! replaying.getReplaying() &&
                  ! config.getIsPrimary() ) {
               MedusaRegistry registry = (MedusaRegistry) x.get("medusaRegistry");

--- a/src/foam/nanos/medusa/PurgeSink.js
+++ b/src/foam/nanos/medusa/PurgeSink.js
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.nanos.medusa',
+  name: 'PurgeSink',
+  extends: 'foam.dao.ProxySink',
+
+  documentation: `Remove old entries from MedusaEntry DAO and cleanup MedusaRegistry`,
+
+  javaImports: [
+    'foam.core.FObject',
+    'foam.core.X',
+    'foam.dao.Sink',
+    'foam.nanos.medusa.MedusaRegistry'
+  ],
+
+  axioms: [
+    {
+      name: 'javaExtras',
+      buildJavaClass: function(cls) {
+        cls.extras.push(foam.java.Code.create({
+          data: `
+  public PurgeSink(X x, Sink delegate) {
+    super(x, delegate);
+  }
+         `
+        }));
+      }
+    }
+  ],
+
+  properties: [
+    {
+      documentation: 'MedusaRegistry for the life of the Sink',
+      name: 'registry',
+      class: 'FObjectProperty',
+      of: 'foam.nanos.medusa.MedusaRegistry',
+      javaFactory: 'return (MedusaRegistry) getX().get("medusaRegistry");'
+    }
+  ],
+
+  methods: [
+    {
+      name: 'put',
+      args: [
+        {
+          name: 'obj',
+          type: 'Object'
+        },
+        {
+          name: 'sub',
+          type: 'foam.core.Detachable'
+        }
+      ],
+      javaCode: `
+      MedusaEntry entry = (MedusaEntry) obj;
+      getRegistry().notify(getX(), entry);
+      getDelegate().put(entry, sub);
+      `
+    },
+    {
+      name: 'remove',
+      javaCode: `//nop`
+    },
+    {
+      name: 'eof',
+      javaCode: `// nop`
+    },
+    {
+      name: 'reset',
+      javaCode: `//nop`
+    }
+  ]
+});

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -204,6 +204,7 @@ FOAM_FILES([
   { name: 'foam/nanos/medusa/MedusaType' },
   { name: 'foam/nanos/medusa/NodeCView' },
   { name: 'foam/nanos/medusa/PromotedPurgeAgent' },
+  { name: 'foam/nanos/medusa/PurgeSink' },
   { name: 'foam/nanos/medusa/RegionCView' },
   { name: 'foam/nanos/medusa/RegionStatus' },
   { name: 'foam/nanos/medusa/ReplayCmd' },

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -425,6 +425,7 @@ var classes = [
   'foam.nanos.medusa.MedusaUniqueDAO',
   'foam.nanos.medusa.MedusaType',
   'foam.nanos.medusa.PromotedPurgeAgent',
+  'foam.nanos.medusa.PurgeSink',
   'foam.nanos.medusa.RegionStatus',
   'foam.nanos.medusa.ReplayCmd',
   'foam.nanos.medusa.ReplayCompleteCmd',


### PR DESCRIPTION
MedusaRegistry entries on idle Secondaries and non-active Regions are never
used and the registry continues to grow.  
When purging the promoted MedusaEntry DAO also remove the same MedusaRegistry entries.

Add 'put' of primary response on the secondary to preserve storageTransient properties in the MDAOs. 