### PR TITLE
Remove console log in FObjectRecursionSlot

### DIFF
--- a/src/foam/u2/wizard/internal/FObjectRecursionSlot.js
+++ b/src/foam/u2/wizard/internal/FObjectRecursionSlot.js
@@ -50,7 +50,6 @@ foam.CLASS({
       this.onDetach(this.cleanup);
       var debug_updateCalls = 0;
       var update = function (obj, parentRefs) {
-        console.log('one of these called');
         debug_updateCalls++;
         if ( parentRefs.includes(obj) ) {
           this.cleanup();


### PR DESCRIPTION
constantly logging to the console making hard to debug in the console