### PR TITLE
notification not clickable - removal trailing comma

### DIFF
--- a/src/menus
+++ b/src/menus
@@ -308,7 +308,7 @@ p({
             {
               "class":"foam.mlang.expr.DateGrouping",
               "name":"Older",
-              "low":2,
+              "low":2
             }
           ]
         }


### PR DESCRIPTION
https://nanopay.atlassian.net/browse/NP-3801


notification bell on top bar was not clickable, removed the trailing comma in menus

was :
![image](https://user-images.githubusercontent.com/33228583/110525366-7fcc6d00-80e2-11eb-9f0e-aa91eede9683.png)


now : 

<img width="826" alt="Screen Shot 2021-03-09 at 2 18 14 PM" src="https://user-images.githubusercontent.com/33228583/110525182-4ac01a80-80e2-11eb-9abc-bb4e98c483e2.png">


