### PR TITLE
Support switching to user on other SPID

### DIFF
--- a/src/foam/nanos/auth/CapabilityAuthService.js
+++ b/src/foam/nanos/auth/CapabilityAuthService.js
@@ -148,7 +148,8 @@ foam.CLASS({
           null :
           user.getId() + ":" + realUser.getId() + permission;
         String userKey = user.getId() + permission;
-        String realUserKey = realUser.getId() == user.getId() ? null : realUser.getId() + permission;
+        String realUserKey = realUser.getId() == user.getId() ? null
+          : (realUser.getSpid().equals(user.getSpid()) ? realUser.getId() + permission : null);
         this.initialize(x);
 
         Boolean result = ( (Map<String, Boolean>) getCache() ).get(userKey);

--- a/src/foam/nanos/auth/CapabilityAuthService.js
+++ b/src/foam/nanos/auth/CapabilityAuthService.js
@@ -42,63 +42,7 @@ foam.CLASS({
     'static foam.mlang.MLang.*'
   ],
 
-  properties: [
-    {
-      class: 'Map',
-      name: 'cache',
-      javaFactory: `
-        return new ConcurrentHashMap<String, Boolean>();
-      `
-    },
-    {
-      name: 'initialized',
-      class: 'Boolean',
-      value: false
-    }
-  ],
-
   methods: [
-    {
-      name: 'initialize',
-      synchronized: true,
-      args: [
-        {
-          name: 'x',
-          type: 'Context'
-        },
-      ],
-      javaCode: `
-        if ( getInitialized() )
-          return;
-
-        DAO userCapabilityJunctionDAO = (DAO) getX().get("userCapabilityJunctionDAO");
-        DAO capabilityDAO = (DAO) getX().get("localCapabilityDAO");
-        if ( capabilityDAO == null || userCapabilityJunctionDAO == null )
-          return;
-
-        Map<String, Boolean> cache = ( Map<String, Boolean> ) getCache();
-        Sink purgeSink = new Sink() {
-          public void put(Object obj, Detachable sub) {
-            cache.clear();
-          }
-          public void remove(Object obj, Detachable sub) {
-            cache.clear();
-          }
-          public void eof() {
-          }
-          public void reset(Detachable sub) {
-            cache.clear();
-          }
-        };
-
-        // Add the purge listener
-        userCapabilityJunctionDAO.listen(purgeSink, TRUE);
-        capabilityDAO.listen(purgeSink, TRUE);
-
-        // Initialization done
-        setInitialized(true);
-      `
-    },
     {
       name: 'check',
       documentation: `
@@ -150,17 +94,6 @@ foam.CLASS({
         String userKey = user.getId() + permission;
         String realUserKey = realUser.getId() == user.getId() ? null
           : (realUser.getSpid().equals(user.getSpid()) ? realUser.getId() + permission : null);
-        this.initialize(x);
-
-        Boolean result = ( (Map<String, Boolean>) getCache() ).get(userKey);
-        if ( realUserKey != null ) result = result == null || ! result ?  ( (Map<String, Boolean>) getCache() ).get(realUserKey) : result;
-        if ( associationKey != null ) result = result == null || ! result ?  ( (Map<String, Boolean>) getCache() ).get(associationKey) : result;
-        if ( result != null ) {
-          if ( ! result ) maybeIntercept(x, permission);
-          return result;
-        }
-
-        result = false;
 
         try {
           DAO capabilityDAO = ( x.get("localCapabilityDAO") == null ) ? (DAO) x.get("capabilityDAO") : (DAO) x.get("localCapabilityDAO");
@@ -190,11 +123,6 @@ foam.CLASS({
             EQ(UserCapabilityJunction.SOURCE_ID, user.getId())
           );
           if ( userCapabilityJunctionDAO.find(AND(userPredicate, capabilityScope, predicate)) != null ) {
-            result = true;
-          }
-
-          (( Map<String, Boolean> ) getCache()).put(userKey, result);
-          if ( result ) {
             return true;
           }
 
@@ -205,11 +133,6 @@ foam.CLASS({
               EQ(UserCapabilityJunction.SOURCE_ID, realUser.getId())
             );
             if ( userCapabilityJunctionDAO.find(AND(userPredicate, capabilityScope, predicate)) != null ) {
-              result = true;
-            }
-
-            (( Map<String, Boolean> ) getCache()).put(realUserKey, result);
-            if ( result ) {
               return true;
             }
           }
@@ -222,11 +145,6 @@ foam.CLASS({
               EQ(AgentCapabilityJunction.EFFECTIVE_USER, user.getId())
             );
             if ( userCapabilityJunctionDAO.find(AND(userPredicate, capabilityScope, predicate)) != null ) {
-              result = true;
-            }
-
-            (( Map<String, Boolean> ) getCache()).put(associationKey, result);
-            if ( result ) {
               return true;
             }
           }


### PR DESCRIPTION
## Ref
- https://nanopay.atlassian.net/browse/NP-3302

## Changes
- Do not check real user capabilities when switching to user on other SPID
- Remove cache in CapabilityAuthService since the CachingAuthService already handle the caching logic

## Benchmark auth.check(x, "capability.interceptedpermission")
- With the change

      N: 100, Time: 0.102965085 (s)
      N: 1000, Time: 0.921998215 (s)
      N: 10000, Time: 7.737831602 (s)
      N: 100000, Time: 72.513942824 (s)
      N: 1000000, Time: 761.028481946 (s)

- Without the change

      N: 100, Time: 0.07837204 (s)
      N: 1000, Time: 0.457370068 (s)
      N: 10000, Time: 2.666314658 (s)
      N: 100000, Time: 23.676882383 (s)
      N: 1000000, Time: 234.789159137 (s)
