### PR TITLE
set default locale template

### DIFF
--- a/src/foam/nanos/notification/email/DAOResourceLoader.java
+++ b/src/foam/nanos/notification/email/DAOResourceLoader.java
@@ -41,6 +41,15 @@ public class DAOResourceLoader
                   EQ(EmailTemplate.LOCALE, locale)
                   ));
 
+      if ( emailTemplate == null ) {
+        emailTemplate = (EmailTemplate) emailTemplateDAO
+          .find(
+            AND(
+              EQ(EmailTemplate.NAME, name),
+              EQ(EmailTemplate.GROUP, ! SafetyUtil.isEmpty(groupId) ? groupId : "*")
+            ));
+      }
+
       if ( emailTemplate != null ) {
         return emailTemplate;
       }
@@ -81,7 +90,7 @@ public class DAOResourceLoader
   public boolean exists(String s) {
     return load(s) != null;
   }
-  
+
   @Override
   public Optional<URL> toUrl(String s) {
     return Optional.absent();


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/NP-3729

now we use locale in emailTemplates to be picked properly according to the language setting.
when some certain language specific email template not existing, use its default language(en) email template
