### PR TITLE
[NP-3321] Fix detailView

### DIFF
--- a/src/foam/u2/DetailPropertyView.js
+++ b/src/foam/u2/DetailPropertyView.js
@@ -64,7 +64,11 @@ foam.CLASS({
         addClass('foam-u2-PropertyView').
         addClass('foam-u2-PropertyView-prop-' + prop.name).
         start('td').addClass('foam-u2-PropertyView-label').add(this.label).end().
-        start('td').addClass('foam-u2-PropertyView-view').add(
+        start('td').addClass('foam-u2-PropertyView-view').
+        callIf( ! this.label, function() {
+          this.style({'width': '100%'});
+        }).
+        add(
           prop,
           prop.units && this.E('span').addClass('foam-u2-PropertyView-units').add(' ', prop.units)).
         end();

--- a/src/foam/u2/DetailPropertyView.js
+++ b/src/foam/u2/DetailPropertyView.js
@@ -31,7 +31,6 @@ foam.CLASS({
       padding: 4px 8px 4px 8px;
       text-align: left;
       vertical-align: top;
-      white-space: nowrap;
     }
     .foam-u2-PropertyView-view {
       padding: 2px 8px 2px 6px;

--- a/src/foam/u2/DetailView.js
+++ b/src/foam/u2/DetailView.js
@@ -124,6 +124,14 @@ foam.CLASS({
       display: flex;
       padding-top: 8px;
     }
+    
+    ^ .foam-u2-stack-StackView {
+      padding-left: 0!important;
+    }
+
+    ^ .foam-u2-CheckBox {
+      margin: 0px;
+    }
   `,
 
   /*

--- a/src/foam/u2/DetailView.js
+++ b/src/foam/u2/DetailView.js
@@ -143,7 +143,7 @@ foam.CLASS({
     }
 
     ^ table .foam-u2-tag-TextArea {
-      width: 100%;
+      max-width: 100%;
     }
   `,
 

--- a/src/foam/u2/DetailView.js
+++ b/src/foam/u2/DetailView.js
@@ -124,13 +124,17 @@ foam.CLASS({
       display: flex;
       padding-top: 8px;
     }
-    
+
     ^ .foam-u2-stack-StackView {
       padding-left: 0!important;
     }
 
     ^ .foam-u2-CheckBox {
       margin: 0px;
+    }
+
+    ^ .full-width {
+      width: 100%;
     }
   `,
 
@@ -208,8 +212,9 @@ foam.CLASS({
 
         return self.actionBorder(
           this.
-            E('table').
             addClass(this.myClass()).
+            E('table').
+            addClass('full-width').
             add(title).
             forEach(properties, function(p) {
               var config = self.config && self.config[p.name];

--- a/src/foam/u2/DetailView.js
+++ b/src/foam/u2/DetailView.js
@@ -117,7 +117,6 @@ foam.CLASS({
       display: block;
       margin: auto;
       width: 100%;
-      overflow-x: scroll;
     }
 
     ^toolbar {
@@ -133,8 +132,17 @@ foam.CLASS({
       margin: 0px;
     }
 
-    ^ .full-width {
+    ^ table {
       width: 100%;
+      table-layout: fixed;
+    }
+
+    ^ table tr td:nth-of-type(1) {
+      width: 30%;
+    }
+
+    ^ table tr td:nth-of-type(2) {
+      width: 70%;
     }
   `,
 
@@ -203,10 +211,7 @@ foam.CLASS({
         // bound to data of a new class, which causes problems.
         self.currentData = self.data;
 
-        var title = self.title && this.E('tr').
-          start('td').addClass(this.myClass('title')).attrs({ colspan: 2 }).
-            add(self.title$).
-          end();
+        self.start().addClass(self.myClass('title')).add(self.title$).end();
 
         var tabs = foam.u2.Tabs.create({}, self);
 
@@ -214,8 +219,6 @@ foam.CLASS({
           this.
             addClass(this.myClass()).
             E('table').
-            addClass('full-width').
-            add(title).
             forEach(properties, function(p) {
               var config = self.config && self.config[p.name];
               var expr = foam.mlang.Expressions.create();

--- a/src/foam/u2/DetailView.js
+++ b/src/foam/u2/DetailView.js
@@ -137,10 +137,6 @@ foam.CLASS({
       table-layout: fixed;
     }
 
-    ^ table tr td:nth-of-type(1) {
-      width: 30%;
-    }
-
     ^ table tr td:nth-of-type(2) {
       width: 70%;
     }

--- a/src/foam/u2/DetailView.js
+++ b/src/foam/u2/DetailView.js
@@ -117,22 +117,12 @@ foam.CLASS({
       display: block;
       margin: auto;
       width: 100%;
+      overflow-x: scroll;
     }
 
     ^toolbar {
       display: flex;
       padding-top: 8px;
-    }
-    ^ tbody {
-      display: grid;
-    }
-
-    ^ .foam-u2-stack-StackView {
-      padding-left: 0!important;
-    }
-
-    ^ .foam-u2-CheckBox {
-      margin: 0px;
     }
   `,
 
@@ -202,7 +192,6 @@ foam.CLASS({
         self.currentData = self.data;
 
         var title = self.title && this.E('tr').
-        style({ display: 'contents' }).
           start('td').addClass(this.myClass('title')).attrs({ colspan: 2 }).
             add(self.title$).
           end();

--- a/src/foam/u2/DetailView.js
+++ b/src/foam/u2/DetailView.js
@@ -122,14 +122,7 @@ foam.CLASS({
     ^toolbar {
       display: flex;
       padding-top: 8px;
-    }
-
-    ^ .foam-u2-stack-StackView {
-      padding-left: 0!important;
-    }
-
-    ^ .foam-u2-CheckBox {
-      margin: 0px;
+      flex-wrap: wrap;
     }
 
     ^ table {
@@ -139,6 +132,18 @@ foam.CLASS({
 
     ^ table tr td:nth-of-type(2) {
       width: 70%;
+    }
+
+    ^ table .foam-u2-stack-StackView {
+      padding-left: 0 !important;
+    }
+
+    ^ table .foam-u2-CheckBox {
+      margin: 0px;
+    }
+
+    ^ table .foam-u2-tag-TextArea {
+      width: 100%;
     }
   `,
 


### PR DESCRIPTION
**nanopay pr:** https://github.com/nanoPayinc/NANOPAY/pull/11825 

**address**: 
- fix detailView to display table correctly
- related tickets -> https://nanopay.atlassian.net/browse/NP-3452, https://nanopay.atlassian.net/browse/NP-3321

**Summary:**
- move title out of the table (this allows adjusting column widths)
- set width for the left and right column
- make contents span whole row if there is no label
- wrap label text if too long

<img width="1917" alt="Screen Shot 2021-02-04 at 4 40 32 PM" src="https://user-images.githubusercontent.com/58435071/106959748-19ca7f80-6709-11eb-9076-272cf0b0519d.png">
<img width="1920" alt="Screen Shot 2021-02-04 at 4 40 56 PM" src="https://user-images.githubusercontent.com/58435071/106959752-1b944300-6709-11eb-8c04-a5dbadd475e9.png">
<img width="1917" alt="Screen Shot 2021-02-04 at 4 41 10 PM" src="https://user-images.githubusercontent.com/58435071/106959761-1df69d00-6709-11eb-9451-56a29329a750.png">
<img width="1918" alt="Screen Shot 2021-02-04 at 4 41 20 PM" src="https://user-images.githubusercontent.com/58435071/106959771-1fc06080-6709-11eb-9066-838287c39c1d.png">
<img width="961" alt="Screen Shot 2021-02-04 at 4 41 34 PM" src="https://user-images.githubusercontent.com/58435071/106959776-218a2400-6709-11eb-9b5f-ff1addef0114.png">
<img width="1919" alt="Screen Shot 2021-02-04 at 4 41 44 PM" src="https://user-images.githubusercontent.com/58435071/106959777-22bb5100-6709-11eb-9ce2-17e3d4887db0.png">



