### PR TITLE
CachingAuthService - if subject.user null return empty cache.

### DIFF
--- a/src/foam/nanos/auth/CachingAuthService.java
+++ b/src/foam/nanos/auth/CachingAuthService.java
@@ -64,6 +64,10 @@ public class CachingAuthService
     Subject subject = (Subject) x.get("subject");
     User    user    = subject.getUser();
 
+    if ( user == null ) {
+      return new ConcurrentHashMap<String,Boolean>();
+    }
+
     // If the user in the context does not match the session user, do not use the
     // cache permission map, which belong to session user
     Long contextUserId = user.getId();


### PR DESCRIPTION
service/threads requires permission service.run.threads and prompts for login.
On admin login, access is denied. 
AuthWebAgent calls auth.check with session.getContext() which does not have the 'admin' user.
During troubleshooting - walk the auth proxy chain calling check on each auth service. The CachingAuthService fails with NPE on dereference of Subject.user, which is null.    If an empty cache is returned when user is null, then the admin access to service/threads succeeds. 