### PR TITLE
missing file for build

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -212,6 +212,7 @@ FOAM_FILES([
   { name: 'foam/u2/borders/CardBorder', flags: ['web'] },
   { name: 'foam/u2/borders/MarginBorder', flags: ['web'] },
   { name: 'foam/u2/borders/SplitScreenBorder', flags: ['web'] },
+  { name: 'foam/u2/borders/Block', flags: ['web'] },
   { name: 'foam/nanos/u2/navigation/IFrameTopNavigation', flags: ['web']},
   { name: "foam/version/VersionTrait" },
   { name: "foam/version/VersionedClass" },


### PR DESCRIPTION
https://github.com/foam-framework/foam2/pull/5073/files

Reported bug by Arthur
 When we press the 'Add Owner' button in the onboarding wizard, the fields don't pop up and if you submit it in this state, you won't be able to open the onboarding wizard again even though it's in ACTION_REQUIRED. 
 
![image](https://user-images.githubusercontent.com/10802216/112987330-99d0fc80-9130-11eb-8b99-d4ae630f7d24.png)

![image](https://user-images.githubusercontent.com/10802216/112987350-9e95b080-9130-11eb-8a76-8c6e2a121498.png)

