### PR TITLE
Crunch updates

### DIFF
--- a/src/foam/nanos/auth/CapabilityAuthService.js
+++ b/src/foam/nanos/auth/CapabilityAuthService.js
@@ -99,12 +99,9 @@ foam.CLASS({
           DAO capabilityDAO = ( x.get("localCapabilityDAO") == null ) ? (DAO) x.get("capabilityDAO") : (DAO) x.get("localCapabilityDAO");
           DAO userCapabilityJunctionDAO = (DAO) x.get("userCapabilityJunctionDAO");
 
-          Predicate capabilityScope = AND(
-            OR(
+          Predicate capabilityScope = OR(
               NOT(HAS(UserCapabilityJunction.EXPIRY)),
               NOT(EQ(UserCapabilityJunction.STATUS, CapabilityJunctionStatus.EXPIRED))
-            ),
-            EQ(UserCapabilityJunction.LIFECYCLE_STATE, LifecycleState.ACTIVE)
           );
           AbstractPredicate predicate = new AbstractPredicate(x) {
             @Override

--- a/src/foam/nanos/auth/CapabilityAuthService.js
+++ b/src/foam/nanos/auth/CapabilityAuthService.js
@@ -99,9 +99,12 @@ foam.CLASS({
           DAO capabilityDAO = ( x.get("localCapabilityDAO") == null ) ? (DAO) x.get("capabilityDAO") : (DAO) x.get("localCapabilityDAO");
           DAO userCapabilityJunctionDAO = (DAO) x.get("userCapabilityJunctionDAO");
 
-          Predicate capabilityScope = OR(
+          Predicate capabilityScope = AND(
+            OR(
               NOT(HAS(UserCapabilityJunction.EXPIRY)),
               NOT(EQ(UserCapabilityJunction.STATUS, CapabilityJunctionStatus.EXPIRED))
+            ),
+            EQ(UserCapabilityJunction.LIFECYCLE_STATE, LifecycleState.ACTIVE)
           );
           AbstractPredicate predicate = new AbstractPredicate(x) {
             @Override

--- a/src/foam/nanos/crunch/MinMaxCapability.js
+++ b/src/foam/nanos/crunch/MinMaxCapability.js
@@ -68,6 +68,30 @@ foam.CLASS({
 
   methods: [
     {
+      name: 'implies',
+      type: 'Boolean',
+      args: [
+        { name: 'x', type: 'Context' },
+        { name: 'permission', type: 'String' }
+      ],
+      documentation: `
+        Checks if a permission or capability string is implied by a minmaxcapability
+        by only checking the capability's name, and permissionsGranted.
+      `,
+      javaCode: `
+        if ( ! this.getEnabled() ) return false;
+
+        // check if permission is a capability string implied by this permission
+        if ( this.stringImplies(this.getName(), permission) ) return true;
+
+        String[] permissionsGranted = this.getPermissionsGranted();
+        for ( String permissionName : permissionsGranted ) {
+          if ( this.stringImplies(permissionName, permission) ) return true;
+        }
+        return false;
+      `
+    },
+    {
       name: 'getPrereqsChainedStatus',
       type: 'CapabilityJunctionStatus',
       args: [

--- a/src/foam/nanos/crunch/services.jrl
+++ b/src/foam/nanos/crunch/services.jrl
@@ -108,6 +108,7 @@ p({
       .setGuid(true)
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
       .setJournalName("userCapabilityJunctions")
+      .setEnableInterfaceDecorators(false)
       .setOf(foam.nanos.crunch.UserCapabilityJunction.getOwnClassInfo())
       // .setDecorator(decorator)
       .build();


### PR DESCRIPTION
- override implies for minmaxcapability - we do not want minmaxcapability to imply the permissions of its prereqs, unlike in regular capa
- disable lifecycleaware for bareucjdao
- add method call in serviceprovider.removespid to reput and invalidate dependents of spid removed