### PR TITLE
[NP-3673] set locale to email templates

### DIFF
--- a/src/foam/nanos/auth/email/EmailVerificationWebAgent.js
+++ b/src/foam/nanos/auth/email/EmailVerificationWebAgent.js
@@ -88,7 +88,12 @@ foam.CLASS({
           EmailTemplateEngine templateEngine = (EmailTemplateEngine) x.get("templateEngine");
           HashMap args = new HashMap();
           args.put("msg", message);
-          EmailTemplate emailTemplate = DAOResourceLoader.findTemplate(x, "verify-email-link", (String) user.getGroup());
+          EmailTemplate emailTemplate = DAOResourceLoader.findTemplate(
+            x,
+            "verify-email-link",
+            (String) user.getGroup(),
+            user.getLanguage().getCode().toString()
+          );
           StringBuilder templateBody = templateEngine.renderTemplate(x, emailTemplate.getBody(), args);
           out.write(templateBody.toString());
           if ( ! redirect.equals("null") ){

--- a/src/foam/nanos/notification/email/DAOResourceLoader.java
+++ b/src/foam/nanos/notification/email/DAOResourceLoader.java
@@ -28,7 +28,7 @@ public class DAOResourceLoader
     extends ContextAwareSupport
     implements ResourceLoader
 {
-  public static EmailTemplate findTemplate(X x, String name, String groupId) {
+  public static EmailTemplate findTemplate(X x, String name, String groupId, String locale) {
     DAO groupDAO = (DAO) x.get("groupDAO");
     DAO emailTemplateDAO = (DAO) x.get("localEmailTemplateDAO");
 
@@ -37,7 +37,8 @@ public class DAOResourceLoader
         .find(
               AND(
                   EQ(EmailTemplate.NAME, name),
-                  EQ(EmailTemplate.GROUP, ! SafetyUtil.isEmpty(groupId) ? groupId : "*")
+                  EQ(EmailTemplate.GROUP, ! SafetyUtil.isEmpty(groupId) ? groupId : "*"),
+                  EQ(EmailTemplate.LOCALE, locale)
                   ));
 
       if ( emailTemplate != null ) {
@@ -57,10 +58,12 @@ public class DAOResourceLoader
   }
 
   protected String groupId_;
+  protected String locale_;
 
-  public DAOResourceLoader(X x, String groupId) {
+  public DAOResourceLoader(X x, String groupId, String locale) {
     setX(x);
     this.groupId_ = groupId;
+    this.locale_ = locale;
   }
 
   @Override
@@ -70,7 +73,7 @@ public class DAOResourceLoader
 
   @Override
   public InputStream load(String s) {
-    EmailTemplate template = DAOResourceLoader.findTemplate(getX(), s, this.groupId_);
+    EmailTemplate template = DAOResourceLoader.findTemplate(getX(), s, this.groupId_, this.locale_);
     return template == null ? null : new ByteArrayInputStream(template.getBodyAsByteArray());
   }
 
@@ -78,7 +81,7 @@ public class DAOResourceLoader
   public boolean exists(String s) {
     return load(s) != null;
   }
-
+  
   @Override
   public Optional<URL> toUrl(String s) {
     return Optional.absent();

--- a/src/foam/nanos/notification/email/EmailTemplate.js
+++ b/src/foam/nanos/notification/email/EmailTemplate.js
@@ -22,7 +22,7 @@ foam.CLASS({
     'java.nio.charset.StandardCharsets'
   ],
 
-  tableColumns: ['id', 'name', 'group'],
+  tableColumns: ['id', 'name', 'group', 'locale'],
 
   properties: [
     {
@@ -38,6 +38,11 @@ foam.CLASS({
       class: 'String',
       name: 'group',
       value: '*'
+    },
+    {
+      class: 'String',
+      name: 'locale',
+      value: 'en'
     },
     {
       class: 'String',

--- a/src/foam/nanos/notification/email/EmailTemplateApplyEmailPropertyService.js
+++ b/src/foam/nanos/notification/email/EmailTemplateApplyEmailPropertyService.js
@@ -36,8 +36,10 @@ foam.CLASS({
       String templateName = (String)templateArgs.get("template");
       if ( SafetyUtil.isEmpty(templateName) ) return emailMessage;
 
+      String locale = (String) templateArgs.get("locale");
+
       // STEP 1) Find EmailTemplate
-      EmailTemplate emailTemplateObj = DAOResourceLoader.findTemplate(x, templateName, group);
+      EmailTemplate emailTemplateObj = DAOResourceLoader.findTemplate(x, templateName, group, locale);
       if ( emailTemplateObj == null ) {
         logger.error(this.getClass().getSimpleName(), "EmailTemplate not found", templateName, group);
         return emailMessage;

--- a/src/foam/util/Emails/EmailsUtility.java
+++ b/src/foam/util/Emails/EmailsUtility.java
@@ -109,22 +109,26 @@ public class EmailsUtility {
         templateArgs = new HashMap<>();
         templateArgs.put("template", templateName);
       }
+
+      String url = appConfig.getUrl().replaceAll("/$", "");
+      templateArgs.put("logo", (url + "/" + theme.getLogo()));
+      templateArgs.put("appLink", url);
+      templateArgs.put("appName", (theme.getAppName()));
+
+      templateArgs.put("locale", user.getLanguage().getCode().toString());
+  
+      foam.nanos.auth.Address address = supportConfig.getSupportAddress();
+      templateArgs.put("supportAddress", address == null ? "" : address.toSummary());
       templateArgs.put("supportPhone", (supportConfig.getSupportPhone()));
       templateArgs.put("supportEmail", (supportConfig.getSupportEmail()));
-
+  
       // personal support user
       User psUser = supportConfig.findPersonalSupportUser(x);
       templateArgs.put("personalSupportPhone", psUser == null ? "" : psUser.getPhoneNumber());
       templateArgs.put("personalSupportEmail", psUser == null ? "" : psUser.getEmail());
       templateArgs.put("personalSupportFirstName", psUser == null ? "" : psUser.getFirstName());
       templateArgs.put("personalSupportFullName", psUser == null ? "" : psUser.getLegalName());
-
-      foam.nanos.auth.Address address = supportConfig.getSupportAddress();
-      templateArgs.put("supportAddress", address == null ? "" : address.toSummary());
-      templateArgs.put("appName", (theme.getAppName()));
-      String url = appConfig.getUrl().replaceAll("/$", "");
-      templateArgs.put("logo", (url + "/" + theme.getLogo()));
-      templateArgs.put("appLink", url);
+      
       emailMessage.setTemplateArguments(templateArgs);
     }
 
@@ -142,5 +146,4 @@ public class EmailsUtility {
     emailMessage.setStatus(foam.nanos.notification.email.Status.UNSENT);
     email.put(emailMessage);
   }
-
 }


### PR DESCRIPTION
**address:** https://nanopay.atlassian.net/browse/NP-3673
**nanopay pr:** https://github.com/nanoPayinc/NANOPAY/pull/11993

**summary:** 
- set locale to email templates and search them by group and locale
- locale defaults to en

***example***
- user _t1_ has locale set to 'en'
- user _t2_ has locale set to 'pt'
- _t1_ and _t2_ receive an email in their locale's language 

![Screen Shot 2021-02-24 at 3 02 31 PM](https://user-images.githubusercontent.com/58435071/109058982-ae455380-76b1-11eb-8cfc-cdaa3bef2505.png)

![Screen Shot 2021-02-24 at 3 02 04 PM](https://user-images.githubusercontent.com/58435071/109058995-b1d8da80-76b1-11eb-9d15-8d87315d459a.png)

![Screen Shot 2021-02-24 at 3 02 21 PM](https://user-images.githubusercontent.com/58435071/109058999-b2717100-76b1-11eb-93cc-6f06b11ec230.png)
