### PR TITLE
do not check whether prerequisites imply a permission in the implies method

### DIFF
--- a/src/foam/nanos/crunch/Capability.js
+++ b/src/foam/nanos/crunch/Capability.js
@@ -330,17 +330,7 @@ foam.CLASS({
         for ( String permissionName : permissionsGranted ) {
           if ( this.stringImplies(permissionName, permission) ) return true;
         }
-
-        CrunchService crunchService = (CrunchService) x.get("crunchService");
-        var prereqs = crunchService.getPrereqs(getId());
-
-        if ( prereqs != null && prereqs.size() > 0 ) {
-          DAO capabilityDAO = (DAO) x.get("capabilityDAO");
-          for ( var capId : prereqs ) {
-            Capability capability = (Capability) capabilityDAO.find(capId);
-            if ( capability != null && capability.implies(x, permission) ) return true;
-          }
-        }
+        
         return false;
       `
     },

--- a/src/foam/nanos/crunch/MinMaxCapability.js
+++ b/src/foam/nanos/crunch/MinMaxCapability.js
@@ -70,30 +70,6 @@ foam.CLASS({
 
   methods: [
     {
-      name: 'implies',
-      type: 'Boolean',
-      args: [
-        { name: 'x', type: 'Context' },
-        { name: 'permission', type: 'String' }
-      ],
-      documentation: `
-        Checks if a permission or capability string is implied by a minmaxcapability
-        by only checking the capability's name, and permissionsGranted.
-      `,
-      javaCode: `
-        if ( ! this.getEnabled() ) return false;
-
-        // check if permission is a capability string implied by this permission
-        if ( this.stringImplies(this.getName(), permission) ) return true;
-
-        String[] permissionsGranted = this.getPermissionsGranted();
-        for ( String permissionName : permissionsGranted ) {
-          if ( this.stringImplies(permissionName, permission) ) return true;
-        }
-        return false;
-      `
-    },
-    {
       name: 'getPrereqsChainedStatus',
       type: 'CapabilityJunctionStatus',
       args: [


### PR DESCRIPTION
Remove the check on whether prerequisites imply a permission in the implies method of Capability
This is redundant since a capability is only granted when its prerequisites are also granted