### PR TITLE
JShell prints/outputs exceptions

### DIFF
--- a/src/foam/nanos/script/jShell/EvalInstruction.java
+++ b/src/foam/nanos/script/jShell/EvalInstruction.java
@@ -10,6 +10,7 @@ import java.util.List;
 import foam.core.X;
 import jdk.jshell.JShell;
 import jdk.jshell.SnippetEvent;
+
 /**
  * Evaluate each instruction and return the result 
  *
@@ -65,9 +66,7 @@ public class EvalInstruction {
       }
       Exception exc = event.exception();
       if ( exc != null ) {
-        String out = exc.getMessage();
-        output += "Error is " + out;
-        System.out.println("Error is " + out);
+        exc.printStackTrace();
       }
     }
     return output;

--- a/src/foam/nanos/script/jShell/EvalInstruction.java
+++ b/src/foam/nanos/script/jShell/EvalInstruction.java
@@ -5,11 +5,14 @@
  */
 package foam.nanos.script.jShell;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.List;
 
 import foam.core.X;
 import jdk.jshell.JShell;
 import jdk.jshell.SnippetEvent;
+import jdk.jshell.EvalException;
 
 /**
  * Evaluate each instruction and return the result 
@@ -66,7 +69,11 @@ public class EvalInstruction {
       }
       Exception exc = event.exception();
       if ( exc != null ) {
-        exc.printStackTrace();
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        exc.printStackTrace(pw);
+        output = ((EvalException) exc).getExceptionClassName() + "\n" + sw.toString();
+        System.out.println("JShell Error: " + output);
       }
     }
     return output;

--- a/src/foam/nanos/test/Test.js
+++ b/src/foam/nanos/test/Test.js
@@ -230,10 +230,10 @@ foam.CLASS({
         }
 
         setLastRun(new Date());
-      setLastDuration(pm.getTime());
-      ps.flush();
-      setOutput(baos.toString() + getOutput());
-    `
+        setLastDuration(pm.getTime());
+        ps.flush();
+        setOutput(baos.toString() + getOutput());
+      `
     }
   ]
 });

--- a/src/foam/nanos/test/Test.js
+++ b/src/foam/nanos/test/Test.js
@@ -16,13 +16,15 @@ foam.CLASS({
 
   javaImports: [
     'bsh.Interpreter',
-    'foam.nanos.logger.Logger',
     'foam.nanos.app.AppConfig',
     'foam.nanos.app.Mode',
+    'foam.nanos.logger.Logger',
     'foam.nanos.pm.PM',
+    'foam.nanos.script.*',
     'java.io.ByteArrayOutputStream',
     'java.io.PrintStream',
-    'java.util.Date'
+    'java.util.Date',
+    'jdk.jshell.JShell'
   ],
 
   tableColumns: [
@@ -138,7 +140,6 @@ foam.CLASS({
     {
       name: 'runScript',
       code: function() {
-        var ret;
         var startTime = Date.now();
 
         return new Promise((resolve, reject) => {
@@ -196,34 +197,42 @@ foam.CLASS({
 
         ByteArrayOutputStream baos  = new ByteArrayOutputStream();
         PrintStream           ps    = new PrintStream(baos);
-        Interpreter           shell = (Interpreter) createInterpreter(x, null);
         PM                    pm    = new PM(this.getClass(), getId());
+        Language              l     = getLanguage();
 
+        setPassed(0);
+        setFailed(0);
         try {
-          setPassed(0);
-          setFailed(0);
-          setOutput("");
-          shell.setOut(ps);
-
-          // creates the testing method
-          shell.eval("test(boolean exp, String message) { if ( exp ) { currentScript.setPassed(currentScript.getPassed()+1); } else { currentScript.setFailed(currentScript.getFailed()+1); } print((exp ? \\"SUCCESS: \\" : \\"FAILURE: \\")+message);}");
-          shell.eval(getCode());
-          // if the test is a java class (not a script), it will just update the lastRun and lastDuration
+          if ( l == foam.nanos.script.Language.BEANSHELL ) {
+            Interpreter shell = (Interpreter) createInterpreter(x, null);
+            setOutput("");
+            shell.setOut(ps);
+            shell.eval("test(boolean exp, String message) { if ( exp ) { currentScript.setPassed(currentScript.getPassed()+1); } else { currentScript.setFailed(currentScript.getFailed()+1); } print((exp ? \\"SUCCESS: \\" : \\"FAILURE: \\")+message);}");
+            shell.eval(getCode());
+          } else if ( l == foam.nanos.script.Language.JSHELL ) {
+            String print = null;
+            JShell jShell = (JShell) createInterpreter(x, ps);
+            print = new JShellExecutor().execute(x, jShell, getCode());
+            ps.print(print);
+          } else {
+            throw new RuntimeException("Script language not supported");
+          }
           runTest(x);
-        } catch (Throwable e) {
-          setFailed(getFailed()+1);
-          ps.println("FAILURE: "+e.getMessage());
-          e.printStackTrace(ps);
+        } catch (Throwable t) {
+          setFailed(getFailed() + 1);
+          ps.println("FAILURE: " + t.getMessage());
+          t.printStackTrace(ps);
           Logger logger = (Logger) x.get("logger");
-          logger.error(e);
+          logger.error(this.getClass().getSimpleName(), "runTest", getId(), t);
+          pm.error(x, t);
         } finally {
           pm.log(x);
         }
 
-        setLastRun(new Date());
-        setLastDuration(pm.getTime());
-        ps.flush();
-        setOutput(baos.toString() + getOutput());
+      setLastRun(new Date());
+      setLastDuration(pm.getTime());
+      ps.flush();
+      setOutput(baos.toString() + getOutput());
     `
     }
   ]

--- a/src/foam/nanos/test/Test.js
+++ b/src/foam/nanos/test/Test.js
@@ -229,7 +229,7 @@ foam.CLASS({
           pm.log(x);
         }
 
-      setLastRun(new Date());
+        setLastRun(new Date());
       setLastDuration(pm.getTime());
       ps.flush();
       setOutput(baos.toString() + getOutput());


### PR DESCRIPTION
JShell scripts print and return exception in output if error is thrown.

EvalException thrown by JShell doesn't include the real exception class name in it's stack trace probably due to a type issue and its getMessage was returning null for every exception I encountered so I constructed a string similar to what would be outputted if the stack trace had been thrown by the jshell script code.