### PR TITLE
Reload subject after switching user

### DIFF
--- a/src/foam/nanos/auth/AgentAuthClient.js
+++ b/src/foam/nanos/auth/AgentAuthClient.js
@@ -8,16 +8,19 @@ foam.CLASS({
   package: 'foam.nanos.auth',
   name: 'AgentAuthClient',
   extends: 'foam.nanos.auth.ProxyAuthService',
+
   documentation: `
     AgentAuthService client side decorator. When user call agentAuth.actAs(), it assign 
     the business to users, and then purge caches.
   `,
+
   imports: [
     'crunchController',
     'ctrl',
     'menuDAO',
     'subject',
   ],
+
   methods: [
     async function actAs(x, user) {
       let result = await this.delegate.actAs(x, user);

--- a/src/foam/nanos/auth/AgentAuthClient.js
+++ b/src/foam/nanos/auth/AgentAuthClient.js
@@ -14,19 +14,20 @@ foam.CLASS({
   `,
   imports: [
     'crunchController',
+    'ctrl',
     'menuDAO',
     'subject',
   ],
   methods: [
-    async function actAs(x, business) {
-      let result = await this.delegate.actAs(x, business);
+    async function actAs(x, user) {
+      let result = await this.delegate.actAs(x, user);
       if ( result ) {
-        await x.fetchGroup();
-        this.subject.user = business;
-        this.subject.realUser = result;
+        await this.ctrl.fetchSubject();
+        await this.ctrl.fetchGroup();
         this.menuDAO.cmd_(x, foam.dao.CachingDAO.PURGE);
         this.menuDAO.cmd_(x, foam.dao.AbstractDAO.RESET_CMD);
         this.crunchController.purgeCachedCapabilityDAOs();
+        return result;
       }
     },
   ],


### PR DESCRIPTION
Reload subject to be in-sync with the server side instead of modifying subject data locally. Also the user passed into `actAs` might not be a full user object when it's a user on other SPID.