### PR TITLE
JSONFObjectFormatter - skip output if property.get(o) equals o.

### DIFF
--- a/src/foam/lib/formatter/JSONFObjectFormatter.java
+++ b/src/foam/lib/formatter/JSONFObjectFormatter.java
@@ -297,7 +297,9 @@ public class JSONFObjectFormatter
     if ( ! outputDefaultValues_ && ! prop.isSet(fo) ) return false;
 
     Object value = prop.get(fo);
-    if ( value == null || ( isArray(value) && Array.getLength(value) == 0 ) ) {
+    if ( value == null ||
+         ( isArray(value) && Array.getLength(value) == 0 ) ||
+         ( value instanceof FObject && value.equals(fo) ) ) {
       return false;
     }
 


### PR DESCRIPTION
This occurs with mixins if the mixin is simply an interface
which adds helper properties returning or manipulating the
original object.