### PR TITLE
Add explicitly desired logLevel support in AppConfig.

### DIFF
--- a/src/foam/nanos/app/AppConfig.js
+++ b/src/foam/nanos/app/AppConfig.js
@@ -62,6 +62,12 @@ foam.CLASS({
       name: 'mode'
     },
     {
+      class: 'Enum',
+      of: 'foam.log.LogLevel',
+      name: 'logLevel',
+      value: 'DEBUG'
+    },
+    {
       class: 'String',
       name: 'appLink',
       value: 'https://www.apple.com/lae/ios/app-store/'

--- a/src/foam/nanos/logger/LogLevelFilterLogger.js
+++ b/src/foam/nanos/logger/LogLevelFilterLogger.js
@@ -42,7 +42,7 @@ foam.CLASS({
           javaType: 'Object...'
         }
       ],
-      javaCode: "if ( getLogError() ) getDelegate().error(args);"
+      javaCode: 'if ( getLogError() ) getDelegate().error(args);'
     },
     {
       name: 'warning',
@@ -53,7 +53,7 @@ foam.CLASS({
           javaType: 'Object...'
         }
       ],
-      javaCode: "if ( getLogWarning() ) getDelegate().warning(args);"
+      javaCode: 'if ( getLogWarning() ) getDelegate().warning(args);'
     },
     {
       name: 'info',
@@ -64,7 +64,7 @@ foam.CLASS({
           javaType: 'Object...'
         }
       ],
-      javaCode: "if ( getLogInfo() ) getDelegate().info(args);"
+      javaCode: 'if ( getLogInfo() ) getDelegate().info(args);'
     },
     {
       name: 'debug',
@@ -75,7 +75,7 @@ foam.CLASS({
           javaType: 'Object...'
         }
       ],
-      javaCode: "if ( getLogDebug() ) getDelegate().debug(args);"
+      javaCode: 'if ( getLogDebug() ) getDelegate().debug(args);'
     }
   ]
 });

