### PR TITLE
Passed in default parameter to translate in TabChoiceView

### DIFF
--- a/src/foam/u2/view/TabChoiceView.js
+++ b/src/foam/u2/view/TabChoiceView.js
@@ -82,7 +82,7 @@ foam.CLASS({
           start('label').
             attrs({for: id}).
             start('span').
-              translate(c[1]).
+              translate(c[1], c[1]).
             end().
           end();
       }.bind(this)));


### PR DESCRIPTION
Thereby making it generic enough so someone can just use the TabChoiceView without having to know about locales + translations and update them accordingly.