### PR TITLE
[DNM] [NP-3798] For debugging, store the path of rules and property changes a UCJ went through

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -760,6 +760,8 @@ FOAM_FILES([
   { name: "foam/core/ContextAware", flags: ['java'] },
   { name: "foam/dao/history/PropertyUpdate" },
   { name: "foam/dao/history/HistoryRecord" },
+  { name: "foam/dao/history/HistoryDAO" },
+  { name: "foam/dao/debug/putpath" },
   { name: "foam/mop/MOP" },
   { name: "foam/dao/jdbc/ConnectionPool" },
   { name: "foam/lib/Outputter" },

--- a/src/foam/dao/debug/putpath.js
+++ b/src/foam/dao/debug/putpath.js
@@ -1,0 +1,196 @@
+foam.CLASS({
+  package: 'foam.dao.debug',
+  name: 'PutPathElement',
+  documentation: `
+    Interface for objects that can store a path of operations they
+    encountered during a put operation.
+  `,
+
+  properties: [
+    {
+      name: 'origin',
+      class: 'String'
+    },
+    {
+      name: 'description',
+      class: 'String'
+    },
+    {
+      name: 'historyRecord',
+      class: 'FObjectProperty',
+      of: 'foam.dao.history.HistoryRecord',
+    },
+    {
+      name: 'snapshot',
+      class: 'FObjectProperty'
+    }
+  ]
+});
+
+foam.INTERFACE({
+  package: 'foam.dao.debug',
+  name: 'PutPathAware',
+  documentation: `
+    Interface for objects that can store a path of operations they
+    encountered during a put operation.
+  `,
+
+  methods: [
+    {
+      name: 'describePut',
+      args: [
+        { name: 'x', type: 'Context' },
+        { name: 'origin', type: 'String' },
+        { name: 'description', type: 'String' }
+      ],
+    }
+  ]
+});
+
+foam.CLASS({
+  package: 'foam.dao.debug',
+  name: 'PutPathTracking',
+  implements: ['foam.dao.debug.PutPathAware'],
+  documentation: `
+    Interface for objects that can store a path of operations they
+    encountered during a put operation.
+  `,
+
+  javaImports: [
+    'foam.core.FObject',
+    'foam.core.PropertyInfo',
+    'foam.core.X',
+    'foam.lib.PropertyPredicate',
+    'foam.lib.StorageOptionalPropertyPredicate',
+    'foam.lib.StoragePropertyPredicate',
+    'foam.dao.history.HistoryRecord',
+    'foam.dao.history.PropertyUpdate',
+    'foam.dao.debug.PutPathElement',
+    'foam.nanos.auth.Subject',
+    'foam.nanos.auth.User',
+    'java.util.ArrayList',
+    'java.util.Date',
+  ],
+
+  axioms: [
+    {
+      name: 'javaExtras',
+      buildJavaClass: function(cls) {
+        cls.extras.push(
+          `
+            private static final PropertyPredicate PROPERTY_PREDICATE = new StoragePropertyPredicate();
+            private static final PropertyPredicate OPTIONAL_PREDICATE = new StorageOptionalPropertyPredicate();
+          `
+        );
+      }
+    }
+  ],
+
+  properties: [
+    {
+      name: 'updateHistory',
+      class: 'FObjectArray',
+      of: 'foam.dao.debug.PutPathElement',
+      javaFactory: `
+        return new PutPathElement[0];
+      `
+    },
+    {
+      name: 'lastUpdateSnapshot',
+      class: 'FObjectProperty',
+    },
+  ],
+
+  methods: [
+    {
+      // TODO: DRY with mixin
+      name: 'formatUserName',
+      visibility: 'protected',
+      type: 'String',
+      args: [
+        { type: 'User', name: 'user ' }
+      ],
+      documentation: 'Formats a User record to the following string: LastName, FirstName (ID)',
+      javaCode: `
+        if ( user == null ) return "";
+        return user.getLastName() +", " +
+            user.getFirstName() +
+            "(" + user.getId() + ")";
+      `
+    },
+    {
+      // TODO: DRY with mixin
+      name: 'getUpdatedProperties',
+      visibility: 'protected',
+      type: 'PropertyUpdate[]',
+      args: [
+        { type: 'Context', name: 'x' },
+        { type: 'FObject', name: 'currentValue' },
+        { type: 'FObject', name: 'newValue' }
+      ],
+      documentation: 'Returns an array of updated properties',
+      javaCode: `
+        var updates = new ArrayList<PropertyUpdate>();
+        var info = newValue.getClassInfo();
+        var of = info.getObjClass().getSimpleName().toLowerCase();
+        var props = info.getAxiomsByClass(PropertyInfo.class);
+
+        for ( var prop : props ) {
+          if ( prop.getName().equals("updateHistory")
+            || prop.getName().equals("lastUpdateSnapshot")
+          ) continue;
+          if ( PROPERTY_PREDICATE.propertyPredicateCheck(x, of, prop)
+            && ! OPTIONAL_PREDICATE.propertyPredicateCheck(x, of, prop)
+            && prop.compare(currentValue, newValue) != 0
+          ) {
+            updates.add(new PropertyUpdate(
+              prop.getName(),
+              prop.f(currentValue),
+              prop.f(newValue)
+            ));
+          }
+        }
+
+        return updates.toArray(new PropertyUpdate[updates.size()]);
+      `
+    },
+    {
+      name: 'describePut',
+      args: [
+        { type: 'Context', name: 'x' },
+        { name: 'origin', type: 'String' },
+        { name: 'description', type: 'String' }
+      ],
+      javaCode: `
+        var arry = new PutPathElement[getUpdateHistory().length + 1];
+
+        Subject subject = (Subject) x.get("subject");
+        User user = subject.getUser();
+        User agent = subject.getRealUser();
+
+        var last = getLastUpdateSnapshot();
+
+        var historyRecord = new HistoryRecord();
+
+        historyRecord.setObjectId(getProperty("id"));
+        historyRecord.setUser(formatUserName(user));
+        historyRecord.setAgent(formatUserName(agent));
+        historyRecord.setTimestamp(new Date());
+        if ( last != null )
+          historyRecord.setUpdates(getUpdatedProperties(x, last, this));
+
+        setLastUpdateSnapshot(((FObject) this).fclone());
+
+        for ( var i = 0 ; i < getUpdateHistory().length; i++ ) {
+          arry[i] = getUpdateHistory()[i];
+        }
+        arry[getUpdateHistory().length] = new PutPathElement.Builder(x)
+          .setOrigin(origin)
+          .setDescription(description)
+          .setHistoryRecord(historyRecord)
+          .build();
+        setUpdateHistory(arry);
+      `
+    }
+  ]
+});

--- a/src/foam/nanos/crunch/UserCapabilityJunctionRefine.js
+++ b/src/foam/nanos/crunch/UserCapabilityJunctionRefine.js
@@ -8,7 +8,10 @@ foam.CLASS({
   package: 'foam.nanos.crunch',
   name: 'UserCapabilityJunctionRefine',
   refines: 'foam.nanos.crunch.UserCapabilityJunction',
-  mixins: [ 'foam.nanos.crunch.CapabilityJunctionPayload' ],
+  mixins: [
+    'foam.nanos.crunch.CapabilityJunctionPayload',
+    'foam.dao.debug.PutPathTracking'
+  ],
   implements: [ 'foam.nanos.auth.LifecycleAware' ],
 
   documentation: `

--- a/src/foam/nanos/ruler/RuleEngine.java
+++ b/src/foam/nanos/ruler/RuleEngine.java
@@ -182,7 +182,7 @@ public class RuleEngine extends ContextAwareSupport {
     if ( obj instanceof PutPathAware ) {
       ((PutPathAware) obj).describePut(
         readOnlyX,
-        String.format("APPLY %s", rule.getId()),
+        String.format("APPLY %s/%s", rule.getName(), rule.getId()),
         rule.getDocumentation()
       );
     }
@@ -231,7 +231,7 @@ public class RuleEngine extends ContextAwareSupport {
             if ( obj instanceof PutPathAware ) {
               ((PutPathAware) obj).describePut(
                 x,
-                String.format("ASYNC APPLY %s", rule.getId()),
+                String.format("ASYNC APPLY %s/%s", rule.getName(), rule.getId()),
                 rule.getDocumentation()
               );
             }

--- a/src/foam/nanos/ruler/RuleEngine.java
+++ b/src/foam/nanos/ruler/RuleEngine.java
@@ -8,6 +8,7 @@ package foam.nanos.ruler;
 
 import foam.core.*;
 import foam.dao.DAO;
+import foam.dao.debug.PutPathAware;
 import foam.nanos.auth.*;
 import foam.nanos.logger.Logger;
 import foam.nanos.pm.PM;
@@ -178,6 +179,13 @@ public class RuleEngine extends ContextAwareSupport {
   private void applyRule(Rule rule, FObject obj, FObject oldObj, Agency agency) {
     ProxyX readOnlyX = new ReadOnlyDAOContext(userX_);
     rule.apply(readOnlyX, obj, oldObj, this, rule, agency);
+    if ( obj instanceof PutPathAware ) {
+      ((PutPathAware) obj).describePut(
+        readOnlyX,
+        String.format("APPLY %s", rule.getId()),
+        rule.getDocumentation()
+      );
+    }
   }
 
   private boolean isRuleActive(Rule rule, RuleAction action) {
@@ -220,6 +228,13 @@ public class RuleEngine extends ContextAwareSupport {
           nu = reloadObject(obj, oldObj, nu, rule.getAfter());
           try {
             rule.asyncApply(x, nu, oldObj, RuleEngine.this, rule);
+            if ( obj instanceof PutPathAware ) {
+              ((PutPathAware) obj).describePut(
+                x,
+                String.format("ASYNC APPLY %s", rule.getId()),
+                rule.getDocumentation()
+              );
+            }
             saveHistory(rule, nu);
           } catch (Exception ex) {
             logger.warning("Retry asyncApply rule(" + rule.getId() + ").", ex);

--- a/src/foam/nanos/ruler/RulerDAO.js
+++ b/src/foam/nanos/ruler/RulerDAO.js
@@ -23,6 +23,7 @@ foam.CLASS({
     'foam.dao.AbstractSink',
     'foam.dao.ArraySink',
     'foam.dao.DAO',
+    'foam.dao.debug.PutPathAware',
     'foam.mlang.order.Desc',
     'foam.mlang.predicate.Predicate',
     'foam.mlang.sink.GroupBy',
@@ -121,6 +122,10 @@ foam.CLASS({
     {
       name: 'put_',
       javaCode: `FObject oldObj = getDelegate().find_(x, obj);
+if ( obj instanceof PutPathAware ) {
+  ((PutPathAware) obj).describePut(x, "RulerDAO", "Before RulerDAO");
+}
+
 Map rulesList = getRulesList();
 if ( oldObj == null ) {
   applyRules(x, obj, oldObj, (GroupBy) rulesList.get(getCreateBefore()));

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -724,6 +724,11 @@ var classes = [
   'foam.nanos.auth.UserPasswordHashingDAO',
   'foam.dao.ValidatingDAO',
 
+  // DAO Debugging
+  'foam.dao.debug.PutPathElement',
+  'foam.dao.debug.PutPathAware',
+  'foam.dao.debug.PutPathTracking',
+
   // Support Files
   'foam.support.model.TicketMessage',
   'foam.support.model.SupportEmail',

--- a/tools/classes.js
+++ b/tools/classes.js
@@ -725,6 +725,7 @@ var classes = [
   'foam.dao.ValidatingDAO',
 
   // DAO Debugging
+  'foam.dao.debug.PutPathDAO',
   'foam.dao.debug.PutPathElement',
   'foam.dao.debug.PutPathAware',
   'foam.dao.debug.PutPathTracking',


### PR DESCRIPTION
The following improvements are needed before this can be merged

- [x] Should not log this data in production (very verbose)
- [x] ~It might be logging too much data~ (turns out it wasn't)
- [x] Should record when the rule engine started so it's easy to see where one chain ends and another begins
- [ ] Any rule doing a "re-put" should probably record that it occurred and why