### PR TITLE
Update enum style + cj status colour

### DIFF
--- a/src/foam/core/Enum.js
+++ b/src/foam/core/Enum.js
@@ -338,7 +338,11 @@ foam.CLASS({
     },
     function toSummary() { return this.label; },
     function toStyle() {
-      var style = {};
+      var style = {
+        'display': 'inline-block',
+        'border-radius': '50px',
+        'padding': '4px 12px'
+      };
 
       if ( this.color      ) style.color          = this.color;
       if ( this.background ) style.background     = this.background;

--- a/src/foam/nanos/crunch/CapabilityJunctionStatus.js
+++ b/src/foam/nanos/crunch/CapabilityJunctionStatus.js
@@ -25,8 +25,8 @@ foam.ENUM({
       name: 'EXPIRED',
       label: { en: 'expired', pt: 'expirada'},
       documentation: 'The information required has changed, or your inputs are no longer valid',
-      background: '#F79393',
-      color: '#631414'
+      background: '#FBE88F',
+      color: '#816819'
     },
     {
       name: 'ACTION_REQUIRED',

--- a/src/foam/nanos/crunch/CapabilityJunctionStatus.js
+++ b/src/foam/nanos/crunch/CapabilityJunctionStatus.js
@@ -59,5 +59,16 @@ foam.ENUM({
       Capable object junctions.`,
       background: '#bfae32'
     },
+  ],
+
+  methods: [
+    function toStyle() {
+      return {
+        'display': 'inline-block',
+        'background': this.background,
+        'border-radius': '50px',
+        'padding': '4px 12px'
+      }
+    }
   ]
 });

--- a/src/foam/nanos/crunch/CapabilityJunctionStatus.js
+++ b/src/foam/nanos/crunch/CapabilityJunctionStatus.js
@@ -59,16 +59,5 @@ foam.ENUM({
       Capable object junctions.`,
       background: '#bfae32'
     },
-  ],
-
-  methods: [
-    function toStyle() {
-      return {
-        'display': 'inline-block',
-        'background': this.background,
-        'border-radius': '50px',
-        'padding': '4px 12px'
-      }
-    }
   ]
 });

--- a/src/foam/nanos/crunch/CapabilityJunctionStatus.js
+++ b/src/foam/nanos/crunch/CapabilityJunctionStatus.js
@@ -11,45 +11,52 @@ foam.ENUM({
       name: 'PENDING',
       label: { en: 'pending', pt: 'pendente'},
       documentation: 'Our team is currently reviewing. Approvals may take up to 24 hours',
-      background: '#bfae32'
+      background: '#E7EAEC',
+      color: '#1E1F21'
     },
     {
       name: 'GRANTED',
       label: { en: 'granted', pt: 'concedida'},
       documentation: 'The information you provided has been approved',
-      background: '#32bf5e'
+      background: '#E2F2DD',
+      color: '#19402E'
     },
     {
       name: 'EXPIRED',
       label: { en: 'expired', pt: 'expirada'},
       documentation: 'The information required has changed, or your inputs are no longer valid',
-      background: '#bf3232'
+      background: '#F79393',
+      color: '#631414'
     },
     {
       name: 'ACTION_REQUIRED',
       label: { en: 'action required', pt: 'ação requerida'},
       documentation: 'Information is missing for required fields',
-      background: '#cf6f0a'
+      background: '#FBE88F',
+      color: '#816819'
     },
     {
       name: 'AVAILABLE',
       label: { en: 'available', pt: 'acessível'},
       documentation: 'You are ready to get started',
-      background: '#604aff'
+      background: '#A7BEFF',
+      color: '#202341'
     },
     {
       name: 'APPROVED',
       label: { en: 'approved', pt: 'aprovada'},
       documentation: `- not seen by users - Denoting a UCJ requiring review has been approved. It would need to go through the rules of the ucjDAO before
       being set to granted.`,
-      background: '#bfae32',
+      background: '#E2F2DD',
+      color: '#19402E',
       ordinal: 6
     },
     {
       name: 'PENDING_REVIEW',
       label: { en: 'pending review', pt: 'revisão pendente' },
       documentation: 'The information you provided is pending review',
-      background: '#bfae32'
+      background: '#FBE88F',
+      color: '#816819'
     },
     {
       name: 'REJECTED',
@@ -57,7 +64,8 @@ foam.ENUM({
       documentation: `- not seen by users - Denoting a junction requiring review has been rejected. Meant to mark items in a FINAL rejected state where it is not 
       expected to go to EXPIRED and have the user fill out more info. Used in the 
       Capable object junctions.`,
-      background: '#bfae32'
+      background: '#F79393',
+      color: '#631414'
     },
   ]
 });

--- a/src/foam/u2/crunch/CapabilityFeatureView.js
+++ b/src/foam/u2/crunch/CapabilityFeatureView.js
@@ -119,7 +119,10 @@ foam.CLASS({
                 .add(isRenewable ? "Capability is renewable" : "")
               .end()
               .add(cjStatus.label).addClass(style.myClass('badge'))
-              .style({ 'background-color': cjStatus.background });
+              .style({
+                'background-color': cjStatus.background,
+                'color': cjStatus.color
+              });
           }))
         .end()
         .start()


### PR DESCRIPTION
**Summary:** 
- Set default style for enums
- Update text colour and background colour for capability junction status

**Before:**

![Screen Shot 2021-02-17 at 12 57 51 PM](https://user-images.githubusercontent.com/58435071/108246731-cb14e080-711f-11eb-88b4-3fbd4616f32a.png)
![Screen Shot 2021-02-17 at 12 57 58 PM](https://user-images.githubusercontent.com/58435071/108246736-cbad7700-711f-11eb-9104-0213a324f54d.png)



**After:**

![Screen Shot 2021-02-17 at 2 42 41 PM](https://user-images.githubusercontent.com/58435071/108258888-804e9500-712e-11eb-9c76-31caca28c35d.png)
![Screen Shot 2021-02-17 at 2 42 24 PM](https://user-images.githubusercontent.com/58435071/108258917-880e3980-712e-11eb-8717-22e808712b5d.png)
![Screen Shot 2021-02-17 at 2 42 32 PM](https://user-images.githubusercontent.com/58435071/108258921-88a6d000-712e-11eb-884a-cf02042cc296.png)
![Screen Shot 2021-02-17 at 2 43 03 PM](https://user-images.githubusercontent.com/58435071/108258926-893f6680-712e-11eb-98b6-6859c233b1c6.png)

