### PR TITLE
Added TableCellFormatter for Images and ImageView in Capability details

### DIFF
--- a/src/foam/nanos/crunch/Capability.js
+++ b/src/foam/nanos/crunch/Capability.js
@@ -90,6 +90,18 @@ foam.CLASS({
       class: 'Image',
       documentation: `Path to capability icon`,
       section: 'uiSettings',
+      view: {
+        class: 'foam.u2.MultiView',
+        horizontal: false,
+        views: [
+          {
+            class: 'foam.u2.view.StringView'
+          },
+          {
+            class: 'foam.u2.view.ImageView'
+          }
+        ]
+      },
       includeInDigest: false
     },
     {

--- a/src/foam/u2/view/TableCellFormatter.js
+++ b/src/foam/u2/view/TableCellFormatter.js
@@ -150,6 +150,41 @@ foam.CLASS({
   ]
 });
 
+foam.CLASS({
+  package: 'foam.u2.view',
+  name: 'ImageTableCellFormatterRefinement',
+  refines: 'foam.core.Image',
+
+  requires: [
+    'foam.u2.view.ImageView',
+    'foam.u2.crunch.Style'
+  ],
+  css: `
+    .foam-u2-view-ImageTableCellFormatter {
+      height: -webkit-fill-available;
+      height: -moz-available;
+      padding: 2px;
+    }
+  `,
+  properties: [
+    {
+      class: 'foam.u2.view.TableCellFormatter',
+      name: 'tableCellFormatter',
+      value: function(value) {
+        if ( value ) {
+          this
+            .start({ class: 'foam.u2.view.ImageView', data: value })
+              .addClass('foam-u2-view-ImageTableCellFormatter')
+            .end();
+        } else {
+          this.start().
+            add('-').
+          end();
+        }
+      }
+    }
+  ]
+});
 
 foam.CLASS({
   package: 'foam.u2.view',

--- a/src/foam/u2/view/TableCellFormatter.js
+++ b/src/foam/u2/view/TableCellFormatter.js
@@ -177,9 +177,9 @@ foam.CLASS({
               .addClass('foam-u2-view-ImageTableCellFormatter')
             .end();
         } else {
-          this.start().
-            add('-').
-          end();
+          this.start()
+            .add('-')
+          .end();
         }
       }
     }


### PR DESCRIPTION
- Images now render in tables instead of showing the image path (TableCellFormtter)
 ![image](https://user-images.githubusercontent.com/81172969/113044410-97d85f00-916b-11eb-8946-db3ca233240b.png)

- Capability DetailView shows both ImageView and path for the Capability 'icon' property
![image](https://user-images.githubusercontent.com/81172969/113044376-8db66080-916b-11eb-8c4c-bcb544944bbd.png)

