### PR TITLE
DAO slots & Rich Choice View

### DIFF
--- a/src/foam/u2/view/RichChoiceView.js
+++ b/src/foam/u2/view/RichChoiceView.js
@@ -45,7 +45,7 @@ foam.CLASS({
       class: 'foam.dao.DAOProperty',
       name: 'filteredDAO',
       documentation: 'A filtered version of the underlying DAO, depending on the search term the user has typed in.',
-      factory: function() { return this.dao; }
+      expression: function(dao) { return dao; }
     },
     {
       class: 'Array',
@@ -292,6 +292,12 @@ foam.CLASS({
       `,
       postSet: function(_, nv) {
         if ( nv && ! this.hasBeenOpenedYet_ ) this.hasBeenOpenedYet_ = true;
+        if ( ! nv ) {
+          this.clearProperty('filter_');
+          this.sections.forEach((section) => {
+            section.clearProperty('filteredDAO');
+          });
+        }
       }
     },
     {
@@ -534,7 +540,6 @@ foam.CLASS({
                     sections.forEach(function(section) {
                       promiseArray.push(section.dao.select(self.COUNT()));
                     });
-
                     return Promise.all(promiseArray).then((resp) => {
                       var index = 0;
                       return this.E().forEach(sections, function(section) {


### PR DESCRIPTION
Resolves issues with the rich choice view list not updating due to detached listeners on the filteredDAO prop of the RichChoiceView. The filteredDAO prop, which is used to populate the choices of the choiceview, was using a factory to initiate its value using the dao value. This was most likely a mistake considering it's behaviour could be configured by either slotting the dao prop to a slot dao value or not.

Also added clearing of filter and choice selection on close of choice view list. This could be debated but the behaviour was odd considering filters and list would persist on close, selections and list(dao) changes.