### PR TITLE
Capability changing to status predicate

### DIFF
--- a/src/foam/nanos/crunch/predicate/CapabilityJunctionTransistionToStatus.js
+++ b/src/foam/nanos/crunch/predicate/CapabilityJunctionTransistionToStatus.js
@@ -1,7 +1,11 @@
-
+/**
+ * @license
+ * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
 
 foam.CLASS({
-  package: 'net.nanopay.crunch.compliance',
+  package: 'foam.nanos.crunch.predicate',
   name: 'CapabilityJunctionTransistionToStatus',
   extends: 'foam.mlang.predicate.AbstractPredicate',
   implements: ['foam.core.Serializable'],
@@ -40,12 +44,12 @@ foam.CLASS({
       javaCode: `
         X x = (X) obj;
         UserCapabilityJunction old = (UserCapabilityJunction) x.get("OLD");
-        UserCapabilityJunction new = (UserCapabilityJunction) x.get("NEW");
+        UserCapabilityJunction ucj = (UserCapabilityJunction) x.get("NEW");
 
         return old != null &&
-            ! old.getStatus().equals(new.getStatus()) &&
-            new.getStatus().equals(getStatus()) &&
-            new.getTargetId().equals(getCapabilityId());
+            ! old.getStatus().equals(ucj.getStatus()) &&
+            ucj.getStatus().equals(getStatus()) &&
+            ucj.getTargetId().equals(getCapabilityId());
       `
     }
   ]

--- a/src/foam/nanos/crunch/predicate/CapabilityJunctionTransistionToStatus.js
+++ b/src/foam/nanos/crunch/predicate/CapabilityJunctionTransistionToStatus.js
@@ -1,0 +1,52 @@
+
+
+foam.CLASS({
+  package: 'net.nanopay.crunch.compliance',
+  name: 'CapabilityJunctionTransistionToStatus',
+  extends: 'foam.mlang.predicate.AbstractPredicate',
+  implements: ['foam.core.Serializable'],
+  
+  documentation: `Returns true if the capability of the ucj submitted is transistioning to status defined.`,
+  
+  javaImports: [
+    'foam.core.X',
+    'foam.dao.DAO',
+    'foam.nanos.crunch.CapabilityJunctionStatus',
+    'foam.nanos.crunch.UserCapabilityJunction',
+    'static foam.mlang.MLang.*'
+  ],
+
+  properties: [
+    {
+      class: 'Reference',
+      name: 'capabilityId',
+      of: 'foam.nanos.crunch.Capability',
+      documentation: `Used to catch any ucj's with their targetId equaling this value.`
+    },
+    {
+      name: 'status',
+      class: 'Enum',
+      of: 'foam.nanos.crunch.CapabilityJunctionStatus',
+      documentation: `Status to check compare to the new ucj's status. (ie. ucj's transistion to status provided.)`,
+      javaFactory: `
+        return foam.nanos.crunch.CapabilityJunctionStatus.PENDING;
+      `
+    }
+  ],
+
+  methods: [
+    {
+      name: 'f',
+      javaCode: `
+        X x = (X) obj;
+        UserCapabilityJunction old = (UserCapabilityJunction) x.get("OLD");
+        UserCapabilityJunction new = (UserCapabilityJunction) x.get("NEW");
+
+        return old != null &&
+            ! old.getStatus().equals(new.getStatus()) &&
+            new.getStatus().equals(getStatus()) &&
+            new.getTargetId().equals(getCapabilityId());
+      `
+    }
+  ]
+});

--- a/src/foam/nanos/crunch/predicate/CapabilityJunctionTransitionToStatus.js
+++ b/src/foam/nanos/crunch/predicate/CapabilityJunctionTransitionToStatus.js
@@ -6,11 +6,11 @@
 
 foam.CLASS({
   package: 'foam.nanos.crunch.predicate',
-  name: 'CapabilityJunctionTransistionToStatus',
+  name: 'CapabilityJunctionTransitionToStatus',
   extends: 'foam.mlang.predicate.AbstractPredicate',
   implements: ['foam.core.Serializable'],
   
-  documentation: `Returns true if the capability of the ucj submitted is transistioning to status defined.`,
+  documentation: `Returns true if the capability of the ucj submitted is transitioning to status defined.`,
   
   javaImports: [
     'foam.core.X',
@@ -31,7 +31,7 @@ foam.CLASS({
       name: 'status',
       class: 'Enum',
       of: 'foam.nanos.crunch.CapabilityJunctionStatus',
-      documentation: `Status to check compare to the new ucj's status. (ie. ucj's transistion to status provided.)`,
+      documentation: `Status to check compare to the new ucj's status. (ie. ucj's transition to status provided.)`,
       javaFactory: `
         return foam.nanos.crunch.CapabilityJunctionStatus.PENDING;
       `

--- a/src/foam/nanos/crunch/predicate/CapabilityJunctionTransitionToStatus.js
+++ b/src/foam/nanos/crunch/predicate/CapabilityJunctionTransitionToStatus.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 The FOAM Authors. All Rights Reserved.
+ * Copyright 2021 The FOAM Authors. All Rights Reserved.
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
@@ -47,9 +47,9 @@ foam.CLASS({
         UserCapabilityJunction ucj = (UserCapabilityJunction) x.get("NEW");
 
         return old != null &&
-            ! old.getStatus().equals(ucj.getStatus()) &&
-            ucj.getStatus().equals(getStatus()) &&
-            ucj.getTargetId().equals(getCapabilityId());
+            ! old.getStatus() == ucj.getStatus() &&
+            ucj.getStatus() == getStatus() &&
+            ucj.getTargetId() == getCapabilityId();
       `
     }
   ]

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -484,6 +484,7 @@ FOAM_FILES([
   { name: 'foam/nanos/crunch/predicate/CapabilityPrerequisitesGranted' },
   { name: 'foam/nanos/crunch/predicate/StatusChangedTo' },
   { name: 'foam/nanos/crunch/predicate/IsAgent' },
+  { name: 'foam/nanos/crunch/predicate/CapabilityJunctionTransistionToStatus' },
   //spid
   { name: "foam/nanos/auth/CreateUserCapabilityJunctionOnSpidSet" },
   { name: "foam/nanos/auth/SetUserServiceProviderJunctionRuleAction" },

--- a/src/foam/nanos/nanos.js
+++ b/src/foam/nanos/nanos.js
@@ -484,7 +484,7 @@ FOAM_FILES([
   { name: 'foam/nanos/crunch/predicate/CapabilityPrerequisitesGranted' },
   { name: 'foam/nanos/crunch/predicate/StatusChangedTo' },
   { name: 'foam/nanos/crunch/predicate/IsAgent' },
-  { name: 'foam/nanos/crunch/predicate/CapabilityJunctionTransistionToStatus' },
+  { name: 'foam/nanos/crunch/predicate/CapabilityJunctionTransitionToStatus' },
   //spid
   { name: "foam/nanos/auth/CreateUserCapabilityJunctionOnSpidSet" },
   { name: "foam/nanos/auth/SetUserServiceProviderJunctionRuleAction" },

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -845,7 +845,7 @@ var classes = [
   'foam.nanos.crunch.predicate.CapabilityPrerequisitesGranted',
   'foam.nanos.crunch.predicate.StatusChangedTo',
   'foam.nanos.crunch.predicate.IsAgent',
-  'foam.nanos.crunch.predicate.CapabilityJunctionTransistionToStatus',
+  'foam.nanos.crunch.predicate.CapabilityJunctionTransitionToStatus',
 
   //authservice
   'foam.nanos.auth.CapabilityAuthService',

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -845,6 +845,7 @@ var classes = [
   'foam.nanos.crunch.predicate.CapabilityPrerequisitesGranted',
   'foam.nanos.crunch.predicate.StatusChangedTo',
   'foam.nanos.crunch.predicate.IsAgent',
+  'foam.nanos.crunch.predicate.CapabilityJunctionTransistionToStatus',
 
   //authservice
   'foam.nanos.auth.CapabilityAuthService',


### PR DESCRIPTION
Rule predicate to make things easier when looking for a ucj capability status transistion.

Similar to IsCapabilityOfCertainCategoryAndStatus except predicate checks specified capability.