### PR TITLE
On the failure reploy flow, explicitly set the context on the message…

### DIFF
--- a/src/foam/java/Skeleton.js
+++ b/src/foam/java/Skeleton.js
@@ -133,6 +133,8 @@ foam.CLASS({
         }
       }
       ((foam.nanos.logger.Logger) getMessageX(message).get("logger")).debug("returning skeleton exception", t);
+      // NOTE: this is required for SocketClientReplyBox to find the socket that this request arrived on.  The localAttributes 'x' does not have access to the socket.
+      message.setX(getX());
       message.replyWithException(t);
 
       return;


### PR DESCRIPTION
… so the SocketClientReplyBox has access to the correct context to find the Socket to reply on.

I initially thought this was necessary - but a clean build indicated otherwise. 