### PR TITLE
Eric's fix

### DIFF
--- a/src/foam/u2/view/AnyView.js
+++ b/src/foam/u2/view/AnyView.js
@@ -19,9 +19,37 @@ foam.CLASS({
     'foam.u2.view.MapView'
   ],
 
-  constants: [
+  classes: [
     {
-      name: 'DEFAULT_TYPES',
+      name: 'Choice',
+      properties: [
+        {
+          class: 'String',
+          name: 'label'
+        },
+        {
+          name: 'type'
+        },
+        {
+          class: 'foam.u2.ViewSpec',
+          name: 'view'
+        },
+        {
+          class: 'Function',
+          documentation: `
+            A function that takes an argument and makes a best effort in
+            converting that into the current type. See DEFAULT_TYPES for
+            examples.
+          `,
+          name: 'toType'
+        }
+      ]
+    }
+  ],
+
+  properties: [
+    {
+      name: 'types',
       factory: function() {
         return [
           foam.u2.view.AnyView.Choice.create({
@@ -98,43 +126,6 @@ foam.CLASS({
             }
           })
         ];
-      }
-    }
-  ],
-
-  classes: [
-    {
-      name: 'Choice',
-      properties: [
-        {
-          class: 'String',
-          name: 'label'
-        },
-        {
-          name: 'type'
-        },
-        {
-          class: 'foam.u2.ViewSpec',
-          name: 'view'
-        },
-        {
-          class: 'Function',
-          documentation: `
-            A function that takes an argument and makes a best effort in
-            converting that into the current type. See DEFAULT_TYPES for
-            examples.
-          `,
-          name: 'toType'
-        }
-      ]
-    }
-  ],
-
-  properties: [
-    {
-      name: 'types',
-      factory: function() {
-        return this.DEFAULT_TYPES;
       }
     },
     {


### PR DESCRIPTION
Removed AnyView.DEFAULT_TYPES constant and just rendered its factory contents in AnyView.types.factory instead of just calling the constant itself.