### PR TITLE
createView on config of DAOMenu2/its Controllers

### DIFF
--- a/src/foam/comics/v2/DAOControllerConfig.js
+++ b/src/foam/comics/v2/DAOControllerConfig.js
@@ -101,6 +101,13 @@ foam.CLASS({
     },
     {
       class: 'foam.u2.ViewSpec',
+      name: 'createView',
+      factory: function() {
+        return { class: 'foam.u2.detail.SectionedDetailView' };
+      }
+    },
+    {
+      class: 'foam.u2.ViewSpec',
       name: 'summaryView',
       expression: function(defaultColumns) {
         return {

--- a/src/foam/comics/v2/DAOControllerConfig.js
+++ b/src/foam/comics/v2/DAOControllerConfig.js
@@ -103,7 +103,7 @@ foam.CLASS({
       class: 'foam.u2.ViewSpec',
       name: 'createView',
       factory: function() {
-        return { class: 'foam.u2.detail.SectionedDetailView' };
+        return { class: 'foam.u2.view.FObjectView' };
       }
     },
     {

--- a/src/foam/comics/v2/DAOCreateView.js
+++ b/src/foam/comics/v2/DAOCreateView.js
@@ -77,8 +77,8 @@ foam.CLASS({
     {
       class: 'foam.u2.ViewSpec',
       name: 'viewView',
-      expression: function() {
-        return foam.u2.detail.SectionedDetailView;
+      factory: function() {
+        return this.config.createView;
       }
     },
     {


### PR DESCRIPTION
Allows to configure the createView for DAOMenu2 instead of the SectionedDetailView being hard coded. Still limited since it's a viewSpec and can't really manage the create view data very well, but is better than having the DAOMenu2 restricted to the SectionedDetailView create view.