--- a/src/foam/nanos/logger/LogMessage.js
+++ b/src/foam/nanos/logger/LogMessage.js
@@ -29,6 +29,25 @@ foam.CLASS({
     'message'
   ],
 
+  axioms: [
+    {
+      name: 'javaExtras',
+      buildJavaClass: function(cls) {
+        cls.extras.push(foam.java.Code.create({
+          data: `
+  protected static ThreadLocal<foam.util.FastTimestamper> timestamper_ = new ThreadLocal<foam.util.FastTimestamper>() {
+    @Override
+    protected foam.util.FastTimestamper initialValue() {
+      foam.util.FastTimestamper ft = new foam.util.FastTimestamper();
+      return ft;
+    }
+  };
+          `
+        }));
+      }
+    }
+  ],
+
   properties: [
     {
       name: 'hostname',
@@ -126,5 +145,14 @@ foam.CLASS({
     //   view: { class: 'foam.u2.view.PreView' },
     //   updateVisibility: 'RO'
     // }
+  ],
+
+  methods: [
+    {
+      name: 'toString',
+      javaCode: `
+      return timestamper_.get().createTimestamp(getCreated().getTime())+","+getThread()+","+getSeverity()+","+getMessage();
+      `
+    }
   ]
 });

--- a/src/foam/nanos/logger/StdoutLoggerDAO.js
+++ b/src/foam/nanos/logger/StdoutLoggerDAO.js
@@ -27,29 +27,9 @@ foam.CLASS({
       value: true
     },
     {
-      name: 'mode',
-      class: 'Enum',
-      of: 'foam.nanos.app.Mode',
-      value: 'DEVELOPMENT'
-    }
-  ],
-
-  axioms: [
-    {
-      name: 'javaExtras',
-      buildJavaClass: function(cls) {
-        cls.extras.push(foam.java.Code.create({
-          data: `
-  protected static ThreadLocal<foam.util.FastTimestamper> timestamper_ = new ThreadLocal<foam.util.FastTimestamper>() {
-    @Override
-    protected foam.util.FastTimestamper initialValue() {
-      foam.util.FastTimestamper ft = new foam.util.FastTimestamper();
-      return ft;
-    }
-  };
-          `
-        }));
-      }
+      name: 'appConfig',
+      class: 'FObjectProperty',
+      of: 'foam.nanos.app.AppConfig'
     }
   ],
 
@@ -57,18 +37,23 @@ foam.CLASS({
     {
       name: 'put_',
       javaCode: `
-      LogMessage lm = (LogMessage) getDelegate().put_(x, obj);
+      LogMessage lm = (LogMessage) obj;
       if ( getEnabled() &&
            lm != null ) {
-        // Only write INFO, WARN, ERROR to SYSLOG in production to reduce
-        // burden on syslogd, journald. With our own journal logs we are
-        // effectively writing out logs twice. 
-        if ( getMode() != Mode.PRODUCTION ||
-             lm.getSeverity().getOrdinal() >= LogLevel.INFO.getOrdinal() ) {
-          System.err.println(timestamper_.get().createTimestamp(lm.getCreated().getTime())+","+lm.getThread()+","+lm.getSeverity()+","+lm.getMessage());
+        if ( ( getAppConfig().getMode() != Mode.PRODUCTION &&
+               lm.getSeverity().getOrdinal() == LogLevel.DEBUG.getOrdinal() ) ||
+             lm.getSeverity().getOrdinal() == LogLevel.INFO.getOrdinal() ) {
+          System.out.println(lm.toString());
+        } else if ( lm.getSeverity().getOrdinal() > LogLevel.INFO.getOrdinal() ) {
+          System.err.println(lm.toString());
         }
+        // In PRODUCTION only write to syslogd for performance, no filesystem log
+        if ( getAppConfig().getMode() != Mode.PRODUCTION ) {
+          return getDelegate().put_(x, lm);
+        }
+        return lm;
       }
-      return lm;
+      return getDelegate().put_(x, obj);
       `
     }
   ]

--- a/src/foam/nanos/logger/StdoutLoggerDAO.js
+++ b/src/foam/nanos/logger/StdoutLoggerDAO.js
@@ -27,9 +27,10 @@ foam.CLASS({
       value: true
     },
     {
-      name: 'appConfig',
-      class: 'FObjectProperty',
-      of: 'foam.nanos.app.AppConfig'
+      name: 'mode',
+      class: 'Enum',
+      of: 'foam.nanos.app.Mode',
+      value: 'DEVELOPMENT'
     }
   ],
 
@@ -40,7 +41,7 @@ foam.CLASS({
       LogMessage lm = (LogMessage) obj;
       if ( getEnabled() &&
            lm != null ) {
-        if ( ( getAppConfig().getMode() != Mode.PRODUCTION &&
+        if ( ( getMode() != Mode.PRODUCTION &&
                lm.getSeverity().getOrdinal() == LogLevel.DEBUG.getOrdinal() ) ||
              lm.getSeverity().getOrdinal() == LogLevel.INFO.getOrdinal() ) {
           System.out.println(lm.toString());
@@ -48,7 +49,7 @@ foam.CLASS({
           System.err.println(lm.toString());
         }
         // In PRODUCTION only write to syslogd for performance, no filesystem log
-        if ( getAppConfig().getMode() != Mode.PRODUCTION ) {
+        if ( getMode() != Mode.PRODUCTION ) {
           return getDelegate().put_(x, lm);
         }
         return lm;

--- a/src/foam/nanos/logger/services.jrl
+++ b/src/foam/nanos/logger/services.jrl
@@ -1,4 +1,15 @@
 p({
+  "class":"foam.nanos.boot.NSpec",
+  "name":"stdoutLoggerDAO",
+  "lazy":false,
+  "serviceScript":"""
+    return new foam.nanos.logger.StdoutLoggerDAO.Builder(x)
+      .setMode(((foam.nanos.app.AppConfig) x.get("appConfig")).getMode())
+      .build();
+  """
+})
+
+p({
   "class":
   "foam.nanos.boot.NSpec",
   "name":"localLogMessageDAO",
@@ -20,9 +31,7 @@ p({
       .setIndex(new foam.core.PropertyInfo[] {foam.nanos.logger.LogMessage.CREATED})
       .setDecorator(new foam.nanos.logger.LogMessageDAO.Builder(x)
           .setDelegate(new foam.nanos.logger.RepeatLogMessageDAO.Builder(x)
-          .setDelegate(new foam.nanos.logger.StdoutLoggerDAO.Builder(x)
-            .setAppConfig((foam.nanos.app.AppConfig) x.get("appConfig"))
-            .build())
+          .setDelegate((foam.dao.DAO) x.get("stdoutLoggerDAO"))
           .build())
         .build())
       .build();

--- a/src/foam/nanos/logger/services.jrl
+++ b/src/foam/nanos/logger/services.jrl
@@ -18,10 +18,10 @@ p({
         .setSize(100000)
         .build())
       .setIndex(new foam.core.PropertyInfo[] {foam.nanos.logger.LogMessage.CREATED})
-      .setDecorator(new foam.nanos.logger.StdoutLoggerDAO.Builder(x)
-        .setMode(((foam.nanos.app.AppConfig) x.get("appConfig")).getMode())
-        .setDelegate(new foam.nanos.logger.LogMessageDAO.Builder(x)
+      .setDecorator(new foam.nanos.logger.LogMessageDAO.Builder(x)
           .setDelegate(new foam.nanos.logger.RepeatLogMessageDAO.Builder(x)
+          .setDelegate(new foam.nanos.logger.StdoutLoggerDAO.Builder(x)
+            .setAppConfig((foam.nanos.app.AppConfig) x.get("appConfig"))
             .build())
           .build())
         .build())
@@ -51,7 +51,27 @@ p({
   "class":"foam.nanos.boot.NSpec",
   "name":"logLevelFilterLogger",
   "lazy":false,
-  "service":{"class":"foam.nanos.logger.LogLevelFilterLogger"}
+  "serviceScript":"""
+    import foam.log.LogLevel;
+    import foam.nanos.app.AppConfig;
+    import foam.nanos.app.Mode;
+    import foam.nanos.logger.ProxyLogger;
+    import foam.nanos.logger.LogLevelFilterLogger;
+    ProxyLogger logLevelFilterLogger = new LogLevelFilterLogger();
+    logLevelFilterLogger.setX(x);
+    AppConfig app = (AppConfig) x.get("appConfig");
+    if ( app.getLogLevel() == LogLevel.INFO ) {
+      logLevelFilterLogger.setLogDebug(false);
+    } else if ( app.getLogLevel() == LogLevel.WARN ) {
+      logLevelFilterLogger.setLogDebug(false);
+      logLevelFilterLogger.setLogInfo(false);
+    } else if ( app.getLogLevel() == LogLevel.ERROR ) {
+      logLevelFilterLogger.setLogDebug(false);
+      logLevelFilterLogger.setLogInfo(false);
+      logLevelFilterLogger.setLogWarn(false);
+    }
+    return logLevelFilterLogger;
+  """
 })
 
 p({
@@ -59,23 +79,12 @@ p({
   "name":"logger",
   "lazy":false,
   "serviceScript":"""
-    import foam.nanos.app.AppConfig;
-    import foam.nanos.app.Mode;
     import foam.nanos.logger.ProxyLogger;
     import foam.nanos.logger.LogLevelFilterLogger;
     import foam.nanos.logger.DAOLogger;
-    ProxyLogger logLevelFilterLogger = (ProxyLogger) x.get("logLevelFilterLogger");
-    logLevelFilterLogger.setX(x);
-    AppConfig app = (AppConfig) x.get("appConfig");
-    if ( app.getMode() == Mode.TEST ) {
-      logLevelFilterLogger.setLogDebug(false);
-    }
-    if ( app.getMode() == Mode.PRODUCTION ) {
-      logLevelFilterLogger.setLogDebug(false);
-      logLevelFilterLogger.setLogInfo(false);
-    }
     DAOLogger daoLogger = new DAOLogger(x);
     daoLogger.setDelegate((foam.dao.DAO) x.get("localLogMessageDAO"));
+    ProxyLogger logLevelFilterLogger = (ProxyLogger) x.get("logLevelFilterLogger");
     logLevelFilterLogger.setDelegate(daoLogger);
     return logLevelFilterLogger;
   """


### PR DESCRIPTION
Can be controlled at runtime via service logLevelFilterLogger.
Only write to syslogd in PRODUCTION, only need one copy of log files.
Add nspec for StdoutLoggerDAO so it's level can be controlled easily at runtime.