### PR TITLE
[NP-3529] - Empty RegionDAO Fix

### DIFF
--- a/src/foam/u2/view/ChoiceView.js
+++ b/src/foam/u2/view/ChoiceView.js
@@ -298,7 +298,6 @@ foam.CLASS({
         var self = this;
         var seq = ++this.seq_;
         var dao = this.dao;
-        console.log(this.$UID);
         if ( ! foam.dao.DAO.isInstance(this.dao) ) return;
 
         var of = this.dao.of


### PR DESCRIPTION
Ref: https://nanopay.atlassian.net/browse/NP-3529

Description: Even though the order of the regionDAO requests was correct, we noticed that the promise resolution occurred in reverse at times, LIFO, causing the correct choices to be overwritten with []. Adding a sequence number that increments every time onDAOUpdate gets called ensures that any straggler promises that resolve from a stale state get ignored.