### PR TITLE
[NP-3606] ServiceProviderAwareDAO - use Subject.user rather than realUser

### DIFF
--- a/src/foam/nanos/auth/ServiceProviderAwareDAO.js
+++ b/src/foam/nanos/auth/ServiceProviderAwareDAO.js
@@ -106,7 +106,7 @@ foam.CLASS({
       String spid = (String) x.get("spid");
       Subject subject = (Subject) x.get("subject");
       if ( subject != null ) {
-        user = subject.getRealUser();
+        user = subject.getUser();
         if ( user != null ) {
           if ( ! SafetyUtil.isEmpty(user.getSpid()) ) {
              spid = user.getSpid();


### PR DESCRIPTION
ServiceProviderAwareDAO - in getSpid test spid of Subject.user rather than Subject.realUser