### PR TITLE
No longer throw intercept error if user group auth check is satisfied

### DIFF
--- a/src/foam/nanos/auth/CapabilityAuthService.js
+++ b/src/foam/nanos/auth/CapabilityAuthService.js
@@ -50,9 +50,7 @@ foam.CLASS({
       `,
       javaCode: `
         User user = ((Subject) x.get("subject")).getUser();
-
-        boolean hasViaCrunch = capabilityCheck(x, user, permission);
-        return ( user != null && hasViaCrunch ) || getDelegate().check(x, permission);
+        return getDelegate().check(x, permission) || ( user != null && capabilityCheck(x, user, permission) );
       `
     },
     {

--- a/src/foam/nanos/auth/CapabilityAuthService.js
+++ b/src/foam/nanos/auth/CapabilityAuthService.js
@@ -56,8 +56,7 @@ foam.CLASS({
     {
       name: 'checkUser',
       javaCode: `
-        boolean hasViaCrunch = capabilityCheck(x, user, permission);
-        return hasViaCrunch || getDelegate().checkUser(x, user, permission);
+        return getDelegate().checkUser(x, user, permission) || capabilityCheck(x, user, permission);
       `
     },
     {


### PR DESCRIPTION
I suspected there was an issue with the capability auth check being called before the user and group auth check in CapabilityAuthService but was more so concerned about the performance. Recent errors being thrown with the intercept messages being thrown even though the group has the permission made me think of the condition changed in this pr.

This fixes issues where capability permission intercepts prioritize user and group auth checks. No longer throw intercept issue if regular auth check is satisfied.