### PR TITLE
Update emailTemplates body view + detailView

### DIFF
--- a/src/foam/nanos/notification/email/EmailTemplate.js
+++ b/src/foam/nanos/notification/email/EmailTemplate.js
@@ -48,7 +48,13 @@ foam.CLASS({
       class: 'String',
       name: 'body',
       documentation: 'Template body',
-      view: { class: 'foam.u2.tag.TextArea', rows: 40, cols: 150 }
+      view: {
+        class: 'foam.u2.MultiView',
+        views: [
+          { class: 'foam.u2.HTMLView' },
+          { class: 'foam.u2.tag.TextArea', rows: 40, cols: 150}
+        ]
+      }
     },
     {
       class: 'String',

--- a/src/foam/u2/DetailView.js
+++ b/src/foam/u2/DetailView.js
@@ -141,7 +141,7 @@ foam.CLASS({
      */
 
     ^ table .foam-u2-stack-StackView {
-      padding-left: 0;
+      padding-left: 0 !important;
     }
 
     ^ table .foam-u2-tag-TextArea {

--- a/src/foam/u2/DetailView.js
+++ b/src/foam/u2/DetailView.js
@@ -135,16 +135,21 @@ foam.CLASS({
       width: 70%;
     }
 
-    ^ table .foam-u2-stack-StackView {
-      padding-left: 0 !important;
-    }
+    
+    /* 
+     * Styles for table contents 
+     */
 
-    ^ table .foam-u2-CheckBox {
-      margin: 0px;
+    ^ table .foam-u2-stack-StackView {
+      padding-left: 0;
     }
 
     ^ table .foam-u2-tag-TextArea {
       max-width: 100%;
+    }
+
+    ^ table .foam-u2-Multiview-container[style*="float"] .foam-u2-tag-TextArea {
+      width: 100%;
     }
   `,
 


### PR DESCRIPTION
summary: 
1. Make email templates editable in detailview. credit to @Nauna 
2. Update detailView to display the email template body view nicely when overflowing
![Screen Shot 2021-02-23 at 2 40 34 PM](https://user-images.githubusercontent.com/58435071/108898658-72dd5300-75e5-11eb-83e2-fde54fb78560.png)
![Screen Shot 2021-02-23 at 2 40 47 PM](https://user-images.githubusercontent.com/58435071/108898662-74a71680-75e5-11eb-8cd9-ff84728b8b02.png)

