### PR TITLE
Capability StringImplies -> AuthPermission implies

### DIFF
--- a/src/foam/nanos/auth/CapabilityAuthService.js
+++ b/src/foam/nanos/auth/CapabilityAuthService.js
@@ -88,12 +88,6 @@ foam.CLASS({
         if ( x.get(Session.class) == null ) return false;
         if ( user == null || ! user.getEnabled() ) return false;
         User realUser = ((Subject) x.get("subject")).getRealUser();
-        String associationKey = realUser.getId() == user.getId() ?
-          null :
-          user.getId() + ":" + realUser.getId() + permission;
-        String userKey = user.getId() + permission;
-        String realUserKey = realUser.getId() == user.getId() ? null
-          : (realUser.getSpid().equals(user.getSpid()) ? realUser.getId() + permission : null);
 
         try {
           DAO capabilityDAO = ( x.get("localCapabilityDAO") == null ) ? (DAO) x.get("capabilityDAO") : (DAO) x.get("localCapabilityDAO");
@@ -127,7 +121,7 @@ foam.CLASS({
           }
 
           // Check if a ucj implies the subject.realUser has this permission
-          if ( realUser != null && realUserKey != null ) {
+          if ( realUser != null && realUser.getId() != user.getId() && realUser.getSpid().equals(user.getSpid()) ) {
             userPredicate = AND(
               NOT(INSTANCE_OF(AgentCapabilityJunction.class)),
               EQ(UserCapabilityJunction.SOURCE_ID, realUser.getId())
@@ -138,7 +132,7 @@ foam.CLASS({
           }
 
           // Check if a ucj implies the subject.realUser has this permission in relation to the user
-          if ( realUser != null && associationKey != null ) {
+          if ( realUser != null && realUser.getId() != user.getId() ) {
             userPredicate = AND(
               INSTANCE_OF(AgentCapabilityJunction.class),
               EQ(UserCapabilityJunction.SOURCE_ID, realUser.getId()),

--- a/src/foam/nanos/crunch/Capability.js
+++ b/src/foam/nanos/crunch/Capability.js
@@ -27,6 +27,7 @@ foam.CLASS({
     'foam.nanos.logger.Logger',
     'java.util.Date',
     'java.util.List',
+    'javax.security.auth.AuthPermission',
     'static foam.mlang.MLang.*'
   ],
 
@@ -319,35 +320,19 @@ foam.CLASS({
         if ( ! this.getEnabled() ) return false;
 
         // check if permission is a capability string implied by this permission
-        if ( this.stringImplies(this.getName(), permission) ) return true;
+        if ( new AuthPermission(this.getName()).implies(new AuthPermission(permission))  ) return true;
 
         String[] inherentPermissions = this.getInherentPermissions();
         for ( String permissionName : inherentPermissions ) {
-          if ( this.stringImplies(permissionName, permission) ) return true;
+          if ( new AuthPermission(permissionName).implies(new AuthPermission(permission))  ) return true;
         }
 
         String[] permissionsGranted = this.getPermissionsGranted();
         for ( String permissionName : permissionsGranted ) {
-          if ( this.stringImplies(permissionName, permission) ) return true;
+          if ( new AuthPermission(permissionName).implies(new AuthPermission(permission))  ) return true;
         }
         
         return false;
-      `
-    },
-    {
-      name: 'stringImplies',
-      type: 'Boolean',
-      args: [
-        { name: 's1', type: 'String' },
-        { name: 's2', type: 'String' }
-      ],
-      documentation: `check if s1 implies s2 where s1 and s2 are permission or capability strings`,
-      javaCode: `
-      if ( s1.equals(s2) ) return true;
-      if ( s1.isBlank() || s2.isBlank() ) return false;
-      if ( s1.charAt( s1.length() - 1) != '*' || ( s1.length() - 2 > s2.length() ) ) return false;
-      if ( s2.length() <= s1.length() - 2 ) return s1.substring( 0, s1.length() -2 ).equals( s2.substring( 0, s1.length() - 2 ) );
-      return s1.substring( 0, s1.length() - 1 ).equals( s2.substring( 0, s1.length() -1 ) );
       `
     },
     {

--- a/src/foam/nanos/crunch/Capability.js
+++ b/src/foam/nanos/crunch/Capability.js
@@ -27,6 +27,7 @@ foam.CLASS({
     'foam.nanos.logger.Logger',
     'java.util.Date',
     'java.util.List',
+    'foam.util.Arrays',
     'javax.security.auth.AuthPermission',
     'static foam.mlang.MLang.*'
   ],
@@ -318,21 +319,9 @@ foam.CLASS({
       documentation: `Checks if a permission or capability string is implied by the current capability`,
       javaCode: `
         if ( ! this.getEnabled() ) return false;
-
-        // check if permission is a capability string implied by this permission
-        if ( new AuthPermission(this.getName()).implies(new AuthPermission(permission))  ) return true;
-
-        String[] inherentPermissions = this.getInherentPermissions();
-        for ( String permissionName : inherentPermissions ) {
-          if ( new AuthPermission(permissionName).implies(new AuthPermission(permission))  ) return true;
-        }
-
-        String[] permissionsGranted = this.getPermissionsGranted();
-        for ( String permissionName : permissionsGranted ) {
-          if ( new AuthPermission(permissionName).implies(new AuthPermission(permission))  ) return true;
-        }
-        
-        return false;
+        String[] availablePermissions = Arrays.append(this.getInherentPermissions(), this.getPermissionsGranted());
+        List<String> permissionList = java.util.Arrays.asList(availablePermissions);
+        return permissionList.stream().anyMatch(p -> new AuthPermission(p).implies(new AuthPermission(permission)) );
       `
     },
     {

--- a/src/foam/nanos/crunch/Capability.js
+++ b/src/foam/nanos/crunch/Capability.js
@@ -27,7 +27,6 @@ foam.CLASS({
     'foam.nanos.logger.Logger',
     'java.util.Date',
     'java.util.List',
-    'foam.util.Arrays',
     'javax.security.auth.AuthPermission',
     'static foam.mlang.MLang.*'
   ],
@@ -319,9 +318,13 @@ foam.CLASS({
       documentation: `Checks if a permission or capability string is implied by the current capability`,
       javaCode: `
         if ( ! this.getEnabled() ) return false;
-        String[] availablePermissions = Arrays.append(this.getInherentPermissions(), this.getPermissionsGranted());
-        List<String> permissionList = java.util.Arrays.asList(availablePermissions);
-        return permissionList.stream().anyMatch(p -> new AuthPermission(p).implies(new AuthPermission(permission)) );
+        for ( String grantedPermission : this.getPermissionsGranted() ) {
+          if ( new AuthPermission(grantedPermission).implies(new AuthPermission(permission)) ) return true;
+        }
+        for ( String inherentPermission : this.getInherentPermissions() ) {
+          if ( new AuthPermission(inherentPermission).implies(new AuthPermission(permission)) ) return true;
+        }
+        return false;
       `
     },
     {


### PR DESCRIPTION
While reviewing some code and going over the capabilityAuthService these suggestions came about. 

Capability @stringImplies and AuthPermission @implies do the same thing.

@stringImplies was our own custom method that didn't need to exist since AuthPermission @implies serves the same purpose.

Also cleaned up some odd values/string assignments in the capabilityAuthService from a ways back that aren't used anymore.