### PR TITLE
Refactor compound exception

### DIFF
--- a/src/foam/core/CompoundException.js
+++ b/src/foam/core/CompoundException.js
@@ -42,12 +42,6 @@ foam.CLASS({
   properties:  [
     {
       class: 'Object',
-      name: 'exceptions',
-      javaType: 'ArrayList',
-      javaFactory: 'return new ArrayList<RuntimeException>();'
-    },
-    {
-      class: 'Object',
       name: 'sb',
       javaType: 'ThreadLocal',
       javaFactory: `
@@ -69,6 +63,11 @@ foam.CLASS({
 
   methods:  [
     {
+      name: 'getExceptions',
+      type: 'Throwable[]',
+      javaCode: 'return getSuppressed();'
+    },
+    {
       // TODO: cloning this property from ExceptionInterface creates a bug.
       name: 'getClientRethrowException',
       documentation:
@@ -83,11 +82,10 @@ foam.CLASS({
       type: 'RuntimeException',
       visibility: 'public',
       javaCode: `
-        ArrayList<RuntimeException> exceptions = getExceptions();
-        for ( RuntimeException re : exceptions ) {
-          if ( re instanceof ExceptionInterface ) {
+        for ( var t : getExceptions() ) {
+          if ( t instanceof ExceptionInterface ) {
             RuntimeException clientE =
-                ((ExceptionInterface) re).getClientRethrowException();
+                ((ExceptionInterface) t).getClientRethrowException();
             if ( clientE != null ) {
               return clientE;
             }
@@ -98,7 +96,7 @@ foam.CLASS({
     {
       name: 'add',
       args: [{ name: 't', javaType: 'Throwable' }],
-      javaCode: 'getExceptions().add(t);'
+      javaCode: 'addSuppressed(t);'
     },
     {
       name: 'maybeThrow',
@@ -109,10 +107,10 @@ foam.CLASS({
       type: 'String',
       javaCode: `
         StringBuilder str = (StringBuilder) getSb().get();
-        var size = getExceptions().size();
+        var size = getExceptions().length;
 
         for ( int i = 0; i < size; i++ ) {
-          Throwable t = (Throwable) getExceptions().get(i);
+          var t = getExceptions()[i];
           var counter = i + 1;
 
           str.append('[')

--- a/src/foam/core/CompoundException.js
+++ b/src/foam/core/CompoundException.js
@@ -97,11 +97,11 @@ foam.CLASS({
       name: 'add',
       args: [{ name: 't', javaType: 'Throwable' }],
       javaCode: `
-        for ( var e : t.getSuppressed() ) {
-          add(e);
-        }
-
-        if ( t.getSuppressed().length == 0 ) {
+        if ( t instanceof CompoundException ) {
+          for ( var e : t.getSuppressed() ) {
+            add(e);
+          }
+        } else {
           addSuppressed(t);
         }
       `

--- a/src/foam/core/CompoundException.js
+++ b/src/foam/core/CompoundException.js
@@ -100,7 +100,14 @@ foam.CLASS({
     },
     {
       name: 'maybeThrow',
-      javaCode: 'if ( getExceptions().size() != 0 ) throw this;'
+      javaCode: `
+        if ( getExceptions().length == 1 ) {
+          throw getExceptions()[0] instanceof RuntimeException
+            ? (RuntimeException) getExceptions()[0] : this;
+        }
+
+        if ( getExceptions().length >= 2 ) throw this;
+      `
     },
     {
       name: 'getMessage',

--- a/src/foam/core/CompoundException.js
+++ b/src/foam/core/CompoundException.js
@@ -96,7 +96,15 @@ foam.CLASS({
     {
       name: 'add',
       args: [{ name: 't', javaType: 'Throwable' }],
-      javaCode: 'addSuppressed(t);'
+      javaCode: `
+        for ( var e : t.getSuppressed() ) {
+          add(e);
+        }
+
+        if ( t.getSuppressed().length == 0 ) {
+          addSuppressed(t);
+        }
+      `
     },
     {
       name: 'maybeThrow',

--- a/src/foam/core/ValidationException.js
+++ b/src/foam/core/ValidationException.js
@@ -7,7 +7,7 @@ foam.CLASS({
   package: 'foam.core',
   name: 'ValidationException',
   extends: 'foam.core.FOAMException',
-  implements: ['foam.core.Exception'],
+  implements: ['foam.core.ExceptionInterface'],
   javaGenerateConvenienceConstructor: false,
 
   properties: [


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-3526

## Changes
- Use Throwable.suppressed on CompoundException instead of array property
- Throw underlying exception for single-item compound exception
- Implement ExceptionInterface instead of Exception as it already has implemented getClientRethrowException() 