### PR TITLE
use session subject for history record

### DIFF
--- a/src/foam/dao/history/HistoryDAO.js
+++ b/src/foam/dao/history/HistoryDAO.js
@@ -22,6 +22,7 @@ foam.CLASS({
     'foam.nanos.auth.Subject',
     'foam.nanos.auth.User',
     'foam.nanos.logger.Logger',
+    'foam.nanos.session.Session',
     'java.util.ArrayList',
     'java.util.Date',
     'static foam.mlang.MLang.EQ',
@@ -114,9 +115,8 @@ foam.CLASS({
     {
       name: 'put_',
       javaCode: `
-      Subject subject = (Subject) x.get("subject");
-      User user = subject.getUser();
-      User agent = subject.getRealUser();
+      Subject subject = (Subject) ((Session) x.get(Session.class)).getContext().get("subject");
+
       FObject current = this.find_(x, obj);
       Object objectId = obj.getProperty("id");
 


### PR DESCRIPTION
Currently historyrecord is using the context subject, however there are many places where we change the context subject for a specific operation, which might create historyrecord where subject is 'incorrect'
for example in the approval system we reput an approved object in the context of the initiating user, resulting in a historyrecord where the subject is the initiating user instead of the user who actually approved the object