### PR TITLE
download document bugs

### DIFF
--- a/src/foam/nanos/http/AuthWebAgent.java
+++ b/src/foam/nanos/http/AuthWebAgent.java
@@ -23,6 +23,8 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.bouncycastle.util.encoders.Base64;
+import foam.core.XFactory;
+import java.io.IOException;
 import static foam.mlang.MLang.AND;
 import static foam.mlang.MLang.EQ;
 
@@ -67,10 +69,16 @@ public class AuthWebAgent
 
     // Create a per-request sub-context of the session context which
     // contains necessary Servlet request/response objects.
+    X x_ = x;
     X requestX = session.getContext()
       .put(HttpServletRequest.class,  x.get(HttpServletRequest.class))
       .put(HttpServletResponse.class, x.get(HttpServletResponse.class))
-      .put(PrintWriter.class,         x.get(PrintWriter.class));
+      .putFactory(PrintWriter.class, new XFactory() {
+        @Override
+        public Object create(X x) {
+          return x_.get(PrintWriter.class);
+        }
+      });
     
     try {
       XLocator.set(requestX);


### PR DESCRIPTION
link ticket: https://nanopay.atlassian.net/browse/NP-3719

The root cause of this issue is that for each http response it should only invoke either response.getWriter or response.getOutputstream. You can not invoke both response.getWriter and response.getOutputstream for a http request. In this case, AuthWetAgent calls response.getOutputstream for each http request by default for every http request, so later calling response.getOutputstream in downloading document throws exception.