### PR TITLE
Preserving Inner Exception in DIG

### DIFF
--- a/src/foam/nanos/dig/exception/DigErrorMessage.js
+++ b/src/foam/nanos/dig/exception/DigErrorMessage.js
@@ -23,6 +23,9 @@ foam.CLASS({
           public DigErrorMessage(String message, Throwable cause) {
             super(message, cause);
             setMessage(message);
+            if ( cause instanceof foam.core.Exception ) {
+              setInner((foam.core.Exception) cause);
+            }
           }
         `
         );
@@ -54,6 +57,11 @@ foam.CLASS({
     {
       class: 'String',
       name: 'moreInfo'
+    },
+    {
+      class: 'FObjectProperty',
+      name: 'inner',
+      of: 'foam.core.Exception'
     }
   ],
 


### PR DESCRIPTION
I need the inner exception to be returned to API call if it's a FOAM Exception.